### PR TITLE
Fix invalid texture formats for OpenGL ES 3.0

### DIFF
--- a/src/image_format.rs
+++ b/src/image_format.rs
@@ -1654,6 +1654,8 @@ pub fn format_request_to_glenum(context: &Context, format: TextureFormatRequest,
         None => false,
     };
 
+    let is_es = version.0 == Api::GlEs;
+
     Ok(match format {
         /*******************************************************************/
         /*                           REGULAR                               */
@@ -1664,7 +1666,9 @@ pub fn format_request_to_glenum(context: &Context, format: TextureFormatRequest,
             if version >= &Version(Api::Gl, 3, 0) || version >= &Version(Api::GlEs, 3, 0) {
 
                 match (rq_ty, size) {
+                    (RequestType::TexImage(_), Some(1)) if is_es => gl::R8,
                     (RequestType::TexImage(_), Some(1)) => gl::RED,
+                    (RequestType::TexImage(_), Some(2)) if is_es => gl::RG8,
                     (RequestType::TexImage(_), Some(2)) => gl::RG,
                     (RequestType::TexImage(_), Some(3)) => gl::RGB,
                     (RequestType::TexImage(_), Some(4)) => gl::RGBA,


### PR DESCRIPTION
According to [The OpenGL ES 3.0 Spec](https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glTexImage2D.xhtml#id-1.6.11.1) (and my own experiences) some of the unsized internal formats are not available on OpenGL ES (which is in contrast to the situation for [OpenGL 4.0](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexImage2D.xhtml#id-1.6.13.1)).

Btw, I'm not sure if my fix is the "nicest" way of writing that -- if you have different preferences let me know.