### PR TITLE
Make VertexBindings and VertexAttrib public

### DIFF
--- a/macros/src/vertex.rs
+++ b/macros/src/vertex.rs
@@ -69,11 +69,11 @@ fn body(ecx: &mut base::ExtCtxt, span: codemap::Span,
                     let ident_str = ident_str.get();
 
                     quote_expr!(ecx, {
-                        bindings.insert($ident_str.to_string(), (
-                            GLDataTuple::get_gl_type(None::<$elem_type>),
-                            GLDataTuple::get_num_elems(None::<$elem_type>),
-                            offset_sum
-                        ));
+                        bindings.push(($ident_str.to_string(), VertexAttrib {
+                            offset: offset_sum,     // TODO: wrong, doesn't use alignment
+                            data_type: GLDataTuple::get_gl_type(None::<$elem_type>),
+                            elements_count: GLDataTuple::get_num_elems(None::<$elem_type>) as u32,
+                        }));
 
                         offset_sum += mem::size_of::<$elem_type>();
                     })
@@ -81,10 +81,11 @@ fn body(ecx: &mut base::ExtCtxt, span: codemap::Span,
                 }).collect::<Vec<P<ast::Expr>>>();
 
             quote_expr!(ecx, {
+                use glium::vertex_buffer::VertexAttrib;
                 use glium::GLDataTuple;
                 use std::mem;
 
-                let mut bindings = { use std::collections::HashMap; HashMap::new() };
+                let mut bindings = Vec::new();
                 let mut offset_sum = 0;
                 $content;
                 bindings

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -665,15 +665,17 @@ impl<'a, 'b, 'c, 'd, 'e, V, U: uniforms::Uniforms>
 
                 // binding vertex buffer
                 let mut locations = Vec::new();
-                for (name, &(data_type, data_size, data_offset)) in vb_bindingsclone.iter() {
+                for &(ref name, vertex_buffer::VertexAttrib { offset, data_type, elements_count })
+                    in vb_bindingsclone.iter()
+                {
                     let loc = gl.GetAttribLocation(program_id, name.to_c_str().unwrap());
                     locations.push(loc);
 
                     if loc != -1 {
                         match data_type {
                             gl::BYTE | gl::UNSIGNED_BYTE | gl::SHORT | gl::UNSIGNED_SHORT | gl::INT | gl::UNSIGNED_INT
-                                => fail!("Not supported"), // TODO: gl.VertexAttribIPointer(loc as u32, data_size, data_type, vb_elementssize as i32, data_offset as *const libc::c_void),
-                            _ => gl.VertexAttribPointer(loc as u32, data_size, data_type, 0, vb_elementssize as i32, data_offset as *const libc::c_void)
+                                => fail!("Not supported"), // TODO: gl.VertexAttribIPointer(loc as u32, elements_count, data_type, vb_elementssize as i32, offset as *const libc::c_void),
+                            _ => gl.VertexAttribPointer(loc as u32, elements_count as gl::types::GLint, data_type, 0, vb_elementssize as i32, offset as *const libc::c_void)
                         }
                         
                         gl.EnableVertexAttribArray(loc as u32);

--- a/src/vertex_buffer.rs
+++ b/src/vertex_buffer.rs
@@ -158,14 +158,31 @@ impl<T> Drop for VertexBuffer<T> {
     }
 }
 
-/// For each binding, the data type, number of elements, and offset.
-/// Includes the total size.
-#[doc(hidden)]
-pub type VertexBindings = HashMap<String, (gl::types::GLenum, gl::types::GLint, uint)>;
+/// Describes the attribute of a vertex.
+///
+/// When you create a vertex buffer, you need to pass some sort of array of data. In order for
+/// OpenGL to use this data, we must tell it some informations about each field of each
+/// element. This structure describes one such field.
+#[deriving(Show, Clone)]
+pub struct VertexAttrib {
+    /// The offset, in bytes, between the start of each vertex and the attribute.
+    pub offset: uint,
+
+    /// Type of the field.
+    pub data_type: gl::types::GLenum,
+
+    /// Number of invidual elements in the attribute.
+    ///
+    /// For example if `data_type` is a f32 and `elements_count` is 2, then you have a `vec2`.
+    pub elements_count: u32,
+}
+
+/// Describes the layout of each vertex in a vertex buffer.
+pub type VertexBindings = Vec<(String, VertexAttrib)>;
 
 /// Trait for structures that represent a vertex.
-#[doc(hidden)]
 pub trait VertexFormat: Copy {
+    /// Builds the `VertexBindings` representing the layout of this element.
     fn build_bindings(Option<Self>) -> VertexBindings;
 }
 


### PR DESCRIPTION
Allows easily defining your own vertex formats.

Won't break anything if you were using `#[vertex_format]`
