### PR TITLE
[WIP] Update to the new `EventsLoop` glutin/winit API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ default = ["glutin"]
 unstable = []       # used for benchmarks
 
 [dependencies.glutin]
-version = "0.7.1"
+version = "0.8"
 features = []
 optional = true
 

--- a/examples/blitting.rs
+++ b/examples/blitting.rs
@@ -5,18 +5,15 @@ extern crate glium;
 extern crate image;
 
 use std::io::Cursor;
-use glium::{DisplayBuild, Surface};
-
-use glium::glutin;
+use glium::{glutin, Surface};
 
 mod support;
 
 fn main() {
     // building the display, ie. the main object
-    let display = glutin::WindowBuilder::new()
-        .with_vsync()
-        .build_glium()
-        .unwrap();
+    let events_loop = glutin::EventsLoop::new();
+    let window = glutin::WindowBuilder::new().with_vsync().build(&events_loop).unwrap();
+    let display = glium::build(window).unwrap();
 
     // building a texture with "OpenGL" drawn on it
     let image = image::load(Cursor::new(&include_bytes!("../tests/fixture/opengl.png")[..]),
@@ -53,14 +50,17 @@ fn main() {
         dest_texture.as_surface().fill(&target, glium::uniforms::MagnifySamplerFilter::Linear);
         target.finish().unwrap();
 
+        let mut action = support::Action::Continue;
+
         // polling and handling the events received by the window
-        for event in display.poll_events() {
+        events_loop.poll_events(|event| {
             match event {
-                glutin::Event::Closed => return support::Action::Stop,
+                glutin::Event::WindowEvent { event: glutin::WindowEvent::Closed, .. } =>
+                    action = support::Action::Stop,
                 _ => ()
             }
-        }
+        });
 
-        support::Action::Continue
+        action
     });
 }

--- a/examples/deferred.rs
+++ b/examples/deferred.rs
@@ -13,12 +13,14 @@ mod support;
 fn main() {
     use cgmath::SquareMatrix;
 
-    // building the display, ie. the main object
-    let display = glutin::WindowBuilder::new()
+    let events_loop = glutin::EventsLoop::new();
+    let window = glutin::WindowBuilder::new()
         .with_dimensions(800, 500)
-        .with_title(format!("Glium Deferred Example"))
-        .build_glium()
+        .with_title("Glium Deferred Example")
+        .build(&events_loop)
         .unwrap();
+    // building the display, ie. the main object
+    let display = glium::build(window).unwrap();
 
     let image = image::load(Cursor::new(&include_bytes!("../tests/fixture/opengl.png")[..]), image::PNG).unwrap().to_rgba();
     let image_dimensions = image.dimensions();
@@ -358,14 +360,17 @@ fn main() {
         target.draw(&quad_vertex_buffer, &quad_index_buffer, &composition_program, &uniforms, &Default::default()).unwrap();
         target.finish().unwrap();
 
-        // polling and handling the events received by the window
-        for event in display.poll_events() {
-            match event {
-                glutin::Event::Closed => return support::Action::Stop,
-                _ => ()
-            }
-        }
+        let mut action = support::Action::Continue;
 
-        support::Action::Continue
+        // polling and handling the events received by the window
+        events_loop.poll_events(|event| {
+            match event {
+                glutin::Event::WindowEvent { event: glutin::WindowEvent::Closed, .. } =>
+                    action = support::Action::Stop,
+                _ => (),
+            }
+        });
+
+        action
     });
 }

--- a/examples/displacement_mapping.rs
+++ b/examples/displacement_mapping.rs
@@ -9,12 +9,10 @@ use glium::Surface;
 mod support;
 
 fn main() {
-    use glium::DisplayBuild;
-
     // building the display, ie. the main object
-    let display = glutin::WindowBuilder::new()
-        .build_glium()
-        .unwrap();
+    let events_loop = glutin::EventsLoop::new();
+    let window = glutin::WindowBuilder::new().build(&events_loop).unwrap();
+    let display = glium::build(window).unwrap();
 
     let image = image::load(Cursor::new(&include_bytes!("../tests/fixture/opengl.png")[..]),
                             image::PNG).unwrap().to_rgba();
@@ -218,14 +216,17 @@ fn main() {
                     &Default::default()).unwrap();
         target.finish().unwrap();
 
+        let mut action = support::Action::Continue;
+
         // polling and handling the events received by the window
-        for event in display.poll_events() {
+        events_loop.poll_events(|event| {
             match event {
-                glutin::Event::Closed => return support::Action::Stop,
+                glutin::Event::WindowEvent { event: glutin::WindowEvent::Closed, .. } =>
+                    action = support::Action::Stop,
                 _ => ()
             }
-        }
+        });
 
-        support::Action::Continue
+        action
     });
 }

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -4,18 +4,16 @@ extern crate image;
 
 use std::io::Cursor;
 
