### PR TITLE
Add `viewport` to DrawParameters

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -230,6 +230,9 @@ pub struct Capabilities {
     ///
     /// `None` if the extension is not supported by the hardware.
     pub max_texture_max_anisotropy: Option<gl::types::GLfloat>,
+
+    /// Maximum width and height of `glViewport`.
+    pub max_viewport_dims: (gl::types::GLint, gl::types::GLint),
 }
 
 impl Context {
@@ -647,5 +650,12 @@ fn get_capabilities(gl: &gl::Gl, version: &GlVersion, extensions: &ExtensionsLis
                 val
             })
         },
+
+        max_viewport_dims: unsafe {
+            let mut val: [gl::types::GLint, .. 2] = [ 0, 0 ];
+            gl.GetIntegerv(gl::MAX_VIEWPORT_DIMS, val.as_mut_ptr());
+            (val[0], val[1])
+        },
+
     }
 }

--- a/src/fbo.rs
+++ b/src/fbo.rs
@@ -220,9 +220,6 @@ pub fn draw<I, U>(display: &Arc<DisplayImpl>,
         unsafe {
             bind_framebuffer(&mut ctxt, fbo_id, true, false);
 
-            // TODO: do this correctly
-            ctxt.gl.Viewport(0, 0, dimensions.0 as i32, dimensions.1 as i32);
-
             // binding program
             if ctxt.state.program != program_id {
                 ctxt.gl.UseProgram(program_id);
@@ -250,7 +247,7 @@ pub fn draw<I, U>(display: &Arc<DisplayImpl>,
             }
 
             // sync-ing parameters
-            draw_parameters.sync(&mut ctxt);
+            draw_parameters.sync(&mut ctxt, dimensions);
 
             // drawing
             ctxt.gl.DrawElements(primitives, indices_count as i32, data_type, pointer);

--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -217,6 +217,13 @@ impl<'a> Surface for SimpleFrameBuffer<'a> {
             panic!("Requested a depth function but no depth buffer is attached");
         }
 
+        if let Some(viewport) = draw_parameters.viewport {
+            assert!(viewport.width <= self.display.context.capabilities().max_viewport_dims.0
+                    as u32, "Viewport dimensions are too large");
+            assert!(viewport.height <= self.display.context.capabilities().max_viewport_dims.1
+                    as u32, "Viewport dimensions are too large");
+        }
+
         fbo::draw(&self.display, Some(&self.attachments), vb.to_vertices_source(),
                   &ib.to_indices_source(), program, uniforms, draw_parameters, self.dimensions)
     }

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -36,3 +36,22 @@ fn release_shader_compiler() {
     display.release_shader_compiler();
     display.assert_no_error();
 }
+
+#[test]
+#[should_fail(expected = "Viewport dimensions are too large")]
+fn viewport_too_large() {
+    let display = support::build_display();
+
+    let params = glium::DrawParameters {
+        viewport: Some(glium::Rect {
+            left: 0,
+            bottom: 0,
+            width: 4294967295,
+            height: 4294967295,
+        }),
+        .. std::default::Default::default()
+    };
+
+    let (vb, ib, program) = support::build_fullscreen_red_pipeline(&display);
+    display.draw().draw(&vb, &ib, &program, &glium::uniforms::EmptyUniforms, &params);
+}


### PR DESCRIPTION
- Adds `viewport` to `DrawParameters`, which is set to the whole surface by default
- Only switch viewport state if needed
- Panics if requested viewport is too large for what the hardware supports
- Adds `get_max_viewport_dimensions()` to `Display`

Close #153 
