### PR TITLE
Fix picking example

### DIFF
--- a/examples/picking.rs
+++ b/examples/picking.rs
@@ -104,7 +104,7 @@ fn main() {
     ).unwrap();
 
     let mut camera = support::camera::CameraState::new();
-    camera.set_position((0.0, 0.0, 1.5));
+    camera.set_position((0.0, 0.0, -1.5));
     camera.set_direction((0.0, 0.0, 1.0));
 
     //id's must be unique and != 0
@@ -211,7 +211,7 @@ fn main() {
         if let (Some(cursor), Some(&(ref picking_texture, _))) = (cursor_position, picking_attachments.as_ref()) {
             let read_target = glium::Rect {
                 left: (cursor.0 - 1) as u32,
-                bottom: picking_texture.get_height().unwrap() - std::cmp::max(cursor.1 - 1, 0) as u32,
+                bottom: picking_texture.get_height().unwrap().saturating_sub(std::cmp::max(cursor.1 - 1, 0) as u32),
                 width: 1,
                 height: 1,
             };


### PR DESCRIPTION
Includes @Mufferaw's fix for the camera position, as well as using saturated sub to avoid a panic when the mouse is at the bottom of the screen.