-use glium::{DisplayBuild, Surface};
-use glium::glutin;
+use glium::{glutin, Surface};
 use glium::index::PrimitiveType;
 
 mod support;
 
 fn main() {
     // building the display, ie. the main object
-    let display = glutin::WindowBuilder::new()
-        .with_vsync()
-        .build_glium()
-        .unwrap();
+    let events_loop = glutin::EventsLoop::new();
+    let window = glutin::WindowBuilder::new().with_vsync().build(&events_loop).unwrap();
+    let display = glium::build(window).unwrap();
 
     // building a texture with "OpenGL" drawn on it
     let image = image::load(Cursor::new(&include_bytes!("../tests/fixture/opengl.png")[..]),
@@ -156,13 +154,16 @@ fn main() {
         target.finish().unwrap();
 
         // polling and handling the events received by the window
-        for event in display.poll_events() {
+        let mut action = support::Action::Continue;
+        events_loop.poll_events(|event| {
             match event {
-                glutin::Event::Closed => return support::Action::Stop,
-                _ => ()
+                glutin::Event::WindowEvent { event, .. } => match event {
+                    glutin::WindowEvent::Closed => action = support::Action::Stop,
+                    _ => ()
+                },
             }
-        }
+        });
 
-        support::Action::Continue
+        action
     });
 }

--- a/examples/info.rs
+++ b/examples/info.rs
@@ -2,14 +2,13 @@
 extern crate glium;
 
 fn main() {
-    use glium::{Api, DisplayBuild, Profile, Version};
+    use glium::{Api, Profile, Version};
     use glium::glutin;
 
     // building the display, ie. the main object
-    let display = glutin::WindowBuilder::new()
-        .with_visibility(false)
-        .build_glium()
-        .unwrap();
+    let events_loop = glutin::EventsLoop::new();
+    let window = glutin::WindowBuilder::new().with_visibility(false).build(&events_loop).unwrap();
+    let display = glium::build(window).unwrap();
 
     let version = *display.get_opengl_version();
     let api = match version {

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -8,17 +8,14 @@ use glium::glutin;
 mod support;
 
 fn main() {
-    use glium::DisplayBuild;
-
     println!("This example draws 10,000 instanced teapots. Each teapot gets a random position and \
               direction at initialization. Then the CPU updates and uploads the positions of each \
               teapot at each frame.");
 
     // building the display, ie. the main object
-    let display = glutin::WindowBuilder::new()
-        .with_depth_buffer(24)
-        .build_glium()
-        .unwrap();
+    let events_loop = glutin::EventsLoop::new();
+    let window = glutin::WindowBuilder::new().with_depth_buffer(24).build(&events_loop).unwrap();
+    let display = glium::build(window).unwrap();
 
     // building the vertex and index buffers
     let vertex_buffer = support::load_wavefront(&display, include_bytes!("support/teapot.obj"));
@@ -122,14 +119,18 @@ fn main() {
                     &params).unwrap();
         target.finish().unwrap();
 
-        // polling and handling the events received by the window
-        for event in display.poll_events() {
-            match event {
-                glutin::Event::Closed => return support::Action::Stop,
-                _ => ()
-            }
-        }
+        let mut action = support::Action::Continue;
 
-        support::Action::Continue
+        // polling and handling the events received by the window
+        events_loop.poll_events(|event| {
+            match event {
+                glutin::Event::WindowEvent { event, .. } => match event {
+                    glutin::WindowEvent::Closed => action = support::Action::Stop,
+                    _ => (),
+                },
+            }
+        });
+
+        action
     });
 }

