### PR TITLE
Replace tomaka repo urls with newer glium

### DIFF
--- a/book/README.md
+++ b/book/README.md
@@ -2,4 +2,4 @@
 
 Hello and welcome to the glium tutorials! This series of tutorials will teach you how to work with OpenGL thanks to the glium library. Glium's API uses the exact same concepts as OpenGL and has been designed to remove the burden of using raw OpenGL function calls, which are often non-portable, tedious and error-prone. Even if for some reason you don't plan on using the glium library in the future, these tutorials can still be useful as they will teach you how OpenGL and graphics programming in general work.
 
-If at any moment you encounter an error, please open an issue. Everything related to the window, fullscreen mode, or events is handled by [glutin](https://github.com/tomaka/glutin/issues), while everything related to rendering is handled by [glium](https://github.com/tomaka/glium/issues).
+If at any moment you encounter an error, please open an issue. Everything related to the window, fullscreen mode, or events is handled by [glutin](https://github.com/glutin/glutin/issues), while everything related to rendering is handled by [glium](https://github.com/glutin/glium/issues).

--- a/book/tuto-02-triangle.md
+++ b/book/tuto-02-triangle.md
@@ -133,4 +133,4 @@ The "draw command" designation could make you think that drawing is a heavy oper
 
 ![Our final result](tuto-02-triangle.png)
 
-**[You can find the entire source code here](https://github.com/tomaka/glium/blob/master/examples/tutorial-02.rs).**
+**[You can find the entire source code here](https://github.com/glium/glium/blob/master/examples/tutorial-02.rs).**

--- a/book/tuto-04-matrices.md
+++ b/book/tuto-04-matrices.md
@@ -60,4 +60,4 @@ let uniforms = uniform! {
 };
 ```
 
-**[You can find the entire source code here](https://github.com/tomaka/glium/blob/master/examples/tutorial-04.rs).**
+**[You can find the entire source code here](https://github.com/glium/glium/blob/master/examples/tutorial-04.rs).**

--- a/book/tuto-05-colors.md
+++ b/book/tuto-05-colors.md
@@ -45,4 +45,4 @@ And the result should look like this:
 
 ![The result](tuto-05-linear.png)
 
-**[You can find the entire source code here](https://github.com/tomaka/glium/blob/master/examples/tutorial-05.rs).**
+**[You can find the entire source code here](https://github.com/glium/glium/blob/master/examples/tutorial-05.rs).**

--- a/book/tuto-06-texture.md
+++ b/book/tuto-06-texture.md
@@ -109,4 +109,4 @@ And here is the result:
 
 ![The result](tuto-06-texture.png)
 
-**[You can find the entire source code here](https://github.com/tomaka/glium/blob/master/examples/tutorial-06.rs).**
+**[You can find the entire source code here](https://github.com/glium/glium/blob/master/examples/tutorial-06.rs).**

--- a/book/tuto-07-shape.md
+++ b/book/tuto-07-shape.md
@@ -146,4 +146,4 @@ And you should now get the correct result:
 
 This looks very primitive, but it is a good first step towards 3D rendering.
 
-**[You can find the entire source code here](https://github.com/tomaka/glium/blob/master/examples/tutorial-07.rs).**
+**[You can find the entire source code here](https://github.com/glium/glium/blob/master/examples/tutorial-07.rs).**

--- a/book/tuto-08-gouraud.md
+++ b/book/tuto-08-gouraud.md
@@ -119,4 +119,4 @@ And here is the result:
 Now that we have brightness we can see that there are more things that are wrong with
 our rendering, this will be covered in the next sections!
 
-**[You can find the entire source code here](https://github.com/tomaka/glium/blob/master/examples/tutorial-08.rs).**
+**[You can find the entire source code here](https://github.com/glium/glium/blob/master/examples/tutorial-08.rs).**

--- a/book/tuto-09-depth.md
+++ b/book/tuto-09-depth.md
@@ -106,4 +106,4 @@ represented as shades of gray. Here is our depth buffer after drawing the teapot
 
 ![Depth buffer](tuto-09-depth.png)
 
-**[You can find the entire source code here](https://github.com/tomaka/glium/blob/master/examples/tutorial-09.rs).**
+**[You can find the entire source code here](https://github.com/glium/glium/blob/master/examples/tutorial-09.rs).**

--- a/book/tuto-10-perspective.md
+++ b/book/tuto-10-perspective.md
@@ -146,4 +146,4 @@ longer stretched.
 If you compare this to the previous screenshot, you can also see how the teapot now looks
 much better.
 
-**[You can find the entire source code here](https://github.com/tomaka/glium/blob/master/examples/tutorial-10.rs).**
+**[You can find the entire source code here](https://github.com/glium/glium/blob/master/examples/tutorial-10.rs).**

--- a/book/tuto-12-camera.md
+++ b/book/tuto-12-camera.md
@@ -118,4 +118,4 @@ And here is the result:
 
 ![Result](tuto-12-result.png)
 
-**[You can find the entire source code here](https://github.com/tomaka/glium/blob/master/examples/tutorial-12.rs).**
+**[You can find the entire source code here](https://github.com/glium/glium/blob/master/examples/tutorial-12.rs).**

--- a/book/tuto-13-phong.md
+++ b/book/tuto-13-phong.md
@@ -87,4 +87,4 @@ And here is the result:
 
 The big white spots are the specular reflection.
 
-**[You can find the entire source code here](https://github.com/tomaka/glium/blob/master/examples/tutorial-13.rs).**
+**[You can find the entire source code here](https://github.com/glium/glium/blob/master/examples/tutorial-13.rs).**

--- a/book/tuto-14-wall.md
+++ b/book/tuto-14-wall.md
@@ -200,4 +200,4 @@ And here is the result:
 
 This is much more convincing!
 
-**[You can find the entire source code here](https://github.com/tomaka/glium/blob/master/examples/tutorial-14.rs).**
+**[You can find the entire source code here](https://github.com/glium/glium/blob/master/examples/tutorial-14.rs).**

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -168,6 +168,7 @@ impl Context {
 
         let version = version::get_gl_version(&gl);
         let extensions = extensions::get_extensions(&gl, &version);
+
         try!(check_gl_compatibility(&version, &extensions));
 
         let capabilities = capabilities::get_capabilities(&gl, &version, &extensions);
@@ -213,6 +214,7 @@ impl Context {
             resident_image_handles: resident_image_handles,
         });
 
+        panic!("HERE");
         if context.debug_callback.is_some() {
             init_debug_callback(&context, synchronous);
         }
@@ -222,11 +224,11 @@ impl Context {
             let mut ctxt = context.make_current();
             if ::get_gl_error(&mut ctxt).is_some() {
                 println!("glium has triggered an OpenGL error during initialization. Please report \
-                          this error: https://github.com/tomaka/glium/issues");
+                          this error: https://github.com/glutin/glium/issues");
             }
             /*assert!(::get_gl_error(&mut ctxt).is_none(),
                     "glium has triggered an OpenGL error during initialization. Please report \
-                     this error: https://github.com/tomaka/glium/issues");*/
+                     this error: https://github.com/glutin/glium/issues");*/
         }
 
         Ok(context)
@@ -844,7 +846,7 @@ fn default_debug_callback(_: debug::Source, ty: debug::MessageType, severity: de
 
     if report_debug_output_errors {
         print!("Debug message with high or medium severity: `{}`.\n\
-                Please report this error: https://github.com/tomaka/glium/issues\n\
+                Please report this error: https://github.com/glutin/glium/issues\n\
                 Backtrace:",
                 message);
 


### PR DESCRIPTION
While digging through some old Test code I found cases where we told user to create an issue to the old `tomaka/glium.git` repo. 