### PR TITLE
Rework indices source for cleaner implementation

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -38,21 +38,6 @@ impl BufferType for ArrayBuffer {
     }
 }
 
-/// Used for index buffers.
-pub struct ElementArrayBuffer;
-
-impl BufferType for ElementArrayBuffer {
-    fn get_storage_point(_: Option<ElementArrayBuffer>, state: &mut context::GLState)
-        -> &mut Option<gl::types::GLuint>
-    {
-        &mut state.element_array_buffer_binding
-    }
-
-    fn get_bind_point(_: Option<ElementArrayBuffer>) -> gl::types::GLenum {
-        gl::ELEMENT_ARRAY_BUFFER
-    }
-}
-
 /// Used for pixel buffers.
 pub struct PixelPackBuffer;
 
@@ -290,10 +275,6 @@ impl Drop for Buffer {
         self.display.context.exec(proc(ctxt) {
             if ctxt.state.array_buffer_binding == Some(id) {
                 ctxt.state.array_buffer_binding = None;
-            }
-
-            if ctxt.state.element_array_buffer_binding == Some(id) {
-                ctxt.state.element_array_buffer_binding = None;
             }
 
             if ctxt.state.pixel_pack_buffer_binding == Some(id) {

--- a/src/context.rs
+++ b/src/context.rs
@@ -88,9 +88,6 @@ pub struct GLState {
     /// The latest buffer bound to `GL_ARRAY_BUFFER`.
     pub array_buffer_binding: Option<gl::types::GLuint>,
 
-    /// The latest buffer bound to `GL_ELEMENT_ARRAY_BUFFER`.
-    pub element_array_buffer_binding: Option<gl::types::GLuint>,
-
     /// The latest buffer bound to `GL_PIXEL_PACK_BUFFER`.
     pub pixel_pack_buffer_binding: Option<gl::types::GLuint>,
 
@@ -150,7 +147,6 @@ impl GLState {
             clear_depth: 1.0,
             clear_stencil: 0,
             array_buffer_binding: None,
-            element_array_buffer_binding: None,
             pixel_pack_buffer_binding: None,
             pixel_unpack_buffer_binding: None,
             read_framebuffer: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -700,7 +700,13 @@ pub trait IndicesSource {
 }
 
 /// Opaque type used by the implementation.
-pub struct IndicesSourceHelper(proc(&mut context::CommandContext): Send);
+pub struct IndicesSourceHelper<'a> {
+    index_buffer: Option<&'a buffer::Buffer>,
+    pointer: Option<*const libc::c_void>,
+    primitives: gl::types::GLenum,
+    data_type: gl::types::GLenum,
+    indices_count: gl::types::GLuint,
+}
 
 /// Objects that can build a `Display` object.
 pub trait DisplayBuild {
@@ -804,9 +810,9 @@ struct DisplayImpl {
     framebuffer_objects: Mutex<HashMap<framebuffer::FramebufferAttachments,
                                        framebuffer::FrameBufferObject>>,
 
-    // we maintain a list of VAOs for each vertexbuffer-program association
+    // we maintain a list of VAOs for each vertexbuffer-indexbuffer-program association
     // the key is a (vertexbuffer, program)
-    vertex_array_objects: Mutex<HashMap<(gl::types::GLuint, gl::types::GLuint),
+    vertex_array_objects: Mutex<HashMap<(gl::types::GLuint, gl::types::GLuint, gl::types::GLuint),
                                         vertex_array_object::VertexArrayObject>>,
 }
 

--- a/src/program.rs
+++ b/src/program.rs
@@ -191,7 +191,7 @@ impl Drop for Program {
         // removing VAOs which contain this program
         {
             let mut vaos = self.display.vertex_array_objects.lock();
-            let to_delete = vaos.keys().filter(|&&(_, p)| p == self.id)
+            let to_delete = vaos.keys().filter(|&&(_, _, p)| p == self.id)
                 .map(|k| k.clone()).collect::<Vec<_>>();
             for k in to_delete.into_iter() {
                 vaos.remove(&k);

--- a/src/vertex_buffer.rs
+++ b/src/vertex_buffer.rs
@@ -138,7 +138,7 @@ impl<T> Drop for VertexBuffer<T> {
     fn drop(&mut self) {
         // removing VAOs which contain this vertex buffer
         let mut vaos = self.buffer.get_display().vertex_array_objects.lock();
-        let to_delete = vaos.keys().filter(|&&(v, _)| v == self.buffer.get_id())
+        let to_delete = vaos.keys().filter(|&&(v, _, _)| v == self.buffer.get_id())
             .map(|k| k.clone()).collect::<Vec<_>>();
         for k in to_delete.into_iter() {
             vaos.remove(&k);


### PR DESCRIPTION
Current implementation is hacky because it doesn't remember which element array buffer is bound to a VAO.