--- a/examples/manual-creation.rs
+++ b/examples/manual-creation.rs
@@ -27,7 +27,8 @@ use std::os::raw::c_void;
 fn main() {
     // building the glutin window
     // note that it's just `build` and not `build_glium`
-    let window = glutin::WindowBuilder::new().build().unwrap();
+    let events_loop = glutin::EventsLoop::new();
+    let window = glutin::WindowBuilder::new().build(&events_loop).unwrap();
     let window = Rc::new(window);
 
     // in order to create our context, we will need to provide an object which implements
@@ -90,10 +91,12 @@ fn main() {
     target.finish().unwrap();
 
     // the window is still available
-    for event in window.wait_events() {
+    events_loop.run_forever(|event| {
         match event {
-            glutin::Event::Closed => return,
-            _ => ()
+            glutin::Event::WindowEvent { event, .. } => match event {
+                glutin::WindowEvent::Closed => events_loop.interrupt(),
+                _ => (),
+            },
         }
-    }
+    });
 }

--- a/examples/picking.rs
+++ b/examples/picking.rs
@@ -15,13 +15,10 @@ struct PerInstance {
 implement_vertex!(PerInstance, id, w_position, color);
 
 fn main() {
-    use glium::DisplayBuild;
-
     // building the display, ie. the main object
-    let display = glutin::WindowBuilder::new()
-        .with_depth_buffer(24)
-        .build_glium()
-        .unwrap();
+    let events_loop = glutin::EventsLoop::new();
+    let window = glutin::WindowBuilder::new().with_depth_buffer(24).build(&events_loop).unwrap();
+    let display = glium::build(window).unwrap();
 
     // building the vertex and index buffers
     let vertex_buffer = support::load_wavefront(&display, include_bytes!("support/teapot.obj"));
@@ -229,15 +226,19 @@ fn main() {
             picking_pbo.write(&[0]);
         }
 
-        // polling and handling the events received by the window
-        for event in display.poll_events() {
-            match event {
-                glutin::Event::Closed => return support::Action::Stop,
-                glutin::Event::MouseMoved(x,y) => cursor_position = Some((x,y)),
-                ev => camera.process_input(&ev),
-            }
-        }
+        let mut action = support::Action::Continue;
 
-        support::Action::Continue
+        // polling and handling the events received by the window
+        events_loop.poll_events(|event| {
+            match event {
+                glutin::Event::WindowEvent { event, .. } => match event {
+                    glutin::WindowEvent::Closed => action = support::Action::Stop,
+                    glutin::WindowEvent::MouseMoved(x,y) => cursor_position = Some((x,y)),
+                    ev => camera.process_input(&ev),
+                },
+            }
+        });
+
+        action
     });
 }

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -8,13 +8,10 @@ use glium::index::PrimitiveType;
 use std::path::Path;
 
 fn main() {
-    use glium::DisplayBuild;
-
     // building the display, ie. the main object
-    let display = glutin::WindowBuilder::new()
-        .with_visibility(false)
-        .build_glium()
-        .unwrap();
+    let events_loop = glutin::EventsLoop::new();
+    let window = glutin::WindowBuilder::new().with_visibility(false).build(&events_loop).unwrap();
+    let display = glium::build(window).unwrap();
 
     // building the vertex buffer, which contains all the vertices that we will draw
     let vertex_buffer = {

--- a/examples/sprites-batching.rs
+++ b/examples/sprites-batching.rs
@@ -2,7 +2,7 @@
 extern crate glium;
 extern crate rand;
 
-use glium::{DisplayBuild, Surface};
+use glium::Surface;
 use glium::index::PrimitiveType;
 use glium::glutin;
 
@@ -19,7 +19,9 @@ fn main() {
     const SPRITES_COUNT: usize = 1024;
     println!("Number of sprites: {}", SPRITES_COUNT);
 
-    let display = glutin::WindowBuilder::new().build_glium().unwrap();
+    let events_loop = glutin::EventsLoop::new();
+    let window = glutin::WindowBuilder::new().build(&events_loop).unwrap();
+    let display = glium::build(window).unwrap();
 
     // generating a bunch of unicolor 2D images that will be used for a texture
     // we store all of them in a `Texture2dArray`
@@ -241,14 +243,17 @@ fn main() {
                     &program, &uniform! { tex: &texture }, &Default::default()).unwrap();
         target.finish().unwrap();
 
+        let mut action = support::Action::Continue;
 
-        for event in display.poll_events() {
+        events_loop.poll_events(|event| {
             match event {
-                glutin::Event::Closed => return support::Action::Stop,
-                _ => ()
+                glutin::Event::WindowEvent { event, .. } => match event {
+                    glutin::WindowEvent::Closed => action = support::Action::Stop,
+                    _ => ()
+                },
             }
-        }
+        });
 
-        support::Action::Continue
+        action
     });
 }

--- a/examples/subroutines.rs
+++ b/examples/subroutines.rs
@@ -9,12 +9,10 @@ use glium::index::PrimitiveType;
 use glium::program::ShaderStage;
 
 fn main() {
-    use glium::DisplayBuild;
-
     // building the display, ie. the main object
-    let display = glutin::WindowBuilder::new()
-        .build_glium()
-        .unwrap();
+    let events_loop = glutin::EventsLoop::new();
+    let window = glutin::WindowBuilder::new().build(&events_loop).unwrap();
+    let display = glium::build(window).unwrap();
 
     // building the vertex buffer, which contains all the vertices that we will draw
     let vertex_buffer = {
@@ -117,14 +115,18 @@ fn main() {
         target.draw(&vertex_buffer, &index_buffer, &program, &uniforms, &Default::default()).unwrap();
         target.finish().unwrap();
 
-        // polling and handling the events received by the window
-        for event in display.poll_events() {
+        let mut action = support::Action::Continue;
+
+        events_loop.poll_events(|event| {
             match event {
-                glutin::Event::Closed => return support::Action::Stop,
-                _ => ()
+                glutin::Event::WindowEvent { event, .. } => match event {
+                    glutin::WindowEvent::Closed => action = support::Action::Stop,
+                    _ => ()
+                },
             }
-        }
+        });
         i += 1;
-        support::Action::Continue
+
+        action
     });
 }

--- a/examples/support/camera.rs
+++ b/examples/support/camera.rs
@@ -150,45 +150,18 @@ impl CameraState {
         }
     }
 
