### PR TITLE
Enable cocoa support for Cargo features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ name = "glium"
 version = "0.0.1"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 
+[features]
+default = ["cocoa"]
+cocoa = ["glutin/cocoa"]
+
 [dependencies.compile_msg]
 git = "https://github.com/huonw/compile_msg"
 


### PR DESCRIPTION
This is possible since today's nightly. Waiting for one day or two to merge this.
