### PR TITLE
Remove hack in uniforms

### DIFF
--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -199,11 +199,12 @@ pub fn draw<V, I, U>(display: &Arc<DisplayImpl>,
             }
 
             // binding program uniforms
+            let mut active_texture = gl::TEXTURE0;
             uniforms.0(gl, |name| {
                 uniforms_locations
                     .find_equiv(name)
                     .map(|val| val.0)
-            });
+            }, &mut active_texture);
 
             // binding vertex buffer
             if state.vertex_array != vao_id {


### PR DESCRIPTION
The `#[uniforms]` macro worked by accessing semi-private fields (fields that were public but hidden from docs).
This has been fixed by adding a `UniformsStorage` type and using it instead.