-    pub fn process_input(&mut self, event: &glutin::Event) {
-        match event {
-            &glutin::Event::KeyboardInput(glutin::ElementState::Pressed, _, Some(glutin::VirtualKeyCode::Space)) => {
-                self.moving_up = true;
-            },
-            &glutin::Event::KeyboardInput(glutin::ElementState::Released, _, Some(glutin::VirtualKeyCode::Space)) => {
-                self.moving_up = false;
-            },
-            &glutin::Event::KeyboardInput(glutin::ElementState::Pressed, _, Some(glutin::VirtualKeyCode::Down)) => {
-                self.moving_down = true;
-            },
-            &glutin::Event::KeyboardInput(glutin::ElementState::Released, _, Some(glutin::VirtualKeyCode::Down)) => {
-                self.moving_down = false;
-            },
-            &glutin::Event::KeyboardInput(glutin::ElementState::Pressed, _, Some(glutin::VirtualKeyCode::A)) => {
-                self.moving_left = true;
-            },
-            &glutin::Event::KeyboardInput(glutin::ElementState::Released, _, Some(glutin::VirtualKeyCode::A)) => {
-                self.moving_left = false;
-            },
-            &glutin::Event::KeyboardInput(glutin::ElementState::Pressed, _, Some(glutin::VirtualKeyCode::D)) => {
-                self.moving_right = true;
-            },
-            &glutin::Event::KeyboardInput(glutin::ElementState::Released, _, Some(glutin::VirtualKeyCode::D)) => {
-                self.moving_right = false;
-            },
-            &glutin::Event::KeyboardInput(glutin::ElementState::Pressed, _, Some(glutin::VirtualKeyCode::W)) => {
-                self.moving_forward = true;
-            },
-            &glutin::Event::KeyboardInput(glutin::ElementState::Released, _, Some(glutin::VirtualKeyCode::W)) => {
-                self.moving_forward = false;
-            },
-            &glutin::Event::KeyboardInput(glutin::ElementState::Pressed, _, Some(glutin::VirtualKeyCode::S)) => {
-                self.moving_backward = true;
-            },
-            &glutin::Event::KeyboardInput(glutin::ElementState::Released, _, Some(glutin::VirtualKeyCode::S)) => {
-                self.moving_backward = false;
-            },
-            _ => {}
+    pub fn process_input(&mut self, event: &glutin::WindowEvent) {
+        if let glutin::WindowEvent::KeyboardInput(state, _, Some(key), _) = *event {
+            let pressed = state == glutin::ElementState::Pressed;
+            match key {
+                glutin::VirtualKeyCode::Up => self.moving_up = pressed,
+                glutin::VirtualKeyCode::Down => self.moving_down = pressed,
+                glutin::VirtualKeyCode::A => self.moving_left = pressed,
+                glutin::VirtualKeyCode::D => self.moving_right = pressed,
+                glutin::VirtualKeyCode::W => self.moving_forward = pressed,
+                glutin::VirtualKeyCode::S => self.moving_backward = pressed,
+                _ => (),
+            };
         }
     }
 }

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -8,12 +8,9 @@ use glium::glutin;
 use glium::index::PrimitiveType;
 
 fn main() {
-    use glium::DisplayBuild;
-
-    // building the display, ie. the main object
-    let display = glutin::WindowBuilder::new()
-        .build_glium()
-        .unwrap();
+    let events_loop = glutin::EventsLoop::new();
+    let window = glutin::WindowBuilder::new().build(&events_loop).unwrap();
+    let display = glium::build(window).unwrap();
 
     // building the vertex buffer, which contains all the vertices that we will draw
     let vertex_buffer = {
@@ -123,8 +120,12 @@ fn main() {
         },
     ).unwrap();
 
-    // the main loop
-    support::start_loop(|| {
+    // Here we draw the black background and triangle to the screen using the previously
+    // initialised resources.
+    //
+    // In this case we use a closure for simplicity, however keep in mind that most serious
+    // applications should probably use a function that takes the resources as an argument.
+    let draw = || {
         // building the uniforms
         let uniforms = uniform! {
             matrix: [
@@ -140,15 +141,19 @@ fn main() {
         target.clear_color(0.0, 0.0, 0.0, 0.0);
         target.draw(&vertex_buffer, &index_buffer, &program, &uniforms, &Default::default()).unwrap();
         target.finish().unwrap();
+    };
 
-        // polling and handling the events received by the window
-        for event in display.poll_events() {
-            match event {
-                glutin::Event::Closed => return support::Action::Stop,
-                _ => ()
-            }
-        }
+    // Draw the triangle to the screen.
+    draw();
 
-        support::Action::Continue
+    // the main loop
+    events_loop.run_forever(|event| match event {
+        glutin::Event::WindowEvent { event, .. } => match event {
+            // Break from the main loop when the window is closed.
+            glutin::WindowEvent::Closed => events_loop.interrupt(),
+            // Redraw the triangle when the window is resized.
+            glutin::WindowEvent::Resized(..) => draw(),
+            _ => (),
+        },
     });
 }

--- a/examples/tutorial-02.rs
+++ b/examples/tutorial-02.rs
@@ -2,8 +2,10 @@
 extern crate glium;
 
 fn main() {
-    use glium::{DisplayBuild, Surface};
-    let display = glium::glutin::WindowBuilder::new().build_glium().unwrap();
+    use glium::Surface;
+    let events_loop = glium::glutin::EventsLoop::new();
+    let window = glium::glutin::WindowBuilder::new().build(&events_loop).unwrap();
+    let display = glium::build(window).unwrap();
 
     #[derive(Copy, Clone)]
     struct Vertex {
@@ -49,11 +51,16 @@ fn main() {
                     &Default::default()).unwrap();
         target.finish().unwrap();
 
-        for ev in display.poll_events() {
-            match ev {
-                glium::glutin::Event::Closed => return,
-                _ => ()
+        let mut closed = false;
+        events_loop.poll_events(|event| {
+            match event {
+                glium::glutin::Event::WindowEvent { event, .. } => match event {
+                    glium::glutin::WindowEvent::Closed => closed = true,
+                    _ => ()
+                },
             }
-        }
+        });
+
+        if closed { break; }
     }
 }

--- a/examples/tutorial-03.rs
+++ b/examples/tutorial-03.rs
@@ -2,8 +2,10 @@
 extern crate glium;
 
 fn main() {
-    use glium::{DisplayBuild, Surface};
-    let display =glium:: glutin::WindowBuilder::new().build_glium().unwrap();
+    use glium::Surface;
+    let events_loop = glium::glutin::EventsLoop::new();
+    let window = glium::glutin::WindowBuilder::new().build(&events_loop).unwrap();
+    let display = glium::build(window).unwrap();
 
     #[derive(Copy, Clone)]
     struct Vertex {
@@ -56,20 +58,21 @@ fn main() {
 
         let mut target = display.draw();
         target.clear_color(0.0, 0.0, 1.0, 1.0);
-
-        let uniforms = uniform! {
-            t:t
-                };
-
+        let uniforms = uniform! { t: t };
         target.draw(&vertex_buffer, &indices, &program, &uniforms,
                     &Default::default()).unwrap();
         target.finish().unwrap();
 
-        for ev in display.poll_events() {
-            match ev {
-                glium::glutin::Event::Closed => return,
-                _ => ()
+        let mut closed = false;
+        events_loop.poll_events(|event| {
+            match event {
+                glium::glutin::Event::WindowEvent { event, .. } => match event {
+                    glium::glutin::WindowEvent::Closed => closed = true,
+                    _ => ()
+                },
             }
-        }
+        });
+
+        if closed { break; }
     }
 }

--- a/examples/tutorial-04.rs
+++ b/examples/tutorial-04.rs
@@ -2,8 +2,10 @@
 extern crate glium;
 
 fn main() {
-    use glium::{DisplayBuild, Surface};
-    let display =glium:: glutin::WindowBuilder::new().build_glium().unwrap();
+    use glium::Surface;
+    let events_loop = glium::glutin::EventsLoop::new();
+    let window = glium::glutin::WindowBuilder::new().build(&events_loop).unwrap();
+    let display = glium::build(window).unwrap();
 
     #[derive(Copy, Clone)]
     struct Vertex {
@@ -69,11 +71,16 @@ fn main() {
                     &Default::default()).unwrap();
         target.finish().unwrap();
 
-        for ev in display.poll_events() {
-            match ev {
-                glium::glutin::Event::Closed => return,
-                _ => ()
+        let mut closed = false;
+        events_loop.poll_events(|event| {
+            match event {
+                glium::glutin::Event::WindowEvent { event, .. } => match event {
+                    glium::glutin::WindowEvent::Closed => closed = true,
+                    _ => ()
+                },
             }
-        }
+        });
+
+        if closed { break; }
     }
 }

--- a/examples/tutorial-05.rs
+++ b/examples/tutorial-05.rs
@@ -2,8 +2,11 @@
 extern crate glium;
 
 fn main() {
-    use glium::{DisplayBuild, Surface};
-    let display =glium:: glutin::WindowBuilder::new().build_glium().unwrap();
+    use glium::Surface;
+
+    let events_loop = glium::glutin::EventsLoop::new();
+    let window = glium::glutin::WindowBuilder::new().build(&events_loop).unwrap();
+    let display = glium::build(window).unwrap();
 
     #[derive(Copy, Clone)]
     struct Vertex {
@@ -72,11 +75,16 @@ fn main() {
                     &Default::default()).unwrap();
         target.finish().unwrap();
 
-        for ev in display.poll_events() {
-            match ev {
-                glium::glutin::Event::Closed => return,
-                _ => ()
+        let mut closed = false;
+        events_loop.poll_events(|event| {
+            match event {
+                glium::glutin::Event::WindowEvent { event, .. } => match event {
+                    glium::glutin::WindowEvent::Closed => closed = true,
+                    _ => ()
+                },
             }
-        }
+        });
+
+        if closed { break; }
     }
 }

--- a/examples/tutorial-06.rs
+++ b/examples/tutorial-06.rs
@@ -5,8 +5,10 @@ extern crate image;
 use std::io::Cursor;
 
 fn main() {
-    use glium::{DisplayBuild, Surface};
-    let display = glium::glutin::WindowBuilder::new().build_glium().unwrap();
+    use glium::Surface;
+    let events_loop = glium::glutin::EventsLoop::new();
+    let window = glium::glutin::WindowBuilder::new().build(&events_loop).unwrap();
+    let display = glium::build(window).unwrap();
 
     let image = image::load(Cursor::new(&include_bytes!("../tests/fixture/opengl.png")[..]),
                             image::PNG).unwrap().to_rgba();
@@ -86,11 +88,16 @@ fn main() {
                     &Default::default()).unwrap();
         target.finish().unwrap();
 
-        for ev in display.poll_events() {
-            match ev {
-                glium::glutin::Event::Closed => return,
-                _ => ()
+        let mut closed = false;
+        events_loop.poll_events(|event| {
+            match event {
+                glium::glutin::Event::WindowEvent { event, .. } => match event {
+                    glium::glutin::WindowEvent::Closed => closed = true,
+                    _ => ()
+                },
             }
-        }
+        });
+
+        if closed { break; }
     }
 }

--- a/examples/tutorial-07.rs
+++ b/examples/tutorial-07.rs
@@ -5,8 +5,10 @@ extern crate glium;
 mod teapot;
 
 fn main() {
-    use glium::{DisplayBuild, Surface};
-    let display = glium::glutin::WindowBuilder::new().build_glium().unwrap();
+    use glium::Surface;
+    let events_loop = glium::glutin::EventsLoop::new();
+    let window = glium::glutin::WindowBuilder::new().build(&events_loop).unwrap();
+    let display = glium::build(window).unwrap();
 
     let positions = glium::VertexBuffer::new(&display, &teapot::VERTICES).unwrap();
     let normals = glium::VertexBuffer::new(&display, &teapot::NORMALS).unwrap();
@@ -54,11 +56,16 @@ fn main() {
                     &Default::default()).unwrap();
         target.finish().unwrap();
 
-        for ev in display.poll_events() {
-            match ev {
-                glium::glutin::Event::Closed => return,
-                _ => ()
+        let mut closed = false;
+        events_loop.poll_events(|event| {
+            match event {
+                glium::glutin::Event::WindowEvent { event, .. } => match event {
+                    glium::glutin::WindowEvent::Closed => closed = true,
+                    _ => ()
+                },
             }
-        }
+        });
+
+        if closed { break; }
     }
 }

--- a/examples/tutorial-08.rs
+++ b/examples/tutorial-08.rs
@@ -5,8 +5,10 @@ extern crate glium;
 mod teapot;
 
 fn main() {
-    use glium::{DisplayBuild, Surface};
-    let display = glium::glutin::WindowBuilder::new().build_glium().unwrap();
+    use glium::Surface;
+    let events_loop = glium::glutin::EventsLoop::new();
+    let window = glium::glutin::WindowBuilder::new().build(&events_loop).unwrap();
+    let display = glium::build(window).unwrap();
 
     let positions = glium::VertexBuffer::new(&display, &teapot::VERTICES).unwrap();
     let normals = glium::VertexBuffer::new(&display, &teapot::NORMALS).unwrap();
@@ -65,11 +67,16 @@ fn main() {
                     &Default::default()).unwrap();
         target.finish().unwrap();
 
-        for ev in display.poll_events() {
-            match ev {
-                glium::glutin::Event::Closed => return,
-                _ => ()
+        let mut closed = false;
+        events_loop.poll_events(|event| {
+            match event {
+                glium::glutin::Event::WindowEvent { event, .. } => match event {
+                    glium::glutin::WindowEvent::Closed => closed = true,
+                    _ => ()
+                },
             }
-        }
+        });
+
+        if closed { break; }
     }
 }

--- a/examples/tutorial-09.rs
+++ b/examples/tutorial-09.rs
@@ -5,10 +5,13 @@ extern crate glium;
 mod teapot;
 
 fn main() {
-    use glium::{DisplayBuild, Surface};
-    let display = glium::glutin::WindowBuilder::new()
-                        .with_depth_buffer(24)
-                        .build_glium().unwrap();
+    use glium::Surface;
+    let events_loop = glium::glutin::EventsLoop::new();
+    let window = glium::glutin::WindowBuilder::new()
+        .with_depth_buffer(24)
+        .build(&events_loop)
+        .unwrap();
+    let display = glium::build(window).unwrap();
 
     let positions = glium::VertexBuffer::new(&display, &teapot::VERTICES).unwrap();
     let normals = glium::VertexBuffer::new(&display, &teapot::NORMALS).unwrap();
@@ -75,11 +78,16 @@ fn main() {
                     &uniform! { matrix: matrix, u_light: light }, &params).unwrap();
         target.finish().unwrap();
 
-        for ev in display.poll_events() {
-            match ev {
-                glium::glutin::Event::Closed => return,
-                _ => ()
+        let mut closed = false;
+        events_loop.poll_events(|event| {
+            match event {
+                glium::glutin::Event::WindowEvent { event, .. } => match event {
+                    glium::glutin::WindowEvent::Closed => closed = true,
+                    _ => ()
+                },
             }
-        }
+        });
+
+        if closed { break; }
     }
 }

--- a/examples/tutorial-10.rs
+++ b/examples/tutorial-10.rs
@@ -5,10 +5,13 @@ extern crate glium;
 mod teapot;
 
 fn main() {
-    use glium::{DisplayBuild, Surface};
-    let display = glium::glutin::WindowBuilder::new()
-                        .with_depth_buffer(24)
-                        .build_glium().unwrap();
+    use glium::Surface;
+    let events_loop = glium::glutin::EventsLoop::new();
+    let window = glium::glutin::WindowBuilder::new()
+        .with_depth_buffer(24)
+        .build(&events_loop)
+        .unwrap();
+    let display = glium::build(window).unwrap();
 
     let positions = glium::VertexBuffer::new(&display, &teapot::VERTICES).unwrap();
     let normals = glium::VertexBuffer::new(&display, &teapot::NORMALS).unwrap();
@@ -95,12 +98,17 @@ fn main() {
                     &params).unwrap();
         target.finish().unwrap();
 
-        for ev in display.poll_events() {
-            match ev {
-                glium::glutin::Event::Closed => return,
-                _ => ()
+        let mut closed = false;
+        events_loop.poll_events(|event| {
+            match event {
+                glium::glutin::Event::WindowEvent { event, .. } => match event {
+                    glium::glutin::WindowEvent::Closed => closed = true,
+                    _ => ()
+                },
             }
-        }
+        });
+
+        if closed { break; }
     }
 }
 

--- a/examples/tutorial-12.rs
+++ b/examples/tutorial-12.rs
@@ -5,10 +5,13 @@ extern crate glium;
 mod teapot;
 
 fn main() {
-    use glium::{DisplayBuild, Surface};
-    let display = glium::glutin::WindowBuilder::new()
-                        .with_depth_buffer(24)
-                        .build_glium().unwrap();
+    use glium::Surface;
+    let events_loop = glium::glutin::EventsLoop::new();
+    let window = glium::glutin::WindowBuilder::new()
+        .with_depth_buffer(24)
+        .build(&events_loop)
+        .unwrap();
+    let display = glium::build(window).unwrap();
 
     let positions = glium::VertexBuffer::new(&display, &teapot::VERTICES).unwrap();
     let normals = glium::VertexBuffer::new(&display, &teapot::NORMALS).unwrap();
@@ -100,12 +103,17 @@ fn main() {
                     &params).unwrap();
         target.finish().unwrap();
 
-        for ev in display.poll_events() {
-            match ev {
-                glium::glutin::Event::Closed => return,
-                _ => ()
+        let mut closed = false;
+        events_loop.poll_events(|event| {
+            match event {
+                glium::glutin::Event::WindowEvent { event, .. } => match event {
+                    glium::glutin::WindowEvent::Closed => closed = true,
+                    _ => ()
+                },
             }
-        }
+        });
+
+        if closed { break; }
     }
 }
 

--- a/examples/tutorial-13.rs
+++ b/examples/tutorial-13.rs
@@ -5,10 +5,13 @@ extern crate glium;
 mod teapot;
 
 fn main() {
-    use glium::{DisplayBuild, Surface};
-    let display = glium::glutin::WindowBuilder::new()
-                        .with_depth_buffer(24)
-                        .build_glium().unwrap();
+    use glium::Surface;
+    let events_loop = glium::glutin::EventsLoop::new();
+    let window = glium::glutin::WindowBuilder::new()
+        .with_depth_buffer(24)
+        .build(&events_loop)
+        .unwrap();
+    let display = glium::build(window).unwrap();
 
     let positions = glium::VertexBuffer::new(&display, &teapot::VERTICES).unwrap();
     let normals = glium::VertexBuffer::new(&display, &teapot::NORMALS).unwrap();
@@ -112,12 +115,17 @@ fn main() {
                     &params).unwrap();
         target.finish().unwrap();
 
-        for ev in display.poll_events() {
-            match ev {
-                glium::glutin::Event::Closed => return,
-                _ => ()
+        let mut closed = false;
+        events_loop.poll_events(|event| {
+            match event {
+                glium::glutin::Event::WindowEvent { event, .. } => match event {
+                    glium::glutin::WindowEvent::Closed => closed = true,
+                    _ => ()
+                },
             }
-        }
+        });
+
+        if closed { break; }
     }
 }
 

--- a/examples/tutorial-14.rs
+++ b/examples/tutorial-14.rs
@@ -5,10 +5,13 @@ extern crate image;
 use std::io::Cursor;
 
 fn main() {
-    use glium::{DisplayBuild, Surface};
-    let display = glium::glutin::WindowBuilder::new()
-                        .with_depth_buffer(24)
-                        .build_glium().unwrap();
+    use glium::Surface;
+    let events_loop = glium::glutin::EventsLoop::new();
+    let window = glium::glutin::WindowBuilder::new()
+        .with_depth_buffer(24)
+        .build(&events_loop)
+        .unwrap();
+    let display = glium::build(window).unwrap();
 
     #[derive(Copy, Clone)]
     struct Vertex {
@@ -164,12 +167,17 @@ fn main() {
                     &params).unwrap();
         target.finish().unwrap();
 
-        for ev in display.poll_events() {
-            match ev {
-                glium::glutin::Event::Closed => return,
-                _ => ()
+        let mut closed = false;
+        events_loop.poll_events(|event| {
+            match event {
+                glium::glutin::Event::WindowEvent { event, .. } => match event {
+                    glium::glutin::WindowEvent::Closed => closed = true,
+                    _ => ()
+                },
             }
-        }
+        });
+
+        if closed { break; }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1265,6 +1265,36 @@ pub trait DisplayBuild {
     fn rebuild_glium(self, &Self::Facade) -> Result<(), Self::Err>;
 }
 
+
+/// Build a context and a facade to draw on it.
+///
+/// Performs a compatibility check to make sure that all core elements of glium
+/// are supported by the implementation.
+pub fn build<T>(build: T) -> Result<T::Facade, T::Err>
+    where T: DisplayBuild,
+{
+    build.build_glium()
+}
+
+/// Build a context and a facade to draw on it.
+///
+/// Performs a compatibility check to make sure that all core elements of glium
+/// are supported by the implementation.
+pub fn build_debug<T>(build: T, debug: debug::DebugCallbackBehavior)
+    -> Result<T::Facade, T::Err>
+    where T: DisplayBuild,
+{
+    build.build_glium_debug(debug)
+}
+
+/// Changes the settings of an existing facade.
+pub fn rebuild<T>(build: T, facade: &T::Facade) -> Result<(), T::Err>
+    where T: DisplayBuild,
+{
+    build.rebuild_glium(facade)
+}
+
+
 /// Error that can happen while creating a glium display.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum GliumCreationError<T> {

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -20,8 +20,14 @@ pub fn build_display() -> glium::Display {
                                                        .with_gl(version)
                                                        .build_glium().unwrap()
     } else {
-        glutin::WindowBuilder::new().with_gl_debug_flag(true).with_visibility(false)
-                                    .with_gl(version).build_glium().unwrap()
+        let events_loop = glutin::EventsLoop::new();
+        let window = glutin::WindowBuilder::new()
+            .with_gl_debug_flag(true)
+            .with_visibility(false)
+            .with_gl(version)
+            .build(&events_loop)
+            .unwrap();
+        glium::build(window).unwrap()
     };
 
     display
@@ -39,8 +45,14 @@ pub fn rebuild_display(display: &glium::Display) {
                                                        .with_gl(version)
                                                        .rebuild_glium(display).unwrap();
     } else {
-        glutin::WindowBuilder::new().with_gl_debug_flag(true).with_visibility(false)
-                                    .with_gl(version).rebuild_glium(display).unwrap();
+        let events_loop = glutin::EventsLoop::new();
+        let window = glutin::WindowBuilder::new()
+            .with_gl_debug_flag(true)
+            .with_visibility(false)
+            .with_gl(version)
+            .build(&events_loop)
+            .unwrap();
+        glium::rebuild(window, display).unwrap()
     }
 }
 


### PR DESCRIPTION
This change is in anticipation of tomaka/glutin#864 which updates to winit's new `EventsLoop` based API. See the linked PR for details.

Now that winit `Window`s require an `EventsLoop` argument to their
`build` method, the current `DisplayBuild` trait does not work well with
the `glutin` backend. To compensate for this, the `DisplayBuild` trait
has been implemented for `Window` itself rather than `WindowBuilder`,
allowing the user to build their glutin `Window` separately from
building their glium `Display`.

`build`, `build_debug` and `rebuild` fns have been added to remove the
need for uses to import the `DisplayBuild` trait.

One problem that arose while making this change is that, now that
`rebuild_glium` no longer has access to the `WindowBuilder` for the new
window, it can no longer insert the `.with_shared_lists` builder method.
I see a couple possible alternatives for this:

1. Rely on the user calling
`.with_shared_lists(display.get_window().unwrap())` when building the
new window that is to be used for rebuilding the display.
2. Add a `.share_lists(&other_window)` method to `glutin::Window`.
3. Something else?

@tomaka I haven't updated the book or `Cargo.toml` yet as I thought it best to get your thoughts on everything first, but I'm happy to do so once you are happy with the changes.