### PR TITLE
Replace From/Into Traits to replace AsUniformValue

### DIFF
--- a/src/buffer/fences.rs
+++ b/src/buffer/fences.rs
@@ -11,9 +11,6 @@ use std::rc::Rc;
 use context::CommandContext;
 use sync::{self, LinearSyncFence};
 
-
-pub type RefFences = Rc<Fences>;
-
 /// Contains a list of fences.
 #[derive(Clone)]
 pub struct Fences {

--- a/src/buffer/fences.rs
+++ b/src/buffer/fences.rs
@@ -6,28 +6,31 @@ This module handles the fences of a buffer.
 use smallvec::SmallVec;
 use std::cell::RefCell;
 use std::ops::Range;
+use std::rc::Rc;
 
 use context::CommandContext;
 use sync::{self, LinearSyncFence};
 
+
+pub type RefFences = Rc<Fences>;
+
 /// Contains a list of fences.
+#[derive(Clone)]
 pub struct Fences {
-    fences: RefCell<SmallVec<[(Range<usize>, LinearSyncFence); 16]>>,
+    fences: Rc<RefCell<SmallVec<[(Range<usize>, LinearSyncFence); 16]>>>,
 }
 
 impl Fences {
     /// Initialization.
     pub fn new() -> Fences {
-        Fences {
-            fences: RefCell::new(SmallVec::new()),
-        }
+        Fences { fences: Rc::new(RefCell::new(SmallVec::new())) }
     }
 
     /// Creates an `Inserter` that allows inserting a fence in the list for the given range.
     #[inline]
     pub fn inserter(&self, range: Range<usize>) -> Inserter {
         Inserter {
-            fences: self,
+            fences: self.clone(),
             range: range,
         }
     }
@@ -39,7 +42,7 @@ impl Fences {
 
         for existing in existing_fences.drain() {
             if (existing.0.start >= range.start && existing.0.start < range.end) ||
-               (existing.0.end > range.start && existing.0.end < range.end)
+                (existing.0.end > range.start && existing.0.end < range.end)
             {
                 unsafe { sync::wait_linear_sync_fence_and_drop(existing.1, ctxt) };
             } else {
@@ -60,12 +63,12 @@ impl Fences {
 }
 
 /// Allows inserting a fence in the list.
-pub struct Inserter<'a> {
-    fences: &'a Fences,
+pub struct Inserter {
+    fences: Fences,
     range: Range<usize>,
 }
 
-impl<'a> Inserter<'a> {
+impl Inserter {
     /// Inserts a new fence.
     pub fn insert(self, ctxt: &mut CommandContext) {
         let mut new_fences = SmallVec::new();
@@ -81,12 +84,12 @@ impl<'a> Inserter<'a> {
                 // we are stuck here, because we can't duplicate a fence
                 // so instead we just extend the new fence to the existing one
                 let new_fence = unsafe { sync::new_linear_sync_fence(ctxt).unwrap() };
-                new_fences.push((existing.0.start .. self.range.start, existing.1));
-                new_fences.push((self.range.start .. existing.0.end, new_fence));
+                new_fences.push((existing.0.start..self.range.start, existing.1));
+                new_fences.push((self.range.start..existing.0.end, new_fence));
                 written = true;
 
             } else if existing.0.start < self.range.start && existing.0.end >= self.range.start {
-                new_fences.push((existing.0.start .. self.range.start, existing.1));
+                new_fences.push((existing.0.start..self.range.start, existing.1));
                 if !written {
                     let new_fence = unsafe { sync::new_linear_sync_fence(ctxt).unwrap() };
                     new_fences.push((self.range.clone(), new_fence));
@@ -117,7 +120,7 @@ impl<'a> Inserter<'a> {
                     written = true;
                 }
 
-                new_fences.push((self.range.end .. existing.0.end, existing.1));
+                new_fences.push((self.range.end..existing.0.end, existing.1));
             }
         }
 

--- a/src/buffer/view.rs
+++ b/src/buffer/view.rs
@@ -21,7 +21,7 @@ use buffer::BufferType;
 use buffer::BufferMode;
 use buffer::BufferCreationError;
 use buffer::Content;
-use buffer::fences::Fences;
+use buffer::fences::{ Fences };
 use buffer::fences::Inserter;
 use buffer::alloc::Alloc;
 use buffer::alloc::Mapping;
@@ -721,7 +721,7 @@ impl<'a, T: ?Sized> From<&'a mut Buffer<T>> for BufferSlice<'a, T> where T: Cont
 
 impl<'a, T: ?Sized> BufferSliceExt<'a> for BufferSlice<'a, T> where T: Content {
     #[inline]
-    fn add_fence(&self) -> Option<Inserter<'a>> {
+    fn add_fence(&self) -> Option<Inserter> {
         if !self.alloc.uses_persistent_mapping() {
             return None;
         }
@@ -1045,7 +1045,7 @@ impl<'a, T> BufferMutSlice<'a, [T]> where T: PixelValue + 'a {
 
 impl<'a, T: ?Sized> BufferSliceExt<'a> for BufferMutSlice<'a, T> where T: Content {
     #[inline]
-    fn add_fence(&self) -> Option<Inserter<'a>> {
+    fn add_fence(&self) -> Option<Inserter> {
         if !self.alloc.uses_persistent_mapping() {
             return None;
         }
@@ -1313,7 +1313,7 @@ impl<'a> fmt::Debug for BufferAnySlice<'a> {
 
 impl<'a> BufferSliceExt<'a> for BufferAnySlice<'a> {
     #[inline]
-    fn add_fence(&self) -> Option<Inserter<'a>> {
+    fn add_fence(&self) -> Option<Inserter> {
         if !self.alloc.uses_persistent_mapping() {
             return None;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,7 +269,7 @@ trait BufferSliceExt<'a> {
     /// Tries to get an object where to write a fence.
     ///
     /// If this function returns `None`, no fence will be created nor written.
-    fn add_fence(&self) -> Option<buffer::Inserter<'a>>;
+    fn add_fence(&self) -> Option<buffer::Inserter>;
 }
 
 /// Internal trait for contexts.
@@ -385,7 +385,7 @@ trait UniformsExt {
     /// Binds the uniforms to a given program.
     ///
     /// Will replace texture and buffer bind points.
-    fn bind_uniforms<'a, P>(&'a self, &mut CommandContext, &P, &mut Vec<buffer::Inserter<'a>>)
+    fn bind_uniforms<'a, P>(&'a self, &mut CommandContext, &P, &mut Vec<buffer::Inserter>)
                             -> Result<(), DrawError> where P: ProgramExt;
 }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -74,7 +74,6 @@ impl Drop for SyncFence {
 /// The fence must be consumed with either `into_sync_fence`, otherwise
 /// the destructor will panic.
 #[must_use]
-#[derive(Clone)]
 pub struct LinearSyncFence {
     id: Option<gl::types::GLsync>,
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -74,6 +74,7 @@ impl Drop for SyncFence {
 /// The fence must be consumed with either `into_sync_fence`, otherwise
 /// the destructor will panic.
 #[must_use]
+#[derive(Clone)]
 pub struct LinearSyncFence {
     id: Option<gl::types::GLsync>,
 }

--- a/src/texture/any.rs
+++ b/src/texture/any.rs
@@ -55,6 +55,7 @@ pub enum Dimensions {
 }
 
 /// A texture whose type isn't fixed at compile-time.
+#[derive(Clone)]
 pub struct TextureAny {
     context: Rc<Context>,
     id: gl::types::GLuint,

--- a/src/texture/bindless.rs
+++ b/src/texture/bindless.rs
@@ -68,7 +68,6 @@ use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 
 use program::BlockLayout;
-use uniforms::AsUniformValue;
 use uniforms::LayoutMismatchError;
 use uniforms::UniformBlock;
 use uniforms::UniformValue;
@@ -175,10 +174,8 @@ impl<'a> TextureHandle<'a> {
     }
 }
 
-impl<'a> AsUniformValue for TextureHandle<'a> {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        // TODO: u64
+impl<'a> From<TextureHandle<'a>> for UniformValue<'a> {
+    fn from(v: TextureHandle<'a>) -> UniformValue<'a> {
         unimplemented!();
     }
 }

--- a/src/texture/buffer_texture.rs
+++ b/src/texture/buffer_texture.rs
@@ -76,7 +76,6 @@ use buffer::Buffer;
 use buffer::BufferCreationError;
 use buffer::Content as BufferContent;
 
-use uniforms::AsUniformValue;
 use uniforms::UniformValue;
 
 /// Error that can happen while building the texture part of a buffer texture.
@@ -503,31 +502,23 @@ impl<T> BufferTexture<T> where [T]: BufferContent {
     }
 }
 
-impl<T> AsUniformValue for BufferTexture<T> where [T]: BufferContent {
+impl<'a, T: 'a>  From<&'a BufferTexture<T>> for UniformValue<'a> where [T]: BufferContent {
     #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
+    fn from(v: &'a BufferTexture<T>)-> UniformValue<'a> {
         // FIXME: handle `glMemoryBarrier` for the buffer
-        UniformValue::BufferTexture(self.as_buffer_texture_ref())
-    }
-}
-
-impl<'a, T: 'a> AsUniformValue for &'a BufferTexture<T> where [T]: BufferContent {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        // FIXME: handle `glMemoryBarrier` for the buffer
-        UniformValue::BufferTexture(self.as_buffer_texture_ref())
+        UniformValue::BufferTexture(v.as_buffer_texture_ref())
     }
 }
 
 /// Holds a reference to a `BufferTexture`.
-#[derive(Copy, Clone)]
-pub struct BufferTextureRef<'a> {
+#[derive(Copy, Clone, Debug)]
+pub struct BufferTextureRef {
     texture: gl::types::GLuint,
     ty: BufferTextureType,
-    marker: PhantomData<&'a ()>,
+    marker: PhantomData<()>,
 }
 
-impl<'a> BufferTextureRef<'a> {
+impl BufferTextureRef {
     /// Return the type of the texture.
     #[inline]
     pub fn get_texture_type(&self) -> BufferTextureType {
@@ -535,7 +526,7 @@ impl<'a> BufferTextureRef<'a> {
     }
 }
 
-impl<'a> TextureExt for BufferTextureRef<'a> {
+impl TextureExt for BufferTextureRef {
     #[inline]
     fn get_texture_id(&self) -> gl::types::GLuint {
         self.texture

--- a/src/uniforms/bind.rs
+++ b/src/uniforms/bind.rs
@@ -32,11 +32,18 @@ use context;
 use version::Version;
 use version::Api;
 
-impl<U> UniformsExt for U where U: Uniforms {
-    fn bind_uniforms<'a, P>(&'a self, mut ctxt: &mut CommandContext, program: &P,
-                            fences: &mut Vec<Inserter<'a>>)
-                            -> Result<(), DrawError>
-                            where P: ProgramExt
+impl<U> UniformsExt for U
+where
+    U: Uniforms,
+{
+    fn bind_uniforms<'a, P>(
+        &'a self,
+        mut ctxt: &mut CommandContext,
+        program: &P,
+        fences: &mut Vec<Inserter>,
+    ) -> Result<(), DrawError>
+    where
+        P: ProgramExt,
     {
         let mut texture_bind_points = Bitsfield::new();
         let mut uniform_buffer_bind_points = Bitsfield::new();
@@ -44,8 +51,11 @@ impl<U> UniformsExt for U where U: Uniforms {
 
         // Subroutine uniforms must be bound all at once, so we collect them first and process them at the end.
         // The vec contains the uniform we want to set and the value we want to set it to.
-        let mut subroutine_bindings: HashMap<program::ShaderStage, Vec<(&program::SubroutineUniform, &str)>, _>
-            = HashMap::with_hasher(Default::default());
+        let mut subroutine_bindings: HashMap<
+            program::ShaderStage,
+            Vec<(&program::SubroutineUniform, String)>,
+            _,
+        > = HashMap::with_hasher(Default::default());
 
         let mut visiting_result = Ok(());
         self.visit_values(|name, value| {
@@ -57,7 +67,7 @@ impl<U> UniformsExt for U where U: Uniforms {
 
                 if !value.is_usable_with(&uniform.ty) {
                     visiting_result = Err(DrawError::UniformTypeMismatch {
-                        name: name.to_owned(),
+                        name: name.to_string(),
                         expected: uniform.ty,
                     });
                     return;
@@ -73,7 +83,8 @@ impl<U> UniformsExt for U where U: Uniforms {
                     }
                 };
 
-            } else if let Some(block) = program.get_uniform_blocks().get(name) {
+            }
+            else if let Some(block) = program.get_uniform_blocks().get(name) {
                 let fence = match bind_uniform_block(&mut ctxt, &value, block,
                                                      program, &mut uniform_buffer_bind_points, name)
                 {
@@ -85,9 +96,8 @@ impl<U> UniformsExt for U where U: Uniforms {
                 };
 
                 if let Some(fence) = fence {
-                    fences.push(fence);
+                     fences.push(fence);
                 }
-
             } else if let Some(block) = program.get_shader_storage_blocks().get(name) {
                 let fence = match bind_shared_storage_block(&mut ctxt, &value, block, program,
                                                             &mut shared_storage_buffer_bind_points,
@@ -99,15 +109,14 @@ impl<U> UniformsExt for U where U: Uniforms {
                         return;
                     }
                 };
-
                 if let Some(fence) = fence {
                     fences.push(fence);
                 }
-            } else if let UniformValue::Subroutine(stage, sr_name) = value {
-                if let Some(subroutine_uniform) = program.get_subroutine_data().subroutine_uniforms.get(&(name.into(), stage)) {
+            } else if let &UniformValue::Subroutine(stage, sr_name) = value {
+                if let Some(subroutine_uniform) = program.get_subroutine_data().subroutine_uniforms.get(&(String::from(name), stage)) {
                     subroutine_bindings.entry(stage).or_insert(Vec::new());
                     let vec = subroutine_bindings.get_mut(&stage).unwrap();
-                    vec.push((subroutine_uniform, sr_name));
+                    vec.push((subroutine_uniform, sr_name.into()));
                 }
             }
         });
@@ -126,38 +135,51 @@ impl<U> UniformsExt for U where U: Uniforms {
     }
 }
 
-fn bind_subroutine_uniforms<P>(ctxt: &mut context::CommandContext, program: &P,
-                            subroutine_bindings: &HashMap<program::ShaderStage, Vec<(&program::SubroutineUniform, &str)>, BuildHasherDefault<FnvHasher>>)
-                            -> Result<(), DrawError>
-                            where P: ProgramExt
+fn bind_subroutine_uniforms<P>(
+    ctxt: &mut context::CommandContext,
+    program: &P,
+    subroutine_bindings: &HashMap<
+        program::ShaderStage,
+        Vec<(&program::SubroutineUniform, String)>,
+        BuildHasherDefault<FnvHasher>,
+    >,
+) -> Result<(), DrawError>
+where
+    P: ProgramExt,
 {
     let subroutine_data = program.get_subroutine_data();
     for (stage, bindings) in subroutine_bindings {
         // Validate that all subroutine uniforms of this stage are set, otherwise OpenGL will throw an error.
         let set_cnt = bindings.len();
-        let expected_cnt = subroutine_data.subroutine_uniforms.iter()
-                                  .filter(|&(&(_, uni_stage), _)| *stage == uni_stage)
-                                  .count();
+        let expected_cnt = subroutine_data
+            .subroutine_uniforms
+            .iter()
+            .filter(|&(&(_, uni_stage), _)| *stage == uni_stage)
+            .count();
         if set_cnt != expected_cnt {
             return Err(DrawError::SubroutineUniformMissing {
                 stage: *stage,
                 real_count: set_cnt,
                 expected_count: expected_cnt,
-            })
+            });
         }
 
         // Build the indices array
-        let mut indices = vec![0 as gl::types::GLuint; *subroutine_data.location_counts.get(stage).unwrap()];
+        let mut indices =
+            vec![0 as gl::types::GLuint; *subroutine_data.location_counts.get(stage).unwrap()];
         for binding in bindings {
             let uniform = binding.0;
-            let subroutine_str = binding.1;
-            let subroutine = match uniform.compatible_subroutines.iter()
-                                   .find(|subroutine| subroutine.name == subroutine_str) {
+            let ref subroutine_str = binding.1;
+            let subroutine = match uniform.compatible_subroutines.iter().find(|subroutine| {
+                subroutine.name == subroutine_str.as_ref()
+            }) {
                 Some(subroutine) => subroutine,
-                None => return Err(DrawError::SubroutineNotFound {
-                                    stage: *stage,
-                                    name: subroutine_str.into(),
-                                })
+                None => {
+                    return Err(DrawError::SubroutineNotFound {
+                        stage: *stage,
+                        name: subroutine_str.clone(),
+                    })
+                }
             };
 
             indices[uniform.location as usize] = subroutine.index;
@@ -167,11 +189,16 @@ fn bind_subroutine_uniforms<P>(ctxt: &mut context::CommandContext, program: &P,
     Ok(())
 }
 
-fn bind_uniform_block<'a, P>(ctxt: &mut context::CommandContext, value: &UniformValue<'a>,
-                             block: &program::UniformBlock,
-                             program: &P, buffer_bind_points: &mut Bitsfield, name: &str)
-                             -> Result<Option<Inserter<'a>>, DrawError>
-                             where P: ProgramExt
+fn bind_uniform_block<'a, P>(
+    ctxt: &mut context::CommandContext,
+    value: &'a UniformValue,
+    block: &program::UniformBlock,
+    program: &P,
+    buffer_bind_points: &mut Bitsfield,
+    name: &str,
+) -> Result<Option<Inserter>, DrawError>
+where
+    P: ProgramExt,
 {
     match value {
         &UniformValue::Block(buffer, ref layout) => {
@@ -185,10 +212,12 @@ fn bind_uniform_block<'a, P>(ctxt: &mut context::CommandContext, value: &Uniform
                 }
             }
 
-            let bind_point = buffer_bind_points.get_unused().expect("Not enough buffer units");
+            let bind_point = buffer_bind_points.get_unused().expect(
+                "Not enough buffer units",
+            );
             buffer_bind_points.set_used(bind_point);
 
-            assert!(buffer.get_offset_bytes() == 0);     // TODO: not implemented
+            assert!(buffer.get_offset_bytes() == 0); // TODO: not implemented
             let fence = buffer.add_fence();
             let block_id = block.id as gl::types::GLuint;
 
@@ -196,18 +225,21 @@ fn bind_uniform_block<'a, P>(ctxt: &mut context::CommandContext, value: &Uniform
             program.set_uniform_block_binding(ctxt, block_id, bind_point as gl::types::GLuint);
 
             Ok(fence)
-        },
-        _ => {
-            Err(DrawError::UniformValueToBlock { name: name.to_owned() })
         }
+        _ => Err(DrawError::UniformValueToBlock { name: name.to_owned() }),
     }
 }
 
-fn bind_shared_storage_block<'a, P>(ctxt: &mut context::CommandContext, value: &UniformValue<'a>,
-                                    block: &program::UniformBlock,
-                                    program: &P, buffer_bind_points: &mut Bitsfield, name: &str)
-                                    -> Result<Option<Inserter<'a>>, DrawError>
-                                    where P: ProgramExt
+fn bind_shared_storage_block<'a, P>(
+    ctxt: &mut context::CommandContext,
+    value: &UniformValue<'a>,
+    block: &program::UniformBlock,
+    program: &P,
+    buffer_bind_points: &mut Bitsfield,
+    name: &str,
+) -> Result<Option<Inserter>, DrawError>
+where
+    P: ProgramExt,
 {
     match value {
         &UniformValue::Block(buffer, ref layout) => {
@@ -221,370 +253,804 @@ fn bind_shared_storage_block<'a, P>(ctxt: &mut context::CommandContext, value: &
                 }
             }
 
-            let bind_point = buffer_bind_points.get_unused().expect("Not enough buffer units");
+            let bind_point = buffer_bind_points.get_unused().expect(
+                "Not enough buffer units",
+            );
             buffer_bind_points.set_used(bind_point);
 
-            assert!(buffer.get_offset_bytes() == 0);     // TODO: not implemented
+            assert!(buffer.get_offset_bytes() == 0); // TODO: not implemented
             let fence = buffer.add_fence();
             let block_id = block.id as gl::types::GLuint;
 
             buffer.prepare_and_bind_for_shared_storage(ctxt, bind_point as gl::types::GLuint);
-            program.set_shader_storage_block_binding(ctxt, block_id, bind_point as gl::types::GLuint);
+            program.set_shader_storage_block_binding(
+                ctxt,
+                block_id,
+                bind_point as gl::types::GLuint,
+            );
 
             Ok(fence)
-        },
-        _ => {
-            Err(DrawError::UniformValueToBlock { name: name.to_owned() })
+        }
+        _ => Err(DrawError::UniformValueToBlock { name: name.to_owned() }),
+    }
+}
+
+fn bind_uniform<P>(
+    ctxt: &mut context::CommandContext,
+    value: &UniformValue,
+    program: &P,
+    location: gl::types::GLint,
+    texture_bind_points: &mut Bitsfield,
+    name: &str,
+) -> Result<(), DrawError>
+where
+    P: ProgramExt,
+{
+    assert!(location >= 0);
+
+    match value {
+        &UniformValue::Block(_, _) => {
+            Err(DrawError::UniformBufferToValue { name: name.to_owned() })
+        }
+        &UniformValue::Subroutine(_, _) => {
+            Err(DrawError::SubroutineUniformToValue {
+                name: name.to_owned(),
+            })
+        }
+        &UniformValue::Bool(val) => {
+            // Booleans get passed as integers.
+            program.set_uniform(ctxt, location, &RawUniformValue::SignedInt(val as i32));
+            Ok(())
+        }
+        &UniformValue::SignedInt(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::SignedInt(val));
+            Ok(())
+        }
+        &UniformValue::UnsignedInt(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::UnsignedInt(val));
+            Ok(())
+        }
+        &UniformValue::Float(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::Float(val));
+            Ok(())
+        }
+        &UniformValue::Mat2(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::Mat2(val));
+            Ok(())
+        }
+        &UniformValue::Mat3(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::Mat3(val));
+            Ok(())
+        }
+        &UniformValue::Mat4(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::Mat4(val));
+            Ok(())
+        }
+        &UniformValue::Vec2(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::Vec2(val));
+            Ok(())
+        }
+        &UniformValue::Vec3(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::Vec3(val));
+            Ok(())
+        }
+        &UniformValue::Vec4(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::Vec4(val));
+            Ok(())
+        }
+        &UniformValue::IntVec2(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::IntVec2(val));
+            Ok(())
+        }
+        &UniformValue::IntVec3(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::IntVec3(val));
+            Ok(())
+        }
+        &UniformValue::IntVec4(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::IntVec4(val));
+            Ok(())
+        }
+        &UniformValue::UnsignedIntVec2(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::UnsignedIntVec2(val));
+            Ok(())
+        }
+        &UniformValue::UnsignedIntVec3(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::UnsignedIntVec3(val));
+            Ok(())
+        }
+        &UniformValue::UnsignedIntVec4(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::UnsignedIntVec4(val));
+            Ok(())
+        }
+        &UniformValue::BoolVec2(val) => {
+            let val_casted = [val[0] as i32, val[1] as i32];
+            program.set_uniform(ctxt, location, &RawUniformValue::IntVec2(val_casted));
+            Ok(())
+        }
+        &UniformValue::BoolVec3(val) => {
+            let val_casted = [val[0] as i32, val[1] as i32, val[2] as i32];
+            program.set_uniform(ctxt, location, &RawUniformValue::IntVec3(val_casted));
+            Ok(())
+        }
+        &UniformValue::BoolVec4(val) => {
+            let val_casted = [val[0] as i32, val[1] as i32, val[2] as i32, val[3] as i32];
+            program.set_uniform(ctxt, location, &RawUniformValue::IntVec4(val_casted));
+            Ok(())
+        }
+        &UniformValue::Double(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::Double(val));
+            Ok(())
+        }
+        &UniformValue::DoubleMat2(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::DoubleMat2(val));
+            Ok(())
+        }
+        &UniformValue::DoubleMat3(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::DoubleMat3(val));
+            Ok(())
+        }
+        &UniformValue::DoubleMat4(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::DoubleMat4(val));
+            Ok(())
+        }
+        &UniformValue::DoubleVec2(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::DoubleVec2(val));
+            Ok(())
+        }
+        &UniformValue::DoubleVec3(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::DoubleVec3(val));
+            Ok(())
+        }
+        &UniformValue::DoubleVec4(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::DoubleVec4(val));
+            Ok(())
+        }
+        &UniformValue::Int64(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::Int64(val));
+            Ok(())
+        }
+        &UniformValue::Int64Vec2(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::Int64Vec2(val));
+            Ok(())
+        }
+        &UniformValue::Int64Vec3(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::Int64Vec3(val));
+            Ok(())
+        }
+        &UniformValue::Int64Vec4(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::Int64Vec4(val));
+            Ok(())
+        }
+        &UniformValue::UnsignedInt64(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::UnsignedInt64(val));
+            Ok(())
+        }
+        &UniformValue::UnsignedInt64Vec2(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::UnsignedInt64Vec2(val));
+            Ok(())
+        }
+        &UniformValue::UnsignedInt64Vec3(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::UnsignedInt64Vec3(val));
+            Ok(())
+        }
+        &UniformValue::UnsignedInt64Vec4(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::UnsignedInt64Vec4(val));
+            Ok(())
+        }
+        &UniformValue::Texture1d(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::CompressedTexture1d(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::SrgbTexture1d(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::CompressedSrgbTexture1d(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::IntegralTexture1d(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::UnsignedTexture1d(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::DepthTexture1d(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::Texture2d(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::CompressedTexture2d(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::SrgbTexture2d(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::CompressedSrgbTexture2d(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::IntegralTexture2d(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::UnsignedTexture2d(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::DepthTexture2d(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::Texture2dMultisample(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::SrgbTexture2dMultisample(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::IntegralTexture2dMultisample(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::UnsignedTexture2dMultisample(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::DepthTexture2dMultisample(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::Texture3d(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::CompressedTexture3d(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::SrgbTexture3d(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::CompressedSrgbTexture3d(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::IntegralTexture3d(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::UnsignedTexture3d(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::DepthTexture3d(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::Texture1dArray(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::CompressedTexture1dArray(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::SrgbTexture1dArray(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::CompressedSrgbTexture1dArray(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::IntegralTexture1dArray(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::UnsignedTexture1dArray(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::DepthTexture1dArray(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::Texture2dArray(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::CompressedTexture2dArray(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::SrgbTexture2dArray(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::CompressedSrgbTexture2dArray(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::IntegralTexture2dArray(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::UnsignedTexture2dArray(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::DepthTexture2dArray(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::Texture2dMultisampleArray(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::SrgbTexture2dMultisampleArray(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::IntegralTexture2dMultisampleArray(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::UnsignedTexture2dMultisampleArray(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::DepthTexture2dMultisampleArray(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::Cubemap(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::CompressedCubemap(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::SrgbCubemap(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::CompressedSrgbCubemap(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::IntegralCubemap(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::UnsignedCubemap(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::DepthCubemap(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::CubemapArray(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::CompressedCubemapArray(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::SrgbCubemapArray(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::CompressedSrgbCubemapArray(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::IntegralCubemapArray(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::UnsignedCubemapArray(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::DepthCubemapArray(ref texture, sampler) => {
+            bind_texture_uniform(
+                ctxt,
+                &**texture,
+                sampler,
+                location,
+                program,
+                texture_bind_points,
+            )
+        }
+        &UniformValue::BufferTexture(ref texture) => {
+            bind_texture_uniform(
+                ctxt,
+                &texture.clone(),
+                None,
+                location,
+                program,
+                texture_bind_points,
+            )
         }
     }
 }
 
-fn bind_uniform<P>(ctxt: &mut context::CommandContext,
-                   value: &UniformValue, program: &P, location: gl::types::GLint,
-                   texture_bind_points: &mut Bitsfield, name: &str)
-                   -> Result<(), DrawError> where P: ProgramExt
-{
-    assert!(location >= 0);
-
-    match *value {
-        UniformValue::Block(_, _) => {
-            Err(DrawError::UniformBufferToValue {
-                name: name.to_owned(),
-            })
-        },
-        UniformValue::Subroutine(_, _) => {
-            Err(DrawError::SubroutineUniformToValue {
-                name: name.to_owned(),
-            })
-        },
-        UniformValue::Bool(val) => {
-            // Booleans get passed as integers.
-            program.set_uniform(ctxt, location, &RawUniformValue::SignedInt(val as i32));
-            Ok(())
-        },
-        UniformValue::SignedInt(val) => {
-            program.set_uniform(ctxt, location, &RawUniformValue::SignedInt(val));
-            Ok(())
-        },
-        UniformValue::UnsignedInt(val) => {
-            program.set_uniform(ctxt, location, &RawUniformValue::UnsignedInt(val));
-            Ok(())
-        },
-        UniformValue::Float(val) => {
-            program.set_uniform(ctxt, location, &RawUniformValue::Float(val));
-            Ok(())
-        },
-        UniformValue::Mat2(val) => {
-            program.set_uniform(ctxt, location, &RawUniformValue::Mat2(val));
-            Ok(())
-        },
-        UniformValue::Mat3(val) => {
-            program.set_uniform(ctxt, location, &RawUniformValue::Mat3(val));
-            Ok(())
-        },
-        UniformValue::Mat4(val) => {
-            program.set_uniform(ctxt, location, &RawUniformValue::Mat4(val));
-            Ok(())
-        },
-        UniformValue::Vec2(val) => {
-            program.set_uniform(ctxt, location, &RawUniformValue::Vec2(val));
-            Ok(())
-        },
-        UniformValue::Vec3(val) => {
-            program.set_uniform(ctxt, location, &RawUniformValue::Vec3(val));
-            Ok(())
-        },
-        UniformValue::Vec4(val) => {
-            program.set_uniform(ctxt, location, &RawUniformValue::Vec4(val));
-            Ok(())
-        },
-        UniformValue::IntVec2(val) => {
-            program.set_uniform(ctxt, location, &RawUniformValue::IntVec2(val));
-            Ok(())
-        },
-        UniformValue::IntVec3(val) => {
-            program.set_uniform(ctxt, location, &RawUniformValue::IntVec3(val));
-            Ok(())
-        },
-        UniformValue::IntVec4(val) => {
-            program.set_uniform(ctxt, location, &RawUniformValue::IntVec4(val));
-            Ok(())
-        },
-        UniformValue::UnsignedIntVec2(val) => {
-            program.set_uniform(ctxt, location, &RawUniformValue::UnsignedIntVec2(val));
-            Ok(())
-        },
-        UniformValue::UnsignedIntVec3(val) => {
-            program.set_uniform(ctxt, location, &RawUniformValue::UnsignedIntVec3(val));
-            Ok(())
-        },
-        UniformValue::UnsignedIntVec4(val) => {
-            program.set_uniform(ctxt, location, &RawUniformValue::UnsignedIntVec4(val));
-            Ok(())
-        },
-        UniformValue::BoolVec2(val) => {
-            let val_casted = [val[0] as i32, val[1] as i32];
-            program.set_uniform(ctxt, location, &RawUniformValue::IntVec2(val_casted));
-            Ok(())
-        },
-        UniformValue::BoolVec3(val) => {
-            let val_casted = [val[0] as i32, val[1] as i32, val[2] as i32];
-            program.set_uniform(ctxt, location, &RawUniformValue::IntVec3(val_casted));
-            Ok(())
-        },
-        UniformValue::BoolVec4(val) => {
-            let val_casted = [val[0] as i32, val[1] as i32, val[2] as i32, val[3] as i32];
-            program.set_uniform(ctxt, location, &RawUniformValue::IntVec4(val_casted));
-            Ok(())
-        },
-        UniformValue::Double(val) => {
-            program.set_uniform(ctxt, location, &RawUniformValue::Double(val));
-            Ok(())
-        },
-        UniformValue::DoubleMat2(val) => {
-            program.set_uniform(ctxt, location, &RawUniformValue::DoubleMat2(val));
-            Ok(())
-        },
-        UniformValue::DoubleMat3(val) => {
-            program.set_uniform(ctxt, location, &RawUniformValue::DoubleMat3(val));
-            Ok(())
-        },
-        UniformValue::DoubleMat4(val) => {
-            program.set_uniform(ctxt, location, &RawUniformValue::DoubleMat4(val));
-            Ok(())
-        },
-        UniformValue::DoubleVec2(val) => {
-            program.set_uniform(ctxt, location, &RawUniformValue::DoubleVec2(val));
-            Ok(())
-        },
-        UniformValue::DoubleVec3(val) => {
-            program.set_uniform(ctxt, location, &RawUniformValue::DoubleVec3(val));
-            Ok(())
-        },
-        UniformValue::DoubleVec4(val) => {
-            program.set_uniform(ctxt, location, &RawUniformValue::DoubleVec4(val));
-            Ok(())
-        },
-        UniformValue::Int64(val) => {
-            program.set_uniform(ctxt, location, &RawUniformValue::Int64(val));
-            Ok(())
-        },
-        UniformValue::Int64Vec2(val) => {
-            program.set_uniform(ctxt, location, &RawUniformValue::Int64Vec2(val));
-            Ok(())
-        },
-        UniformValue::Int64Vec3(val) => {
-            program.set_uniform(ctxt, location, &RawUniformValue::Int64Vec3(val));
-            Ok(())
-        },
-        UniformValue::Int64Vec4(val) => {
-            program.set_uniform(ctxt, location, &RawUniformValue::Int64Vec4(val));
-            Ok(())
-        },
-        UniformValue::UnsignedInt64(val) => {
-            program.set_uniform(ctxt, location, &RawUniformValue::UnsignedInt64(val));
-            Ok(())
-        },
-        UniformValue::UnsignedInt64Vec2(val) => {
-            program.set_uniform(ctxt, location, &RawUniformValue::UnsignedInt64Vec2(val));
-            Ok(())
-        },
-        UniformValue::UnsignedInt64Vec3(val) => {
-            program.set_uniform(ctxt, location, &RawUniformValue::UnsignedInt64Vec3(val));
-            Ok(())
-        },
-        UniformValue::UnsignedInt64Vec4(val) => {
-            program.set_uniform(ctxt, location, &RawUniformValue::UnsignedInt64Vec4(val));
-            Ok(())
-        },
-        UniformValue::Texture1d(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::CompressedTexture1d(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::SrgbTexture1d(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::CompressedSrgbTexture1d(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::IntegralTexture1d(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::UnsignedTexture1d(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::DepthTexture1d(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::Texture2d(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::CompressedTexture2d(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::SrgbTexture2d(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::CompressedSrgbTexture2d(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::IntegralTexture2d(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::UnsignedTexture2d(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::DepthTexture2d(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::Texture2dMultisample(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::SrgbTexture2dMultisample(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::IntegralTexture2dMultisample(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::UnsignedTexture2dMultisample(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::DepthTexture2dMultisample(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::Texture3d(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::CompressedTexture3d(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::SrgbTexture3d(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::CompressedSrgbTexture3d(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::IntegralTexture3d(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::UnsignedTexture3d(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::DepthTexture3d(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::Texture1dArray(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::CompressedTexture1dArray(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::SrgbTexture1dArray(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::CompressedSrgbTexture1dArray(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::IntegralTexture1dArray(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::UnsignedTexture1dArray(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::DepthTexture1dArray(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::Texture2dArray(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::CompressedTexture2dArray(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::SrgbTexture2dArray(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::CompressedSrgbTexture2dArray(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::IntegralTexture2dArray(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::UnsignedTexture2dArray(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::DepthTexture2dArray(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::Texture2dMultisampleArray(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::SrgbTexture2dMultisampleArray(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::IntegralTexture2dMultisampleArray(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::UnsignedTexture2dMultisampleArray(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::DepthTexture2dMultisampleArray(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::Cubemap(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::CompressedCubemap(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::SrgbCubemap(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::CompressedSrgbCubemap(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::IntegralCubemap(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::UnsignedCubemap(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::DepthCubemap(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::CubemapArray(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::CompressedCubemapArray(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::SrgbCubemapArray(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::CompressedSrgbCubemapArray(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::IntegralCubemapArray(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::UnsignedCubemapArray(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::DepthCubemapArray(texture, sampler) => {
-            bind_texture_uniform(ctxt, &**texture, sampler, location, program, texture_bind_points)
-        },
-        UniformValue::BufferTexture(texture) => {
-            bind_texture_uniform(ctxt, &texture, None, location, program, texture_bind_points)
-        },
-    }
-}
-
-fn bind_texture_uniform<P, T>(ctxt: &mut context::CommandContext,
-                              texture: &T, sampler: Option<SamplerBehavior>,
-                              location: gl::types::GLint, program: &P,
-                              texture_bind_points: &mut Bitsfield)
-                              -> Result<(), DrawError> where P: ProgramExt, T: TextureExt
+fn bind_texture_uniform<P, T>(
+    ctxt: &mut context::CommandContext,
+    texture: &T,
+    sampler: Option<SamplerBehavior>,
+    location: gl::types::GLint,
+    program: &P,
+    texture_bind_points: &mut Bitsfield,
+) -> Result<(), DrawError>
+where
+    P: ProgramExt,
+    T: TextureExt,
 {
     let sampler = if let Some(sampler) = sampler {
         Some(try!(::sampler_object::get_sampler(ctxt, &sampler)))
@@ -595,59 +1061,76 @@ fn bind_texture_uniform<P, T>(ctxt: &mut context::CommandContext,
     let sampler = sampler.unwrap_or(0);
 
     // finding an appropriate texture unit
-    let texture_unit =
-        ctxt.state.texture_units
-            .iter().enumerate()
-            .find(|&(unit, content)| {
-                content.texture == texture.get_texture_id() && (content.sampler == sampler ||
-                                                        !texture_bind_points.is_used(unit as u16))
-            })
-            .map(|(unit, _)| unit as u16)
-            .or_else(|| {
-                if ctxt.state.texture_units.len() <
-                    ctxt.capabilities.max_combined_texture_image_units as usize
-                {
-                    Some(ctxt.state.texture_units.len() as u16)
-                } else {
-                    None
-                }
-            })
-            .unwrap_or_else(|| {
-                texture_bind_points.get_unused().expect("Not enough texture units available")
-            });
-    assert!((texture_unit as gl::types::GLint) <
-            ctxt.capabilities.max_combined_texture_image_units);
+    let texture_unit = ctxt.state
+        .texture_units
+        .iter()
+        .enumerate()
+        .find(|&(unit, content)| {
+            content.texture == texture.get_texture_id() &&
+                (content.sampler == sampler || !texture_bind_points.is_used(unit as u16))
+        })
+        .map(|(unit, _)| unit as u16)
+        .or_else(|| if ctxt.state.texture_units.len() <
+            ctxt.capabilities.max_combined_texture_image_units as
+                usize
+        {
+            Some(ctxt.state.texture_units.len() as u16)
+        } else {
+            None
+        })
+        .unwrap_or_else(|| {
+            texture_bind_points.get_unused().expect(
+                "Not enough texture units available",
+            )
+        });
+    assert!(
+        (texture_unit as gl::types::GLint) < ctxt.capabilities.max_combined_texture_image_units
+    );
     texture_bind_points.set_used(texture_unit);
 
     // updating the program to use the right unit
-    program.set_uniform(ctxt, location,
-                        &RawUniformValue::SignedInt(texture_unit as gl::types::GLint));
+    program.set_uniform(
+        ctxt,
+        location,
+        &RawUniformValue::SignedInt(texture_unit as gl::types::GLint),
+    );
 
     // updating the state of the texture unit
     if ctxt.state.texture_units.len() <= texture_unit as usize {
-        for _ in ctxt.state.texture_units.len() .. texture_unit as usize + 1 {
+        for _ in ctxt.state.texture_units.len()..texture_unit as usize + 1 {
             ctxt.state.texture_units.push(Default::default());
         }
     }
 
     // TODO: do better
     if ctxt.state.texture_units[texture_unit as usize].texture != texture.get_texture_id() ||
-       ctxt.state.texture_units[texture_unit as usize].sampler != sampler
+        ctxt.state.texture_units[texture_unit as usize].sampler != sampler
     {
         // TODO: what if it's not supported?
         if ctxt.state.active_texture != texture_unit as gl::types::GLenum {
-            unsafe { ctxt.gl.ActiveTexture(texture_unit as gl::types::GLenum + gl::TEXTURE0) };
+            unsafe {
+                ctxt.gl.ActiveTexture(
+                    texture_unit as gl::types::GLenum + gl::TEXTURE0,
+                )
+            };
             ctxt.state.active_texture = texture_unit as gl::types::GLenum;
         }
 
         texture.bind_to_current(ctxt);
 
         if ctxt.state.texture_units[texture_unit as usize].sampler != sampler {
-            assert!(ctxt.version >= &Version(Api::Gl, 3, 3) ||
+            assert!(
+                ctxt.version >= &Version(Api::Gl, 3, 3) ||
                     ctxt.version >= &Version(Api::GlEs, 3, 0) ||
-                    ctxt.extensions.gl_arb_sampler_objects);
+                    ctxt.extensions.gl_arb_sampler_objects
+            );
 
-            unsafe { ctxt.gl.BindSampler(texture_unit as gl::types::GLenum, sampler); }
+            unsafe {
+                ctxt.gl.BindSampler(
+                    texture_unit as gl::types::GLenum,
+                    sampler,
+                );
+            }
             ctxt.state.texture_units[texture_unit as usize].sampler = sampler;
         }
     }

--- a/src/uniforms/buffer.rs
+++ b/src/uniforms/buffer.rs
@@ -1,6 +1,6 @@
 use buffer::{Content, Buffer, BufferAny, BufferType, BufferMode, BufferCreationError};
 use buffer::{BufferSlice, BufferMutSlice};
-use uniforms::{AsUniformValue, UniformBlock, UniformValue, LayoutMismatchError};
+use uniforms::{UniformBlock, UniformValue, LayoutMismatchError};
 use program;
 
 use gl;
@@ -24,7 +24,10 @@ use backend::Facade;
 ///         MyBlock: &buffer,
 ///     }
 #[derive(Debug)]
-pub struct UniformBuffer<T: ?Sized> where T: Content {
+pub struct UniformBuffer<T: ?Sized>
+where
+    T: Content,
+{
     buffer: Buffer<T>,
 }
 
@@ -43,11 +46,15 @@ impl<T: ?Sized + Content> GlObject for UniformBuffer<T> {
     }
 }
 
-impl<T> UniformBuffer<T> where T: Copy {
+impl<T> UniformBuffer<T>
+where
+    T: Copy,
+{
     /// Uploads data in the uniforms buffer.
     #[inline]
     pub fn new<F: ?Sized>(facade: &F, data: T) -> Result<UniformBuffer<T>, BufferCreationError>
-                  where F: Facade
+    where
+        F: Facade,
     {
         UniformBuffer::new_impl(facade, data, BufferMode::Default)
     }
@@ -55,49 +62,64 @@ impl<T> UniformBuffer<T> where T: Copy {
     /// Uploads data in the uniforms buffer.
     #[inline]
     pub fn dynamic<F: ?Sized>(facade: &F, data: T) -> Result<UniformBuffer<T>, BufferCreationError>
-                      where F: Facade
+    where
+        F: Facade,
     {
         UniformBuffer::new_impl(facade, data, BufferMode::Dynamic)
     }
 
     /// Uploads data in the uniforms buffer.
     #[inline]
-    pub fn persistent<F: ?Sized>(facade: &F, data: T) -> Result<UniformBuffer<T>, BufferCreationError>
-                  where F: Facade
+    pub fn persistent<F: ?Sized>(
+        facade: &F,
+        data: T,
+    ) -> Result<UniformBuffer<T>, BufferCreationError>
+    where
+        F: Facade,
     {
         UniformBuffer::new_impl(facade, data, BufferMode::Persistent)
     }
 
     /// Uploads data in the uniforms buffer.
     #[inline]
-    pub fn immutable<F: ?Sized>(facade: &F, data: T) -> Result<UniformBuffer<T>, BufferCreationError>
-                        where F: Facade
+    pub fn immutable<F: ?Sized>(
+        facade: &F,
+        data: T,
+    ) -> Result<UniformBuffer<T>, BufferCreationError>
+    where
+        F: Facade,
     {
         UniformBuffer::new_impl(facade, data, BufferMode::Immutable)
     }
 
     #[inline]
-    fn new_impl<F: ?Sized>(facade: &F, data: T, mode: BufferMode)
-                   -> Result<UniformBuffer<T>, BufferCreationError>
-                   where F: Facade
+    fn new_impl<F: ?Sized>(
+        facade: &F,
+        data: T,
+        mode: BufferMode,
+    ) -> Result<UniformBuffer<T>, BufferCreationError>
+    where
+        F: Facade,
     {
         let buffer = try!(Buffer::new(facade, &data, BufferType::UniformBuffer, mode));
 
-        Ok(UniformBuffer {
-            buffer: buffer,
-        })
+        Ok(UniformBuffer { buffer: buffer })
     }
 
     /// Creates an empty buffer.
     #[inline]
-    pub fn empty<F: ?Sized>(facade: &F) -> Result<UniformBuffer<T>, BufferCreationError> where F: Facade {
+    pub fn empty<F: ?Sized>(facade: &F) -> Result<UniformBuffer<T>, BufferCreationError>
+    where
+        F: Facade,
+    {
         UniformBuffer::empty_impl(facade, BufferMode::Default)
     }
 
     /// Creates an empty buffer.
     #[inline]
     pub fn empty_dynamic<F: ?Sized>(facade: &F) -> Result<UniformBuffer<T>, BufferCreationError>
-                            where F: Facade
+    where
+        F: Facade,
     {
         UniformBuffer::empty_impl(facade, BufferMode::Dynamic)
     }
@@ -105,7 +127,8 @@ impl<T> UniformBuffer<T> where T: Copy {
     /// Creates an empty buffer.
     #[inline]
     pub fn empty_persistent<F: ?Sized>(facade: &F) -> Result<UniformBuffer<T>, BufferCreationError>
-                               where F: Facade
+    where
+        F: Facade,
     {
         UniformBuffer::empty_impl(facade, BufferMode::Persistent)
     }
@@ -113,24 +136,30 @@ impl<T> UniformBuffer<T> where T: Copy {
     /// Creates an empty buffer.
     #[inline]
     pub fn empty_immutable<F: ?Sized>(facade: &F) -> Result<UniformBuffer<T>, BufferCreationError>
-                              where F: Facade
+    where
+        F: Facade,
     {
         UniformBuffer::empty_impl(facade, BufferMode::Immutable)
     }
 
     #[inline]
-    fn empty_impl<F: ?Sized>(facade: &F, mode: BufferMode) -> Result<UniformBuffer<T>, BufferCreationError>
-                     where F: Facade
+    fn empty_impl<F: ?Sized>(
+        facade: &F,
+        mode: BufferMode,
+    ) -> Result<UniformBuffer<T>, BufferCreationError>
+    where
+        F: Facade,
     {
         let buffer = try!(Buffer::empty(facade, BufferType::UniformBuffer, mode));
 
-        Ok(UniformBuffer {
-            buffer: buffer,
-        })
+        Ok(UniformBuffer { buffer: buffer })
     }
 }
 
-impl<T: ?Sized> UniformBuffer<T> where T: Content {
+impl<T: ?Sized> UniformBuffer<T>
+where
+    T: Content,
+{
     /// Creates an empty buffer.
     ///
     /// # Panic
@@ -138,9 +167,12 @@ impl<T: ?Sized> UniformBuffer<T> where T: Content {
     /// Panics if the size passed as parameter is not suitable for the type of data.
     ///
     #[inline]
-    pub fn empty_unsized<F: ?Sized>(facade: &F, size: usize)
-                            -> Result<UniformBuffer<T>, BufferCreationError>
-                            where F: Facade
+    pub fn empty_unsized<F: ?Sized>(
+        facade: &F,
+        size: usize,
+    ) -> Result<UniformBuffer<T>, BufferCreationError>
+    where
+        F: Facade,
     {
         UniformBuffer::empty_unsized_impl(facade, size, BufferMode::Default)
     }
@@ -152,9 +184,12 @@ impl<T: ?Sized> UniformBuffer<T> where T: Content {
     /// Panics if the size passed as parameter is not suitable for the type of data.
     ///
     #[inline]
-    pub fn empty_unsized_dynamic<F: ?Sized>(facade: &F, size: usize)
-                                    -> Result<UniformBuffer<T>, BufferCreationError>
-                                    where F: Facade
+    pub fn empty_unsized_dynamic<F: ?Sized>(
+        facade: &F,
+        size: usize,
+    ) -> Result<UniformBuffer<T>, BufferCreationError>
+    where
+        F: Facade,
     {
         UniformBuffer::empty_unsized_impl(facade, size, BufferMode::Dynamic)
     }
@@ -166,9 +201,12 @@ impl<T: ?Sized> UniformBuffer<T> where T: Content {
     /// Panics if the size passed as parameter is not suitable for the type of data.
     ///
     #[inline]
-    pub fn empty_unsized_persistent<F: ?Sized>(facade: &F, size: usize)
-                                       -> Result<UniformBuffer<T>, BufferCreationError>
-                                       where F: Facade
+    pub fn empty_unsized_persistent<F: ?Sized>(
+        facade: &F,
+        size: usize,
+    ) -> Result<UniformBuffer<T>, BufferCreationError>
+    where
+        F: Facade,
     {
         UniformBuffer::empty_unsized_impl(facade, size, BufferMode::Persistent)
     }
@@ -180,27 +218,40 @@ impl<T: ?Sized> UniformBuffer<T> where T: Content {
     /// Panics if the size passed as parameter is not suitable for the type of data.
     ///
     #[inline]
-    pub fn empty_unsized_immutable<F: ?Sized>(facade: &F, size: usize)
-                                      -> Result<UniformBuffer<T>, BufferCreationError>
-                                      where F: Facade
+    pub fn empty_unsized_immutable<F: ?Sized>(
+        facade: &F,
+        size: usize,
+    ) -> Result<UniformBuffer<T>, BufferCreationError>
+    where
+        F: Facade,
     {
         UniformBuffer::empty_unsized_impl(facade, size, BufferMode::Immutable)
     }
 
     #[inline]
-    fn empty_unsized_impl<F: ?Sized>(facade: &F, size: usize, mode: BufferMode)
-                             -> Result<UniformBuffer<T>, BufferCreationError>
-                             where F: Facade
+    fn empty_unsized_impl<F: ?Sized>(
+        facade: &F,
+        size: usize,
+        mode: BufferMode,
+    ) -> Result<UniformBuffer<T>, BufferCreationError>
+    where
+        F: Facade,
     {
-        let buffer = try!(Buffer::empty_unsized(facade, BufferType::UniformBuffer, size, mode));
+        let buffer = try!(Buffer::empty_unsized(
+            facade,
+            BufferType::UniformBuffer,
+            size,
+            mode,
+        ));
 
-        Ok(UniformBuffer {
-            buffer: buffer,
-        })
+        Ok(UniformBuffer { buffer: buffer })
     }
 }
 
-impl<T: ?Sized> Deref for UniformBuffer<T> where T: Content {
+impl<T: ?Sized> Deref for UniformBuffer<T>
+where
+    T: Content,
+{
     type Target = Buffer<T>;
 
     #[inline]
@@ -209,38 +260,52 @@ impl<T: ?Sized> Deref for UniformBuffer<T> where T: Content {
     }
 }
 
-impl<T: ?Sized> DerefMut for UniformBuffer<T> where T: Content {
+impl<T: ?Sized> DerefMut for UniformBuffer<T>
+where
+    T: Content,
+{
     #[inline]
     fn deref_mut(&mut self) -> &mut Buffer<T> {
         &mut self.buffer
     }
 }
 
-impl<'a, T: ?Sized> From<&'a UniformBuffer<T>> for BufferSlice<'a, T> where T: Content {
+impl<'a, T: ?Sized> From<&'a UniformBuffer<T>> for BufferSlice<'a, T>
+where
+    T: Content,
+{
     #[inline]
     fn from(b: &'a UniformBuffer<T>) -> BufferSlice<'a, T> {
         b.buffer.as_slice()
     }
 }
 
-impl<'a, T: ?Sized> From<&'a mut UniformBuffer<T>> for BufferMutSlice<'a, T> where T: Content {
+impl<'a, T: ?Sized> From<&'a mut UniformBuffer<T>> for BufferMutSlice<'a, T>
+where
+    T: Content,
+{
     #[inline]
     fn from(b: &'a mut UniformBuffer<T>) -> BufferMutSlice<'a, T> {
         b.buffer.as_mut_slice()
     }
 }
 
-impl<'a, T: ?Sized> AsUniformValue for &'a UniformBuffer<T> where T: UniformBlock + Content {
+impl<'a, T: ?Sized> From<&'a UniformBuffer<T>> for UniformValue<'a>
+where
+    T: UniformBlock + Content,
+{
     #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
+    fn from(v: &'a UniformBuffer<T>) -> UniformValue<'a> {
+
         #[inline]
-        fn f<T: ?Sized>(block: &program::UniformBlock)
-                        -> Result<(), LayoutMismatchError> where T: UniformBlock + Content
+        fn f<T: ?Sized>(block: &program::UniformBlock) -> Result<(), LayoutMismatchError>
+        where
+            T: UniformBlock + Content,
         {
             // TODO: more checks?
             T::matches(&block.layout, 0)
         }
 
-        UniformValue::Block(self.buffer.as_slice_any(), f::<T>)
+        UniformValue::Block(v.buffer.as_slice_any(), f::<T>)
     }
 }

--- a/src/uniforms/mod.rs
+++ b/src/uniforms/mod.rs
@@ -165,7 +165,8 @@ mod value;
 /// Objects of this type can be passed to the `draw()` function.
 pub trait Uniforms {
     /// Calls the parameter once with the name and value of each uniform.
-    fn visit_values<'a, F: FnMut(&str, UniformValue<'a>)>(&'a self, F);
+    fn visit_values<F>(&self, F)
+        where for<'a> F: FnMut(&str, &UniformValue<'a>) ;
 }
 
 /// Error about a block layout mismatch.

--- a/src/uniforms/mod.rs
+++ b/src/uniforms/mod.rs
@@ -290,15 +290,21 @@ impl fmt::Display for LayoutMismatchError {
 /// Value that can be used as the value of a uniform.
 ///
 /// This includes buffers and textures for example.
-pub trait AsUniformValue {
+pub trait AsUniformValue<'a> {
     /// Builds a `UniformValue`.
-    fn as_uniform_value(&self) -> UniformValue;
+    fn as_uniform_value(self) -> UniformValue<'a>;
+}
+
+impl<'a, T: 'a> From<T> for UniformValue<'a> where T: AsUniformValue<'a> {
+    fn from(v: T) -> UniformValue<'a> {
+        v.as_uniform_value()
+    }
 }
 
 // TODO: no way to bind a slice
-impl<'a, T: ?Sized> AsUniformValue for &'a Buffer<T> where T: UniformBlock + BufferContent {
+impl<'a, T: ?Sized> AsUniformValue<'a> for &'a Buffer<T> where T: UniformBlock + BufferContent {
     #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
+    fn as_uniform_value(self) -> UniformValue<'a> {
         #[inline]
         fn f<T: ?Sized>(block: &program::UniformBlock)
                         -> Result<(), LayoutMismatchError> where T: UniformBlock + BufferContent

--- a/src/uniforms/sampler.rs
+++ b/src/uniforms/sampler.rs
@@ -92,45 +92,37 @@ impl ToGlEnum for MinifySamplerFilter {
 }
 
 /// A sampler.
-#[derive(Debug, Hash, PartialEq, Eq)]
-pub struct Sampler<'t, T: 't>(pub &'t T, pub SamplerBehavior);
+#[derive(Debug, Hash, PartialEq, Eq, Copy, Clone)]
+pub struct Sampler<T>(pub T, pub SamplerBehavior);
 
-impl<'t, T: 't> Sampler<'t, T> {
+impl<T> Sampler<T> {
     /// Builds a new `Sampler` with default parameters.
-    pub fn new(texture: &'t T) -> Sampler<'t, T> {
+    pub fn new(texture: T) -> Sampler<T> {
         Sampler(texture, Default::default())
     }
 
     /// Changes the wrap functions of all three coordinates.
-    pub fn wrap_function(mut self, function: SamplerWrapFunction) -> Sampler<'t, T> {
+    pub fn wrap_function(mut self, function: SamplerWrapFunction) -> Sampler<T> {
         self.1.wrap_function = (function, function, function);
         self
     }
 
     /// Changes the minifying filter of the sampler.
-    pub fn minify_filter(mut self, filter: MinifySamplerFilter) -> Sampler<'t, T> {
+    pub fn minify_filter(mut self, filter: MinifySamplerFilter) -> Sampler<T> {
         self.1.minify_filter = filter;
         self
     }
 
     /// Changes the magnifying filter of the sampler.
-    pub fn magnify_filter(mut self, filter: MagnifySamplerFilter) -> Sampler<'t, T> {
+    pub fn magnify_filter(mut self, filter: MagnifySamplerFilter) -> Sampler<T> {
         self.1.magnify_filter = filter;
         self
     }
 
     /// Changes the magnifying filter of the sampler.
-    pub fn anisotropy(mut self, level: u16) -> Sampler<'t, T> {
+    pub fn anisotropy(mut self, level: u16) -> Sampler<T> {
         self.1.max_anisotropy = level;
         self
-    }
-}
-
-impl<'t, T: 't> Copy for Sampler<'t, T> {}
-
-impl<'t, T: 't> Clone for Sampler<'t, T> {
-    fn clone(&self) -> Self {
-        *self
     }
 }
 

--- a/src/uniforms/uniforms.rs
+++ b/src/uniforms/uniforms.rs
@@ -1,55 +1,82 @@
-use uniforms::{Uniforms, UniformValue, AsUniformValue};
+use std::marker::PhantomData;
+
+use uniforms::{Uniforms, UniformValue};
 
 /// Object that can be used when you don't have any uniforms.
 #[derive(Debug, Copy, Clone)]
 pub struct EmptyUniforms;
 
 impl Uniforms for EmptyUniforms {
-    #[inline]
-    fn visit_values<'a, F: FnMut(&str, UniformValue<'a>)>(&'a self, _: F) {
+    fn visit_values<F>(&self, _: F)
+    where
+        for<'a> F: FnMut(&str, &UniformValue<'a>),
+    {
     }
 }
 
 /// Stores uniforms.
-pub struct UniformsStorage<'n, T, R> where T: AsUniformValue, R: Uniforms {
+pub struct UniformsStorage<'a, 'n, T: 'a, R>
+where
+    T: Into<UniformValue<'a>> + Clone,
+    R: Uniforms,
+{
     name: &'n str,
     value: T,
     rest: R,
+    marker: PhantomData<&'a T>,
 }
 
-impl<'n, T> UniformsStorage<'n, T, EmptyUniforms> where T: AsUniformValue {
+impl<'a, 'n, T: 'a> UniformsStorage<'a, 'n, T, EmptyUniforms>
+where
+    T: Into<UniformValue<'a>> + Clone,
+{
     /// Builds a new storage with a value.
     #[inline]
-    pub fn new(name: &'n str, value: T)
-               -> UniformsStorage<'n, T, EmptyUniforms>
-    {
+    pub fn new(name: &'n str, value: T) -> UniformsStorage<'a, 'n, T, EmptyUniforms> {
         UniformsStorage {
             name: name,
             value: value,
             rest: EmptyUniforms,
+            marker: PhantomData,
         }
     }
 }
 
-impl<'n, T, R> UniformsStorage<'n, T, R> where T: AsUniformValue, R: Uniforms {
+impl<'a, 'n, T: 'a, R> UniformsStorage<'a, 'n, T, R>
+where
+    T: Into<UniformValue<'a>> + Clone,
+    R: Uniforms,
+{
     /// Adds a value to the storage.
     #[inline]
-    pub fn add<U>(self, name: &'n str, value: U)
-                  -> UniformsStorage<'n, U, UniformsStorage<'n, T, R>>
-                  where U: AsUniformValue
+    pub fn add<U>(
+        self,
+        name: &'n str,
+        value: U,
+    ) -> UniformsStorage<'a, 'n, U, UniformsStorage<'a, 'n, T, R>>
+    where
+        U: Into<UniformValue<'a>> + Clone,
     {
         UniformsStorage {
             name: name,
             value: value,
             rest: self,
+            marker: PhantomData,
         }
     }
 }
 
-impl<'n, T, R> Uniforms for UniformsStorage<'n, T, R> where T: AsUniformValue, R: Uniforms {
+impl<'a, 'n, T: 'a, R> Uniforms for UniformsStorage<'a, 'n, T, R>
+where
+    T: Into<UniformValue<'a>> + Clone,
+    R: Uniforms,
+{
     #[inline]
-    fn visit_values<'a, F: FnMut(&str, UniformValue<'a>)>(&'a self, mut output: F) {
-        output(self.name, self.value.as_uniform_value());
+    fn visit_values<F>(&self, mut output: F)
+    where
+        for<'b> F: FnMut(&str, &UniformValue<'b>),
+    {
+        output(self.name, &self.value.to_owned().into());
         self.rest.visit_values(output);
     }
 }

--- a/src/uniforms/value.rs
+++ b/src/uniforms/value.rs
@@ -1,9 +1,11 @@
+use std::fmt::{self, Debug};
+use std::cmp;
+
 use program;
 use program::BlockLayout;
 use program::ShaderStage;
 use texture;
 
-use uniforms::AsUniformValue;
 use uniforms::LayoutMismatchError;
 use uniforms::UniformBlock;
 use uniforms::SamplerBehavior;
@@ -239,13 +241,158 @@ pub enum UniformValue<'a> {
     IntegralCubemapArray(&'a texture::IntegralCubemapArray, Option<SamplerBehavior>),
     UnsignedCubemapArray(&'a texture::UnsignedCubemapArray, Option<SamplerBehavior>),
     DepthCubemapArray(&'a texture::DepthCubemapArray, Option<SamplerBehavior>),
-    BufferTexture(texture::buffer_texture::BufferTextureRef<'a>),
+    BufferTexture(texture::buffer_texture::BufferTextureRef),
 }
 
 impl<'a> Clone for UniformValue<'a> {
     #[inline]
     fn clone(&self) -> UniformValue<'a> {
         *self
+    }
+}
+
+impl<'a> Debug for UniformValue<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            UniformValue::Block(ref i, _) => write!(f, "UniformValue::Block({:?}, fn(&program::UniformBlock) -> Result<(), LayoutMismatchError>)", i),
+            UniformValue::Subroutine(ref i, ref s) => write!(f, "UniformValue::Subroutine({:?}, {:?})", i, s),
+            UniformValue::Float(ref i) => write!(f, "UniformValue::Float({:?})", i),
+            UniformValue::Double(ref i) => write!(f, "UniformValue::Double({:?})", i),
+            UniformValue::Int64(ref i) => write!(f, "UniformValue::Int64({:?})", i),
+            UniformValue::UnsignedInt64(ref i) => write!(f, "UniformValue::UnsignedInt64({:?})", i),
+            UniformValue::SignedInt(ref i) => write!(f, "UniformValue::SignedInt({:?})", i),
+            UniformValue::UnsignedInt(ref i) => write!(f, "UniformValue::UnsignedInt({:?})", i),
+            UniformValue::IntVec2(ref i) => write!(f, "UniformValue::IntVec2({:?})", i),
+            UniformValue::IntVec3(ref i) => write!(f, "UniformValue::IntVec3({:?})", i),
+            UniformValue::IntVec4(ref i) => write!(f, "UniformValue::IntVec4({:?})", i),
+            UniformValue::UnsignedIntVec2(ref i) => write!(f, "UniformValue::UnsignedIntVec2({:?})", i),
+            UniformValue::UnsignedIntVec3(ref i) => write!(f, "UniformValue::UnsignedIntVec3({:?})", i),
+            UniformValue::UnsignedIntVec4(ref i) => write!(f, "UniformValue::UnsignedIntVec4({:?})", i),
+            UniformValue::Bool(ref i) => write!(f, "UniformValue::Bool({:?})", i),
+            UniformValue::BoolVec2(ref i) => write!(f, "UniformValue::BoolVec2({:?})", i),
+            UniformValue::BoolVec3(ref i) => write!(f, "UniformValue::BoolVec3({:?})", i),
+            UniformValue::BoolVec4(ref i) => write!(f, "UniformValue::BoolVec4({:?})", i),
+            UniformValue::Vec2(ref i) => write!(f, "UniformValue::Vec2({:?})", i),
+            UniformValue::Vec3(ref i) => write!(f, "UniformValue::Vec3({:?})", i),
+            UniformValue::Vec4(ref i) => write!(f, "UniformValue::Vec4({:?})", i),
+            UniformValue::DoubleVec2(ref i) => write!(f, "UniformValue::DoubleVec2({:?})", i),
+            UniformValue::DoubleVec3(ref i) => write!(f, "UniformValue::DoubleVec3({:?})", i),
+            UniformValue::DoubleVec4(ref i) => write!(f, "UniformValue::DoubleVec4({:?})", i),
+            UniformValue::Int64Vec2(ref i) => write!(f, "UniformValue::Int64Vec2({:?})", i),
+            UniformValue::Int64Vec3(ref i) => write!(f, "UniformValue::Int64Vec3({:?})", i),
+            UniformValue::Int64Vec4(ref i) => write!(f, "UniformValue::Int64Vec4({:?})", i),
+            UniformValue::UnsignedInt64Vec2(ref i) => write!(f, "UniformValue::UnsignedInt64Vec2({:?})", i),
+            UniformValue::UnsignedInt64Vec3(ref i) => write!(f, "UniformValue::UnsignedInt64Vec3({:?})", i),
+            UniformValue::UnsignedInt64Vec4(ref i) => write!(f, "UniformValue::UnsignedInt64Vec4({:?})", i),
+            UniformValue::Mat2(ref i) => write!(f, "UniformValue::Mat2({:?})", i),
+            UniformValue::Mat3(ref i) => write!(f, "UniformValue::Mat3({:?})", i),
+            UniformValue::Mat4(ref i) => write!(f, "UniformValue::Mat4({:?})", i),
+            UniformValue::DoubleMat2(ref i) => write!(f, "UniformValue::DoubleMat2({:?})", i),
+            UniformValue::DoubleMat3(ref i) => write!(f, "UniformValue::DoubleMat3({:?})", i),
+            UniformValue::DoubleMat4(ref i) => write!(f, "UniformValue::DoubleMat4({:?})", i),
+            UniformValue::Texture1d(ref i, ref o) => write!(f, "UniformValue::Texture1d({:?}, {:?})", i, o),
+            UniformValue::CompressedTexture1d(ref i, ref o) => write!(f, "UniformValue::CompressedTexture1d({:?}, {:?})", i, o),
+            UniformValue::SrgbTexture1d(ref i, ref o) => write!(f, "UniformValue::SrgbTexture1d({:?}, {:?})", i, o),
+            UniformValue::CompressedSrgbTexture1d(ref i, ref o) => write!(f, "UniformValue::CompressedSrgbTexture1d({:?}, {:?})", i, o),
+            UniformValue::IntegralTexture1d(ref i, ref o) => write!(f, "UniformValue::IntegralUnsignedTexture1d({:?}, {:?})", i, o),
+            UniformValue::UnsignedTexture1d(ref i, ref o) => write!(f, "UniformValue::IntegralUnsignedTexture1d({:?}, {:?})", i, o),
+            UniformValue::DepthTexture1d(ref i, ref o) => write!(f, "UniformValue::DepthTexture1d({:?}, {:?})", i, o),
+            UniformValue::Texture2d(ref i, ref o) => write!(f, "UniformValue::Texture2d({:?}, {:?})", i, o),
+            UniformValue::CompressedTexture2d(ref i, ref o) => write!(f, "UniformValue::CompressedTexture2d({:?}, {:?})", i, o),
+            UniformValue::SrgbTexture2d(ref i, ref o) => write!(f, "UniformValue::SrgbTexture2d({:?}, {:?})", i, o),
+            UniformValue::CompressedSrgbTexture2d(ref i, ref o) => write!(f, "UniformValue::CompressedSrgbTexture2d({:?}, {:?})", i, o),
+            UniformValue::IntegralTexture2d(ref i, ref o) => write!(f, "UniformValue::IntegralUnsignedTexture2d({:?}, {:?})", i, o),
+            UniformValue::UnsignedTexture2d(ref i, ref o) => write!(f, "UniformValue::IntegralUnsignedTexture2d({:?}, {:?})", i, o),
+            UniformValue::DepthTexture2d(ref i, ref o) => write!(f, "UniformValue::DepthTexture2d({:?}, {:?})", i, o),
+            UniformValue::Texture3d(ref i, ref o) => write!(f, "UniformValue::Texture3d({:?}, {:?})", i, o),
+            UniformValue::CompressedTexture3d(ref i, ref o) => write!(f, "UniformValue::CompressedTexture3d({:?}, {:?})", i, o),
+            UniformValue::SrgbTexture3d(ref i, ref o) => write!(f, "UniformValue::SrgbTexture3d({:?}, {:?})", i, o),
+            UniformValue::CompressedSrgbTexture3d(ref i, ref o) => write!(f, "UniformValue::CompressedSrgbTexture3d({:?}, {:?})", i, o),
+            UniformValue::IntegralTexture3d(ref i, ref o) => write!(f, "UniformValue::IntegralUnsignedTexture3d({:?}, {:?})", i, o),
+            UniformValue::UnsignedTexture3d(ref i, ref o) => write!(f, "UniformValue::IntegralUnsignedTexture3d({:?}, {:?})", i, o),
+            UniformValue::DepthTexture3d(ref i, ref o) => write!(f, "UniformValue::DepthTexture3d({:?}, {:?})", i, o),
+            UniformValue::CompressedTexture1dArray(ref i, ref o) => write!(f, "UniformValue::CompressedTexture1dArray({:?}, {:?})", i, o),
+            UniformValue::SrgbTexture1dArray(ref i, ref o) => write!(f, "UniformValue::SrgbTexture1dArray({:?}, {:?})", i, o),
+            UniformValue::CompressedSrgbTexture1dArray(ref i, ref o) => write!(f, "UniformValue::CompressedSrgbTexture1dArray({:?}, {:?})", i, o),
+            UniformValue::IntegralTexture1dArray(ref i, ref o) => write!(f, "UniformValue::IntegralUnsignedTexture1dArray({:?}, {:?})", i, o),
+            UniformValue::UnsignedTexture1dArray(ref i, ref o) => write!(f, "UniformValue::IntegralUnsignedTexture1dArray({:?}, {:?})", i, o),
+            UniformValue::DepthTexture1dArray(ref i, ref o) => write!(f, "UniformValue::DepthTexture1dArray({:?}, {:?})", i, o),
+            UniformValue::Texture2dArray(ref i, ref o) => write!(f, "UniformValue::Texture2dArray({:?}, {:?})", i, o),
+            UniformValue::CompressedTexture2dArray(ref i, ref o) => write!(f, "UniformValue::CompressedTexture2dArray({:?}, {:?})", i, o),
+            UniformValue::SrgbTexture2dArray(ref i, ref o) => write!(f, "UniformValue::SrgbTexture2dArray({:?}, {:?})", i, o),
+            UniformValue::CompressedSrgbTexture2dArray(ref i, ref o) => write!(f, "UniformValue::CompressedSrgbTexture2dArray({:?}, {:?})", i, o),
+            UniformValue::IntegralTexture2dArray(ref i, ref o) => write!(f, "UniformValue::IntegralUnsignedTexture2dArray({:?}, {:?})", i, o),
+            UniformValue::UnsignedTexture2dArray(ref i, ref o) => write!(f, "UniformValue::IntegralUnsignedTexture2dArray({:?}, {:?})", i, o),
+            UniformValue::DepthTexture2dArray(ref i, ref o) => write!(f, "UniformValue::DepthTexture2dArray({:?}, {:?})", i, o),
+            UniformValue::Texture2dMultisampleArray(ref i, ref o) => write!(f, "UniformValue::Texture2dMultisampleArray({:?}, {:?})", i, o),
+            UniformValue::SrgbTexture2dMultisampleArray(ref i, ref o) => write!(f, "UniformValue::SrgbTexture2dMultisampleArray({:?}, {:?})", i, o),
+            UniformValue::IntegralTexture2dMultisampleArray(ref i, ref o) => write!(f, "UniformValue::IntegralUnsignedTexture2dMultisampleArray({:?}, {:?})", i, o),
+            UniformValue::UnsignedTexture2dMultisampleArray(ref i, ref o) => write!(f, "UniformValue::IntegralUnsignedTexture2dMultisampleArray({:?}, {:?})", i, o),
+            UniformValue::DepthTexture2dMultisampleArray(ref i, ref o) => write!(f, "UniformValue::DepthTexture2dMultisampleArray({:?}, {:?})", i, o),
+            UniformValue::Texture2dMultisample(ref i, ref o) => write!(f, "UniformValue::Texture2dMultisample({:?}, {:?})", i, o),
+            UniformValue::SrgbTexture2dMultisample(ref i, ref o) => write!(f, "UniformValue::SrgbTexture2dMultisample({:?}, {:?})", i, o),
+            UniformValue::IntegralTexture2dMultisample(ref i, ref o) => write!(f, "UniformValue::IntegralUnsignedTexture2dMultisample({:?}, {:?})", i, o),
+            UniformValue::UnsignedTexture2dMultisample(ref i, ref o) => write!(f, "UniformValue::IntegralUnsignedTexture2dMultisample({:?}, {:?})", i, o),
+            UniformValue::DepthTexture2dMultisample(ref i, ref o) => write!(f, "UniformValue::DepthTexture2dMultisample({:?}, {:?})", i, o),
+            UniformValue::Texture1dArray(ref i, ref o) => write!(f, "UniformValue::Texture1dArray({:?}, {:?})", i, o),
+            UniformValue::Cubemap(ref i, ref o) => write!(f, "UniformValue::Cubemap({:?}, {:?})", i, o),
+            UniformValue::CompressedCubemap(ref i, ref o) => write!(f, "UniformValue::CompressedCubemap({:?}, {:?})", i, o),
+            UniformValue::SrgbCubemap(ref i, ref o) => write!(f, "UniformValue::SrgbCubemap({:?}, {:?})", i, o),
+            UniformValue::CompressedSrgbCubemap(ref i, ref o) => write!(f, "UniformValue::CompressedSrgbCubemap({:?}, {:?})", i, o),
+            UniformValue::IntegralCubemap(ref i, ref o) => write!(f, "UniformValue::IntegralUnsignedCubemap({:?}, {:?})", i, o),
+            UniformValue::UnsignedCubemap(ref i, ref o) => write!(f, "UniformValue::IntegralUnsignedCubemap({:?}, {:?})", i, o),
+            UniformValue::DepthCubemap(ref i, ref o) => write!(f, "UniformValue::DepthCubemap({:?}, {:?})", i, o),
+            UniformValue::CubemapArray(ref i, ref o) => write!(f, "UniformValue::CubemapArray({:?}, {:?})", i, o),
+            UniformValue::CompressedCubemapArray(ref i, ref o) => write!(f, "UniformValue::CompressedCubemapArray({:?}, {:?})", i, o),
+            UniformValue::SrgbCubemapArray(ref i, ref o) => write!(f, "UniformValue::SrgbCubemapArray({:?}, {:?})", i, o),
+            UniformValue::CompressedSrgbCubemapArray(ref i, ref o) => write!(f, "UniformValue::CompressedSrgbCubemapArray({:?}, {:?})", i, o),
+            UniformValue::IntegralCubemapArray(ref i, ref o) => write!(f, "UniformValue::IntegralUnsignedCubemapArray({:?}, {:?})", i, o),
+            UniformValue::UnsignedCubemapArray(ref i, ref o) => write!(f, "UniformValue::IntegralUnsignedCubemapArray({:?}, {:?})", i, o),
+            UniformValue::DepthCubemapArray(ref i, ref o) => write!(f, "UniformValue::DepthCubemapArray({:?}, {:?})", i, o),
+            UniformValue::BufferTexture(ref i) => write!(f, "UniformValue::BufferTexture({:?})", i),
+        }
+    }
+}
+
+impl<'a, 'b> cmp::PartialEq<UniformValue<'b>> for UniformValue<'a> {
+    fn eq(&self, other: &UniformValue<'b>) -> bool {
+        match (self, other) {
+            (&UniformValue::Float(i), &UniformValue::Float(j)) => i == j,
+            (&UniformValue::Double(i), &UniformValue::Double(j)) => i == j,
+            (&UniformValue::Int64(i), &UniformValue::Int64(j)) => i == j,
+            (&UniformValue::UnsignedInt64(i), &UniformValue::UnsignedInt64(j)) => i == j,
+            (&UniformValue::SignedInt(i), &UniformValue::SignedInt(j)) => i == j,
+            (&UniformValue::UnsignedInt(i), &UniformValue::UnsignedInt(j)) => i == j,
+            (&UniformValue::IntVec2(i), &UniformValue::IntVec2(j)) => i == j,
+            (&UniformValue::IntVec3(i), &UniformValue::IntVec3(j)) => i == j,
+            (&UniformValue::IntVec4(i), &UniformValue::IntVec4(j)) => i == j,
+            (&UniformValue::UnsignedIntVec2(i), &UniformValue::UnsignedIntVec2(j)) => i == j,
+            (&UniformValue::UnsignedIntVec3(i), &UniformValue::UnsignedIntVec3(j)) => i == j,
+            (&UniformValue::UnsignedIntVec4(i), &UniformValue::UnsignedIntVec4(j)) => i == j,
+            (&UniformValue::Bool(i), &UniformValue::Bool(j)) => i == j,
+            (&UniformValue::BoolVec2(i), &UniformValue::BoolVec2(j)) => i == j,
+            (&UniformValue::BoolVec3(i), &UniformValue::BoolVec3(j)) => i == j,
+            (&UniformValue::BoolVec4(i), &UniformValue::BoolVec4(j)) => i == j,
+            (&UniformValue::Vec2(i), &UniformValue::Vec2(j)) => i == j,
+            (&UniformValue::Vec3(i), &UniformValue::Vec3(j)) => i == j,
+            (&UniformValue::Vec4(i), &UniformValue::Vec4(j)) => i == j,
+            (&UniformValue::DoubleVec2(i), &UniformValue::DoubleVec2(j)) => i == j,
+            (&UniformValue::DoubleVec3(i), &UniformValue::DoubleVec3(j)) => i == j,
+            (&UniformValue::DoubleVec4(i), &UniformValue::DoubleVec4(j)) => i == j,
+            (&UniformValue::Int64Vec2(i), &UniformValue::Int64Vec2(j)) => i == j,
+            (&UniformValue::Int64Vec3(i), &UniformValue::Int64Vec3(j)) => i == j,
+            (&UniformValue::Int64Vec4(i), &UniformValue::Int64Vec4(j)) => i == j,
+            (&UniformValue::UnsignedInt64Vec2(i), &UniformValue::UnsignedInt64Vec2(j)) => i == j,
+            (&UniformValue::UnsignedInt64Vec3(i), &UniformValue::UnsignedInt64Vec3(j)) => i == j,
+            (&UniformValue::UnsignedInt64Vec4(i), &UniformValue::UnsignedInt64Vec4(j)) => i == j,
+            (&UniformValue::Mat2(i), &UniformValue::Mat2(j)) => i == j,
+            (&UniformValue::Mat3(i), &UniformValue::Mat3(j)) => i == j,
+            (&UniformValue::Mat4(i), &UniformValue::Mat4(j)) => i == j,
+            (&UniformValue::DoubleMat2(i), &UniformValue::DoubleMat2(j)) => i == j,
+            (&UniformValue::DoubleMat3(i), &UniformValue::DoubleMat3(j)) => i == j,
+            (&UniformValue::DoubleMat4(i), &UniformValue::DoubleMat4(j)) => i == j,
+            _ => false,
+        }
     }
 }
 
@@ -451,535 +598,488 @@ macro_rules! impl_uniform_block_basic {
     )
 }
 
-impl AsUniformValue for i8 {
+impl<'a> From<i8> for UniformValue<'a> {
     #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::SignedInt(*self as i32)
+    fn from(v: i8) -> UniformValue<'a> {
+        UniformValue::SignedInt(v as i32)
     }
 }
 
-impl AsUniformValue for u8 {
+impl<'a> From<u8> for UniformValue<'a> {
     #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::UnsignedInt(*self as u32)
+    fn from(v: u8) -> UniformValue<'a> {
+        UniformValue::UnsignedInt(v as u32)
     }
 }
 
-impl AsUniformValue for i16 {
+impl<'a> From<i16> for UniformValue<'a> {
     #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::SignedInt(*self as i32)
+    fn from(v: i16) -> UniformValue<'a> {
+        UniformValue::SignedInt(v as i32)
     }
 }
 
-impl AsUniformValue for u16 {
+impl<'a> From<u16> for UniformValue<'a> {
     #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::UnsignedInt(*self as u32)
+    fn from(v: u16) -> UniformValue<'a> {
+        UniformValue::UnsignedInt(v as u32)
     }
 }
 
-impl AsUniformValue for i32 {
+impl<'a> From<i32> for UniformValue<'a> {
     #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::SignedInt(*self as i32)
+    fn from(v: i32) -> UniformValue<'a> {
+        UniformValue::SignedInt(v as i32)
     }
 }
 
-impl_uniform_block_basic!(i32, UniformType::Int);
-
-impl AsUniformValue for [i32; 2] {
+impl<'a> From<u32> for UniformValue<'a> {
     #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::IntVec2(*self)
+    fn from(v: u32) -> UniformValue<'a> {
+        UniformValue::UnsignedInt(v as u32)
     }
 }
 
-impl_uniform_block_basic!([i32; 2], UniformType::IntVec2);
-
-impl AsUniformValue for (i32, i32) {
+impl<'a> From<[i32; 2]> for UniformValue<'a> {
     #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::IntVec2([self.0, self.1])
+    fn from(v: [i32; 2]) -> UniformValue<'a> {
+        UniformValue::IntVec2(v)
     }
 }
 
-impl_uniform_block_basic!((i32, i32), UniformType::IntVec2);
-
-impl AsUniformValue for [i32; 3] {
+impl<'a> From<[i32; 3]> for UniformValue<'a> {
     #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::IntVec3(*self)
+    fn from(v: [i32; 3]) -> UniformValue<'a> {
+        UniformValue::IntVec3(v)
     }
 }
 
-impl_uniform_block_basic!([i32; 3], UniformType::IntVec3);
-
-impl AsUniformValue for (i32, i32, i32) {
+impl<'a> From<[i32; 4]> for UniformValue<'a> {
     #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::IntVec3([self.0, self.1, self.2])
+    fn from(v: [i32; 4]) -> UniformValue<'a> {
+        UniformValue::IntVec4(v)
     }
 }
 
-impl_uniform_block_basic!((i32, i32, i32), UniformType::IntVec3);
-
-impl AsUniformValue for [i32; 4] {
+impl<'a> From<(i32, i32)> for UniformValue<'a> {
     #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::IntVec4(*self)
+    fn from(v: (i32, i32)) -> UniformValue<'a> {
+        [v.0, v.1].into()
     }
 }
 
-impl_uniform_block_basic!([i32; 4], UniformType::IntVec4);
-
-impl AsUniformValue for (i32, i32, i32, i32) {
+impl<'a> From<(i32, i32, i32)> for UniformValue<'a> {
     #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::IntVec4([self.0, self.1, self.2, self.3])
+    fn from(v: (i32, i32, i32)) -> UniformValue<'a> {
+        [v.0, v.1, v.2].into()
     }
 }
 
-impl_uniform_block_basic!((i32, i32, i32, i32), UniformType::IntVec4);
-
-impl AsUniformValue for u32 {
+impl<'a> From<(i32, i32, i32, i32)> for UniformValue<'a> {
     #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::UnsignedInt(*self as u32)
+    fn from(v: (i32, i32, i32, i32)) -> UniformValue<'a> {
+        [v.0, v.1, v.2, v.3].into()
+    }
+}
+
+impl<'a> From<[u32; 2]> for UniformValue<'a> {
+    #[inline]
+    fn from(v: [u32; 2]) -> UniformValue<'a> {
+        UniformValue::UnsignedIntVec2(v)
+    }
+}
+
+impl<'a> From<[u32; 3]> for UniformValue<'a> {
+    #[inline]
+    fn from(v: [u32; 3]) -> UniformValue<'a> {
+        UniformValue::UnsignedIntVec3(v)
+    }
+}
+
+impl<'a> From<[u32; 4]> for UniformValue<'a> {
+    #[inline]
+    fn from(v: [u32; 4]) -> UniformValue<'a> {
+        UniformValue::UnsignedIntVec4(v)
+    }
+}
+
+impl<'a> From<(u32, u32)> for UniformValue<'a> {
+    #[inline]
+    fn from(v: (u32, u32)) -> UniformValue<'a> {
+        [v.0, v.1].into()
+    }
+}
+
+impl<'a> From<(u32, u32, u32)> for UniformValue<'a> {
+    #[inline]
+    fn from(v: (u32, u32, u32)) -> UniformValue<'a> {
+        [v.0, v.1, v.2].into()
+    }
+}
+
+impl<'a> From<(u32, u32, u32, u32)> for UniformValue<'a> {
+    #[inline]
+    fn from(v: (u32, u32, u32, u32)) -> UniformValue<'a> {
+        [v.0, v.1, v.2, v.3].into()
+    }
+}
+
+
+impl<'a> From<[bool; 2]> for UniformValue<'a> {
+    #[inline]
+    fn from(v: [bool; 2]) -> UniformValue<'a> {
+        UniformValue::BoolVec2(v)
+    }
+}
+
+impl<'a> From<[bool; 3]> for UniformValue<'a> {
+    #[inline]
+    fn from(v: [bool; 3]) -> UniformValue<'a> {
+        UniformValue::BoolVec3(v)
+    }
+}
+
+impl<'a> From<[bool; 4]> for UniformValue<'a> {
+    #[inline]
+    fn from(v: [bool; 4]) -> UniformValue<'a> {
+        UniformValue::BoolVec4(v)
+    }
+}
+
+impl<'a> From<bool> for UniformValue<'a> {
+    #[inline]
+    fn from(v: bool) -> UniformValue<'a> {
+        UniformValue::Bool(v)
+    }
+}
+
+impl<'a> From<(bool, bool)> for UniformValue<'a> {
+    #[inline]
+    fn from(v: (bool, bool)) -> UniformValue<'a> {
+        [v.0, v.1].into()
+    }
+}
+
+impl<'a> From<(bool, bool, bool)> for UniformValue<'a> {
+    #[inline]
+    fn from(v: (bool, bool, bool)) -> UniformValue<'a> {
+        [v.0, v.1, v.2].into()
+    }
+}
+
+impl<'a> From<(bool, bool, bool, bool)> for UniformValue<'a> {
+    #[inline]
+    fn from(v: (bool, bool, bool, bool)) -> UniformValue<'a> {
+        [v.0, v.1, v.2, v.3].into()
+    }
+}
+
+impl<'a> From<f32> for UniformValue<'a> {
+    #[inline]
+    fn from(v: f32) -> UniformValue<'a> {
+        UniformValue::Float(v)
+    }
+}
+
+impl<'a> From<[f32; 2]> for UniformValue<'a> {
+    #[inline]
+    fn from(v: [f32; 2]) -> UniformValue<'a> {
+        UniformValue::Vec2(v)
+    }
+}
+
+impl<'a> From<[f32; 3]> for UniformValue<'a> {
+    #[inline]
+    fn from(v: [f32; 3]) -> UniformValue<'a> {
+        UniformValue::Vec3(v)
+    }
+}
+
+impl<'a> From<[f32; 4]> for UniformValue<'a> {
+    #[inline]
+    fn from(v: [f32; 4]) -> UniformValue<'a> {
+        UniformValue::Vec4(v)
+    }
+}
+
+impl<'a> From<(f32, f32)> for UniformValue<'a> {
+    #[inline]
+    fn from(v: (f32, f32)) -> UniformValue<'a> {
+        [v.0, v.1].into()
+    }
+}
+
+impl<'a> From<(f32, f32, f32)> for UniformValue<'a> {
+    #[inline]
+    fn from(v: (f32, f32, f32)) -> UniformValue<'a> {
+        [v.0, v.1, v.2].into()
+    }
+}
+
+impl<'a> From<(f32, f32, f32, f32)> for UniformValue<'a> {
+    #[inline]
+    fn from(v: (f32, f32, f32, f32)) -> UniformValue<'a> {
+        [v.0, v.1, v.2, v.3].into()
+    }
+}
+
+impl<'a> From<f64> for UniformValue<'a> {
+    #[inline]
+    fn from(v: f64) -> UniformValue<'a> {
+        UniformValue::Double(v)
+    }
+}
+
+impl<'a> From<[f64; 2]> for UniformValue<'a> {
+    #[inline]
+    fn from(v: [f64; 2]) -> UniformValue<'a> {
+        UniformValue::DoubleVec2(v)
+    }
+}
+
+impl<'a> From<[f64; 3]> for UniformValue<'a> {
+    #[inline]
+    fn from(v: [f64; 3]) -> UniformValue<'a> {
+        UniformValue::DoubleVec3(v)
+    }
+}
+
+impl<'a> From<[f64; 4]> for UniformValue<'a> {
+    #[inline]
+    fn from(v: [f64; 4]) -> UniformValue<'a> {
+        UniformValue::DoubleVec4(v)
+    }
+}
+
+impl<'a> From<(f64, f64)> for UniformValue<'a> {
+    #[inline]
+    fn from(v: (f64, f64)) -> UniformValue<'a> {
+        [v.0, v.1].into()
+    }
+}
+
+impl<'a> From<(f64, f64, f64)> for UniformValue<'a> {
+    #[inline]
+    fn from(v: (f64, f64, f64)) -> UniformValue<'a> {
+        [v.0, v.1, v.2].into()
+    }
+}
+
+impl<'a> From<(f64, f64, f64, f64)> for UniformValue<'a> {
+    #[inline]
+    fn from(v: (f64, f64, f64, f64)) -> UniformValue<'a> {
+        [v.0, v.1, v.2, v.3].into()
+    }
+}
+
+impl<'a> From<i64> for UniformValue<'a> {
+    #[inline]
+    fn from(v: i64) -> UniformValue<'a> {
+        UniformValue::Int64(v)
+    }
+}
+
+impl<'a> From<[i64; 2]> for UniformValue<'a> {
+    #[inline]
+    fn from(v: [i64; 2]) -> UniformValue<'a> {
+        UniformValue::Int64Vec2(v)
+    }
+}
+
+impl<'a> From<[i64; 3]> for UniformValue<'a> {
+    #[inline]
+    fn from(v: [i64; 3]) -> UniformValue<'a> {
+        UniformValue::Int64Vec3(v)
+    }
+}
+
+impl<'a> From<[i64; 4]> for UniformValue<'a> {
+    #[inline]
+    fn from(v: [i64; 4]) -> UniformValue<'a> {
+        UniformValue::Int64Vec4(v)
+    }
+}
+
+impl<'a> From<(i64, i64)> for UniformValue<'a> {
+    #[inline]
+    fn from(v: (i64, i64)) -> UniformValue<'a> {
+        [v.0, v.1].into()
+    }
+}
+
+impl<'a> From<(i64, i64, i64)> for UniformValue<'a> {
+    #[inline]
+    fn from(v: (i64, i64, i64)) -> UniformValue<'a> {
+        [v.0, v.1, v.2].into()
+    }
+}
+
+impl<'a> From<(i64, i64, i64, i64)> for UniformValue<'a> {
+    #[inline]
+    fn from(v: (i64, i64, i64, i64)) -> UniformValue<'a> {
+        [v.0, v.1, v.2, v.3].into()
+    }
+}
+
+impl<'a> From<u64> for UniformValue<'a> {
+    #[inline]
+    fn from(v: u64) -> UniformValue<'a> {
+        UniformValue::UnsignedInt64(v)
+    }
+}
+
+impl<'a> From<[u64; 2]> for UniformValue<'a> {
+    #[inline]
+    fn from(v: [u64; 2]) -> UniformValue<'a> {
+        UniformValue::UnsignedInt64Vec2(v)
+    }
+}
+
+impl<'a> From<[u64; 3]> for UniformValue<'a> {
+    #[inline]
+    fn from(v: [u64; 3]) -> UniformValue<'a> {
+        UniformValue::UnsignedInt64Vec3(v)
+    }
+}
+
+impl<'a> From<[u64; 4]> for UniformValue<'a> {
+    #[inline]
+    fn from(v: [u64; 4]) -> UniformValue<'a> {
+        UniformValue::UnsignedInt64Vec4(v)
+    }
+}
+
+impl<'a> From<(u64, u64)> for UniformValue<'a> {
+    #[inline]
+    fn from(v: (u64, u64)) -> UniformValue<'a> {
+        [v.0, v.1].into()
+    }
+}
+
+impl<'a> From<(u64, u64, u64)> for UniformValue<'a> {
+    #[inline]
+    fn from(v: (u64, u64, u64)) -> UniformValue<'a> {
+        [v.0, v.1, v.2].into()
+    }
+}
+
+impl<'a> From<(u64, u64, u64, u64)> for UniformValue<'a> {
+    #[inline]
+    fn from(v: (u64, u64, u64, u64)) -> UniformValue<'a> {
+        [v.0, v.1, v.2, v.3].into()
+    }
+}
+
+impl<'a> From<[[f32; 2]; 2]> for UniformValue<'a> {
+    #[inline]
+    fn from(v: [[f32; 2]; 2]) -> UniformValue<'a> {
+        UniformValue::Mat2(v)
+    }
+}
+
+impl<'a> From<[[f32; 3]; 3]> for UniformValue<'a> {
+    #[inline]
+    fn from(v: [[f32; 3]; 3]) -> UniformValue<'a> {
+        UniformValue::Mat3(v)
+    }
+}
+
+impl<'a> From<[[f32; 4]; 4]> for UniformValue<'a> {
+    #[inline]
+    fn from(v: [[f32; 4]; 4]) -> UniformValue<'a> {
+        UniformValue::Mat4(v)
+    }
+}
+
+impl<'a> From<[[f64; 2]; 2]> for UniformValue<'a> {
+    #[inline]
+    fn from(v: [[f64; 2]; 2]) -> UniformValue<'a> {
+        UniformValue::DoubleMat2(v)
+    }
+}
+
+impl<'a> From<[[f64; 3]; 3]> for UniformValue<'a> {
+    #[inline]
+    fn from(v: [[f64; 3]; 3]) -> UniformValue<'a> {
+        UniformValue::DoubleMat3(v)
+    }
+}
+
+impl<'a> From<[[f64; 4]; 4]> for UniformValue<'a> {
+    #[inline]
+    fn from(v: [[f64; 4]; 4]) -> UniformValue<'a> {
+        UniformValue::DoubleMat4(v)
+    }
+}
+
+impl<'a> From<(&'a str, ShaderStage)> for UniformValue<'a> {
+    #[inline]
+    fn from(v: (&'a str, ShaderStage)) -> UniformValue<'a> {
+        UniformValue::Subroutine(v.1, v.0)
     }
 }
 
 impl_uniform_block_basic!(u32, UniformType::UnsignedInt);
-
-impl AsUniformValue for [u32; 2] {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::UnsignedIntVec2(*self)
-    }
-}
-
-impl_uniform_block_basic!([u32; 2], UniformType::UnsignedIntVec2);
-
-impl AsUniformValue for (u32, u32) {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::UnsignedIntVec2([self.0, self.1])
-    }
-}
-
+impl_uniform_block_basic!(i32, UniformType::Int);
+impl_uniform_block_basic!((i32, i32), UniformType::IntVec2);
+impl_uniform_block_basic!((i32, i32, i32), UniformType::IntVec3);
+impl_uniform_block_basic!((i32, i32, i32, i32), UniformType::IntVec4);
+impl_uniform_block_basic!([i32; 2], UniformType::IntVec2);
+impl_uniform_block_basic!([i32; 3], UniformType::IntVec3);
+impl_uniform_block_basic!([i32; 4], UniformType::IntVec4);
 impl_uniform_block_basic!((u32, u32), UniformType::UnsignedIntVec2);
-
-impl AsUniformValue for [u32; 3] {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::UnsignedIntVec3(*self)
-    }
-}
-
-impl_uniform_block_basic!([u32; 3], UniformType::UnsignedIntVec3);
-
-impl AsUniformValue for (u32, u32, u32) {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::UnsignedIntVec3([self.0, self.1, self.2])
-    }
-}
-
 impl_uniform_block_basic!((u32, u32, u32), UniformType::UnsignedIntVec3);
-
-impl AsUniformValue for [u32; 4] {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::UnsignedIntVec4(*self)
-    }
-}
-
+impl_uniform_block_basic!((u32, u32, u32, u32), UniformType::UnsignedIntVec4);
+impl_uniform_block_basic!([u32; 2], UniformType::UnsignedIntVec2);
+impl_uniform_block_basic!([u32; 3], UniformType::UnsignedIntVec3);
 impl_uniform_block_basic!([u32; 4], UniformType::UnsignedIntVec4);
 
-impl AsUniformValue for (u32, u32, u32, u32) {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::UnsignedIntVec4([self.0, self.1, self.2, self.3])
-    }
-}
-
-impl_uniform_block_basic!((u32, u32, u32, u32), UniformType::UnsignedIntVec4);
-
-impl AsUniformValue for bool {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::Bool(*self)
-    }
-}
-
 impl_uniform_block_basic!(bool, UniformType::Bool);
-
-impl AsUniformValue for [bool; 2] {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::BoolVec2(*self)
-    }
-}
-
-impl_uniform_block_basic!([bool; 2], UniformType::BoolVec2);
-
-impl AsUniformValue for (bool, bool) {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::BoolVec2([self.0, self.1])
-    }
-}
-
 impl_uniform_block_basic!((bool, bool), UniformType::BoolVec2);
-
-impl AsUniformValue for [bool; 3] {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::BoolVec3(*self)
-    }
-}
-
-impl_uniform_block_basic!([bool; 3], UniformType::BoolVec3);
-
-impl AsUniformValue for (bool, bool, bool) {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::BoolVec3([self.0, self.1, self.2])
-    }
-}
-
 impl_uniform_block_basic!((bool, bool, bool), UniformType::BoolVec3);
-
-impl AsUniformValue for [bool; 4] {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::BoolVec4(*self)
-    }
-}
-
+impl_uniform_block_basic!((bool, bool, bool, bool), UniformType::BoolVec4);
+impl_uniform_block_basic!([bool; 2], UniformType::BoolVec2);
+impl_uniform_block_basic!([bool; 3], UniformType::BoolVec3);
 impl_uniform_block_basic!([bool; 4], UniformType::BoolVec4);
 
-impl AsUniformValue for (bool, bool, bool, bool) {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::BoolVec4([self.0, self.1, self.2, self.3])
-    }
-}
-
-impl_uniform_block_basic!((bool, bool, bool, bool), UniformType::BoolVec4);
-
-impl AsUniformValue for f32 {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::Float(*self)
-    }
-}
-
 impl_uniform_block_basic!(f32, UniformType::Float);
-
-impl AsUniformValue for [[f32; 2]; 2] {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::Mat2(*self)
-    }
-}
-
-impl_uniform_block_basic!([[f32; 2]; 2], UniformType::FloatMat2);
-
-impl AsUniformValue for [[f32; 3]; 3] {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::Mat3(*self)
-    }
-}
-
-impl_uniform_block_basic!([[f32; 3]; 3], UniformType::FloatMat3);
-
-impl AsUniformValue for [[f32; 4]; 4] {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::Mat4(*self)
-    }
-}
-
-impl_uniform_block_basic!([[f32; 4]; 4], UniformType::FloatMat4);
-
-impl AsUniformValue for (f32, f32) {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::Vec2([self.0, self.1])
-    }
-}
-
 impl_uniform_block_basic!((f32, f32), UniformType::FloatVec2);
-
-impl AsUniformValue for (f32, f32, f32) {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::Vec3([self.0, self.1, self.2])
-    }
-}
-
 impl_uniform_block_basic!((f32, f32, f32), UniformType::FloatVec3);
-
-impl AsUniformValue for (f32, f32, f32, f32) {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::Vec4([self.0, self.1, self.2, self.3])
-    }
-}
-
 impl_uniform_block_basic!((f32, f32, f32, f32), UniformType::FloatVec4);
-
-impl AsUniformValue for [f32; 2] {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::Vec2(*self)
-    }
-}
-
 impl_uniform_block_basic!([f32; 2], UniformType::FloatVec2);
-
-impl AsUniformValue for [f32; 3] {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::Vec3(*self)
-    }
-}
-
 impl_uniform_block_basic!([f32; 3], UniformType::FloatVec3);
-
-impl AsUniformValue for [f32; 4] {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::Vec4(*self)
-    }
-}
-
 impl_uniform_block_basic!([f32; 4], UniformType::FloatVec4);
 
-//TODO bool, i32, u32 and f64 should also be implemented as cgmath and nalgebra variants (i.e. nalgebra::Vec3<f64>).
-// Start of double type variants
-impl AsUniformValue for f64 {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::Double(*self)
-    }
-}
-
-impl_uniform_block_basic!(f64, UniformType::Double);
-
-impl AsUniformValue for [f64; 2] {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::DoubleVec2(*self)
-    }
-}
+impl_uniform_block_basic!([[f32; 2]; 2], UniformType::FloatMat2);
+impl_uniform_block_basic!([[f32; 3]; 3], UniformType::FloatMat3);
+impl_uniform_block_basic!([[f32; 4]; 4], UniformType::FloatMat4);
 
 impl_uniform_block_basic!([f64; 2], UniformType::DoubleVec2);
-
-impl AsUniformValue for (f64, f64) {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::DoubleVec2([self.0, self.1])
-    }
-}
-
-impl_uniform_block_basic!((f64, f64), UniformType::DoubleVec2);
-
-impl AsUniformValue for [f64; 3] {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::DoubleVec3(*self)
-    }
-}
-
 impl_uniform_block_basic!([f64; 3], UniformType::DoubleVec3);
-
-impl AsUniformValue for (f64, f64, f64) {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::DoubleVec3([self.0, self.1, self.2])
-    }
-}
-
-impl_uniform_block_basic!((f64, f64, f64), UniformType::DoubleVec3);
-
-impl AsUniformValue for [f64; 4] {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::DoubleVec4(*self)
-    }
-}
-
 impl_uniform_block_basic!([f64; 4], UniformType::DoubleVec4);
-
-impl AsUniformValue for (f64, f64, f64, f64) {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::DoubleVec4([self.0, self.1, self.2, self.3])
-    }
-}
-
+impl_uniform_block_basic!(f64, UniformType::Double);
+impl_uniform_block_basic!((f64, f64), UniformType::DoubleVec2);
+impl_uniform_block_basic!((f64, f64, f64), UniformType::DoubleVec3);
 impl_uniform_block_basic!((f64, f64, f64, f64), UniformType::DoubleVec4);
 
-impl AsUniformValue for [[f64; 2]; 2] {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::DoubleMat2(*self)
-    }
-}
-
-impl_uniform_block_basic!([[f64; 2]; 2], UniformType::DoubleMat2);
-
-impl AsUniformValue for [[f64; 3]; 3] {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::DoubleMat3(*self)
-    }
-}
-
-impl_uniform_block_basic!([[f64; 3]; 3], UniformType::DoubleMat3);
-
-impl AsUniformValue for [[f64; 4]; 4] {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::DoubleMat4(*self)
-    }
-}
-
-impl_uniform_block_basic!([[f64; 4]; 4], UniformType::DoubleMat4);
-
-impl AsUniformValue for i64 {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::Int64(*self as i64)
-    }
-}
-
 impl_uniform_block_basic!(i64, UniformType::Int);
-
-impl AsUniformValue for [i64; 2] {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::Int64Vec2(*self)
-    }
-}
-
-impl_uniform_block_basic!([i64; 2], UniformType::Int64Vec2);
-
-impl AsUniformValue for (i64, i64) {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::Int64Vec2([self.0, self.1])
-    }
-}
-
 impl_uniform_block_basic!((i64, i64), UniformType::Int64Vec2);
-
-impl AsUniformValue for [i64; 3] {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::Int64Vec3(*self)
-    }
-}
-
-impl_uniform_block_basic!([i64; 3], UniformType::Int64Vec3);
-
-impl AsUniformValue for (i64, i64, i64) {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::Int64Vec3([self.0, self.1, self.2])
-    }
-}
-
 impl_uniform_block_basic!((i64, i64, i64), UniformType::Int64Vec3);
-
-impl AsUniformValue for [i64; 4] {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::Int64Vec4(*self)
-    }
-}
-
-impl_uniform_block_basic!([i64; 4], UniformType::Int64Vec4);
-
-impl AsUniformValue for (i64, i64, i64, i64) {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::Int64Vec4([self.0, self.1, self.2, self.3])
-    }
-}
-
 impl_uniform_block_basic!((i64, i64, i64, i64), UniformType::Int64Vec4);
 
-impl AsUniformValue for u64 {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::UnsignedInt64(*self as u64)
-    }
-}
+impl_uniform_block_basic!([i64; 2], UniformType::Int64Vec2);
+impl_uniform_block_basic!([i64; 3], UniformType::Int64Vec3);
+impl_uniform_block_basic!([i64; 4], UniformType::Int64Vec4);
 
 impl_uniform_block_basic!(u64, UniformType::UnsignedInt64);
-
-impl AsUniformValue for [u64; 2] {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::UnsignedInt64Vec2(*self)
-    }
-}
-
-impl_uniform_block_basic!([u64; 2], UniformType::UnsignedInt64Vec2);
-
-impl AsUniformValue for (u64, u64) {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::UnsignedInt64Vec2([self.0, self.1])
-    }
-}
-
 impl_uniform_block_basic!((u64, u64), UniformType::UnsignedInt64Vec2);
-
-impl AsUniformValue for [u64; 3] {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::UnsignedInt64Vec3(*self)
-    }
-}
-
-impl_uniform_block_basic!([u64; 3], UniformType::UnsignedInt64Vec3);
-
-impl AsUniformValue for (u64, u64, u64) {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::UnsignedInt64Vec3([self.0, self.1, self.2])
-    }
-}
-
 impl_uniform_block_basic!((u64, u64, u64), UniformType::UnsignedInt64Vec3);
-
-impl AsUniformValue for [u64; 4] {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::UnsignedInt64Vec4(*self)
-    }
-}
-
-impl_uniform_block_basic!([u64; 4], UniformType::UnsignedInt64Vec4);
-
-impl AsUniformValue for (u64, u64, u64, u64) {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::UnsignedInt64Vec4([self.0, self.1, self.2, self.3])
-    }
-}
-
 impl_uniform_block_basic!((u64, u64, u64, u64), UniformType::UnsignedInt64Vec4);
 
-// Subroutines
-impl<'a> AsUniformValue for (&'a str, ShaderStage) {
-    #[inline]
-    fn as_uniform_value(&self) -> UniformValue {
-        UniformValue::Subroutine(self.1, self.0)
-    }
-}
+impl_uniform_block_basic!([u64; 2], UniformType::UnsignedInt64Vec2);
+impl_uniform_block_basic!([u64; 3], UniformType::UnsignedInt64Vec3);
+impl_uniform_block_basic!([u64; 4], UniformType::UnsignedInt64Vec4);
+
+impl_uniform_block_basic!([[f64; 2]; 2], UniformType::DoubleMat2);
+impl_uniform_block_basic!([[f64; 3]; 3], UniformType::DoubleMat3);
+impl_uniform_block_basic!([[f64; 4]; 4], UniformType::DoubleMat4);

--- a/tests/uniform_types.rs
+++ b/tests/uniform_types.rs
@@ -1,0 +1,521 @@
+extern crate glium;
+
+use glium::uniforms::{UniformValue, AsUniformValue};
+
+fn compare_as_uniform_to_from<'a,'b, T, J>(old: &'a T, new: J)
+where
+    T: AsUniformValue<'a>,
+    J: Into<UniformValue<'b>>,
+{
+    let new_expected: UniformValue = new.into();
+    assert_eq!(old.as_uniform_value(), new_expected);
+}
+
+
+#[test]
+fn uniform_from_i8() {
+    let tested_value: i8 = -1;
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::SignedInt(tested_value as i32));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_i16() {
+    let tested_value: i16 = -2550;
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::SignedInt(tested_value as i32));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_i32() {
+    let tested_value: i32 = -2550;
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::SignedInt(tested_value as i32));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_i32_2_tuple() {
+    let tested_value: (i32, i32) = (0, -1);
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::IntVec2([0, -1]));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_i32_3_tuple() {
+    let tested_value: (i32, i32, i32) = (0, -1, 1);
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::IntVec3([0, -1, 1]));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_i32_4_tuple() {
+    let tested_value: (i32, i32, i32, i32) = (0, -1, 1, -1);
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::IntVec4([0, -1, 1, -1]));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_i32_2_array() {
+    let tested_value: [i32; 2] = [0, -1];
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::IntVec2(tested_value));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_i32_3_array() {
+    let tested_value: [i32; 3] = [0, -1, 1];
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::IntVec3(tested_value));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_i32_4_array() {
+    let tested_value: [i32; 4] = [0, -1, 1, -1];
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::IntVec4(tested_value));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_u8() {
+    let tested_value: u8 = 255;
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::UnsignedInt(tested_value as u32));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_u16() {
+    let tested_value: u16 = 2550;
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::UnsignedInt(tested_value as u32));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_u32() {
+    let tested_value: u32 = 2550;
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::UnsignedInt(tested_value as u32));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_u32_2_array() {
+    let tested_value: [u32; 2] = [0, 1];
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::UnsignedIntVec2(tested_value));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_u32_3_array() {
+    let tested_value: [u32; 3] = [0, 1, 1];
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::UnsignedIntVec3(tested_value));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_u32_4_array() {
+    let tested_value: [u32; 4] = [0, 2, 1, 1];
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::UnsignedIntVec4(tested_value));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_u32_2_tuple() {
+    let tested_value: (u32, u32) = (0, 1);
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::UnsignedIntVec2([0, 1]));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_u32_3_tuple() {
+    let tested_value: (u32, u32, u32) = (0, 1, 2);
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::UnsignedIntVec3([0, 1, 2]));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_u32_4_tuple() {
+    let tested_value: (u32, u32, u32, u32) = (0, 1, 2, 3);
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::UnsignedIntVec4([0, 1, 2, 3]));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_bool_2_array() {
+    let tested_value: [bool; 2] = [true, false];
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::BoolVec2(tested_value));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_bool_3_array() {
+    let tested_value: [bool; 3] = [true, false, true];
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::BoolVec3(tested_value));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_bool_4_array() {
+    let tested_value: [bool; 4] = [true, false, false, true];
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::BoolVec4(tested_value));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_bool() {
+    let tested_value: bool = true;
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::Bool(true));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_bool_2_tuple() {
+    let tested_value: (bool, bool) = (true, false);
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::BoolVec2([true, false]));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_bool_3_tuple() {
+    let tested_value: (bool, bool, bool) = (true, false, false);
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::BoolVec3([true, false, false]));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_bool_4_tuple() {
+    let tested_value: (bool, bool, bool, bool) = (true, false, true, false);
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::BoolVec4([true, false, true, false]));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_f32() {
+    let tested_value: f32 = 1.;
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::Float(tested_value as f32));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_f32_2_array() {
+    let tested_value: [f32; 2] = [0., 1.];
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::Vec2(tested_value));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_f32_3_array() {
+    let tested_value: [f32; 3] = [0., 1., 1.];
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::Vec3(tested_value));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_f32_4_array() {
+    let tested_value: [f32; 4] = [0., 2., 1., 1.];
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::Vec4(tested_value));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_f32_2_tuple() {
+    let tested_value: (f32, f32) = (0., -1.);
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::Vec2([0., -1.]));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_f32_3_tuple() {
+    let tested_value: (f32, f32, f32) = (0., -1., 1.);
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::Vec3([0., -1., 1.]));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_f32_4_tuple() {
+    let tested_value: (f32, f32, f32, f32) = (0., -1., 1., -1.);
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::Vec4([0., -1., 1., -1.]));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_f64() {
+    let tested_value: f64 = 1.;
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::Double(tested_value as f64));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_f64_2_array() {
+    let tested_value: [f64; 2] = [0., 1.];
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::DoubleVec2(tested_value));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_f64_3_array() {
+    let tested_value: [f64; 3] = [0., 1., 1.];
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::DoubleVec3(tested_value));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_f64_4_array() {
+    let tested_value: [f64; 4] = [0., 2., 1., 1.];
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::DoubleVec4(tested_value));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_f64_2_tuple() {
+    let tested_value: (f64, f64) = (0., -1.);
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::DoubleVec2([0., -1.]));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_f64_3_tuple() {
+    let tested_value: (f64, f64, f64) = (0., -1., 1.);
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::DoubleVec3([0., -1., 1.]));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_f64_4_tuple() {
+    let tested_value: (f64, f64, f64, f64) = (0., -1., 1., -1.);
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::DoubleVec4([0., -1., 1., -1.]));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_i64() {
+    let tested_value: i64 = 1;
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::Int64(tested_value as i64));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_i64_2_array() {
+    let tested_value: [i64; 2] = [0, 1];
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::Int64Vec2(tested_value));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_i64_3_array() {
+    let tested_value: [i64; 3] = [0, 1, 1];
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::Int64Vec3(tested_value));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_i64_4_array() {
+    let tested_value: [i64; 4] = [0, 2, 1, 1];
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::Int64Vec4(tested_value));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_i64_2_tuple() {
+    let tested_value: (i64, i64) = (0, -1);
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::Int64Vec2([0, -1]));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_i64_3_tuple() {
+    let tested_value: (i64, i64, i64) = (0, -1, 1);
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::Int64Vec3([0, -1, 1]));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_i64_4_tuple() {
+    let tested_value: (i64, i64, i64, i64) = (0, -1, 1, -1);
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::Int64Vec4([0, -1, 1, -1]));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_u64() {
+    let tested_value: u64 = 1;
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::UnsignedInt64(tested_value as u64));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_u64_2_array() {
+    let tested_value: [u64; 2] = [0, 1];
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::UnsignedInt64Vec2(tested_value));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_u64_3_array() {
+    let tested_value: [u64; 3] = [0, 1, 1];
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::UnsignedInt64Vec3(tested_value));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_u64_4_array() {
+    let tested_value: [u64; 4] = [0, 2, 1, 1];
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::UnsignedInt64Vec4(tested_value));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_u64_2_tuple() {
+    let tested_value: (u64, u64) = (0, 1);
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::UnsignedInt64Vec2([0, 1]));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_u64_3_tuple() {
+    let tested_value: (u64, u64, u64) = (0, 1, 1);
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::UnsignedInt64Vec3([0, 1, 1]));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn uniform_from_u64_4_tuple() {
+    let tested_value: (u64, u64, u64, u64) = (0, 1, 1, 1);
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::UnsignedInt64Vec4([0, 1, 1, 1]));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn unfirom_from_f32_2x2_matrix() {
+    let tested_value: [[f32; 2]; 2] = [[1., 0.], [0., 1.]];
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::Mat2([[1., 0.], [0., 1.]]));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn unfirom_from_f32_3x3_matrix() {
+    let tested_value: [[f32; 3]; 3] = [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]];
+    let result: UniformValue = tested_value.into();
+    assert_eq!(
+        result,
+        UniformValue::Mat3([[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]])
+    );
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn unfirom_from_f32_4x4_matrix() {
+    let tested_value: [[f32; 4]; 4] = [
+        [1., 0., 0., 0.],
+        [0., 1., 0., 0.],
+        [0., 0., 1., 0.],
+        [1., 0., 0., 1.],
+    ];
+    let result: UniformValue = tested_value.into();
+    assert_eq!(
+        result,
+        UniformValue::Mat4(
+            [
+                [1., 0., 0., 0.],
+                [0., 1., 0., 0.],
+                [0., 0., 1., 0.],
+                [1., 0., 0., 1.],
+            ],
+        )
+    );
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn unfirom_from_f64_2x2_matrix() {
+    let tested_value: [[f64; 2]; 2] = [[1., 0.], [0., 1.]];
+    let result: UniformValue = tested_value.into();
+    assert_eq!(result, UniformValue::DoubleMat2([[1., 0.], [0., 1.]]));
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn unfirom_from_f64_3x3_matrix() {
+    let tested_value: [[f64; 3]; 3] = [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]];
+    let result: UniformValue = tested_value.into();
+    assert_eq!(
+        result,
+        UniformValue::DoubleMat3([[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]])
+    );
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}
+
+#[test]
+fn unfirom_from_f64_4x4_matrix() {
+    let tested_value: [[f64; 4]; 4] = [
+        [1., 0., 0., 0.],
+        [0., 1., 0., 0.],
+        [0., 0., 1., 0.],
+        [1., 0., 0., 1.],
+    ];
+    let result: UniformValue = tested_value.into();
+    assert_eq!(
+        result,
+        UniformValue::DoubleMat4(
+            [
+                [1., 0., 0., 0.],
+                [0., 1., 0., 0.],
+                [0., 0., 1., 0.],
+                [1., 0., 0., 1.],
+            ],
+        )
+    );
+    compare_as_uniform_to_from(&tested_value, tested_value);
+}

--- a/tests/uniform_types.rs
+++ b/tests/uniform_types.rs
@@ -1,23 +1,11 @@
 extern crate glium;
-
-use glium::uniforms::{UniformValue, AsUniformValue};
-
-fn compare_as_uniform_to_from<'a,'b, T, J>(old: &'a T, new: J)
-where
-    T: AsUniformValue<'a>,
-    J: Into<UniformValue<'b>>,
-{
-    let new_expected: UniformValue = new.into();
-    assert_eq!(old.as_uniform_value(), new_expected);
-}
-
+use glium::uniforms::{UniformValue};
 
 #[test]
 fn uniform_from_i8() {
     let tested_value: i8 = -1;
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::SignedInt(tested_value as i32));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -25,7 +13,6 @@ fn uniform_from_i16() {
     let tested_value: i16 = -2550;
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::SignedInt(tested_value as i32));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -33,7 +20,6 @@ fn uniform_from_i32() {
     let tested_value: i32 = -2550;
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::SignedInt(tested_value as i32));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -41,7 +27,6 @@ fn uniform_from_i32_2_tuple() {
     let tested_value: (i32, i32) = (0, -1);
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::IntVec2([0, -1]));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -49,7 +34,6 @@ fn uniform_from_i32_3_tuple() {
     let tested_value: (i32, i32, i32) = (0, -1, 1);
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::IntVec3([0, -1, 1]));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -57,7 +41,6 @@ fn uniform_from_i32_4_tuple() {
     let tested_value: (i32, i32, i32, i32) = (0, -1, 1, -1);
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::IntVec4([0, -1, 1, -1]));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -65,7 +48,6 @@ fn uniform_from_i32_2_array() {
     let tested_value: [i32; 2] = [0, -1];
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::IntVec2(tested_value));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -73,7 +55,6 @@ fn uniform_from_i32_3_array() {
     let tested_value: [i32; 3] = [0, -1, 1];
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::IntVec3(tested_value));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -81,7 +62,6 @@ fn uniform_from_i32_4_array() {
     let tested_value: [i32; 4] = [0, -1, 1, -1];
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::IntVec4(tested_value));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -89,7 +69,6 @@ fn uniform_from_u8() {
     let tested_value: u8 = 255;
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::UnsignedInt(tested_value as u32));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -97,7 +76,6 @@ fn uniform_from_u16() {
     let tested_value: u16 = 2550;
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::UnsignedInt(tested_value as u32));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -105,7 +83,6 @@ fn uniform_from_u32() {
     let tested_value: u32 = 2550;
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::UnsignedInt(tested_value as u32));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -113,7 +90,6 @@ fn uniform_from_u32_2_array() {
     let tested_value: [u32; 2] = [0, 1];
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::UnsignedIntVec2(tested_value));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -121,7 +97,6 @@ fn uniform_from_u32_3_array() {
     let tested_value: [u32; 3] = [0, 1, 1];
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::UnsignedIntVec3(tested_value));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -129,7 +104,6 @@ fn uniform_from_u32_4_array() {
     let tested_value: [u32; 4] = [0, 2, 1, 1];
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::UnsignedIntVec4(tested_value));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -137,7 +111,6 @@ fn uniform_from_u32_2_tuple() {
     let tested_value: (u32, u32) = (0, 1);
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::UnsignedIntVec2([0, 1]));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -145,7 +118,6 @@ fn uniform_from_u32_3_tuple() {
     let tested_value: (u32, u32, u32) = (0, 1, 2);
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::UnsignedIntVec3([0, 1, 2]));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -153,7 +125,6 @@ fn uniform_from_u32_4_tuple() {
     let tested_value: (u32, u32, u32, u32) = (0, 1, 2, 3);
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::UnsignedIntVec4([0, 1, 2, 3]));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -161,7 +132,6 @@ fn uniform_from_bool_2_array() {
     let tested_value: [bool; 2] = [true, false];
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::BoolVec2(tested_value));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -169,7 +139,6 @@ fn uniform_from_bool_3_array() {
     let tested_value: [bool; 3] = [true, false, true];
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::BoolVec3(tested_value));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -177,7 +146,6 @@ fn uniform_from_bool_4_array() {
     let tested_value: [bool; 4] = [true, false, false, true];
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::BoolVec4(tested_value));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -185,7 +153,6 @@ fn uniform_from_bool() {
     let tested_value: bool = true;
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::Bool(true));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -193,7 +160,6 @@ fn uniform_from_bool_2_tuple() {
     let tested_value: (bool, bool) = (true, false);
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::BoolVec2([true, false]));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -201,7 +167,6 @@ fn uniform_from_bool_3_tuple() {
     let tested_value: (bool, bool, bool) = (true, false, false);
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::BoolVec3([true, false, false]));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -209,7 +174,6 @@ fn uniform_from_bool_4_tuple() {
     let tested_value: (bool, bool, bool, bool) = (true, false, true, false);
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::BoolVec4([true, false, true, false]));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -217,7 +181,6 @@ fn uniform_from_f32() {
     let tested_value: f32 = 1.;
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::Float(tested_value as f32));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -225,7 +188,6 @@ fn uniform_from_f32_2_array() {
     let tested_value: [f32; 2] = [0., 1.];
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::Vec2(tested_value));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -233,7 +195,6 @@ fn uniform_from_f32_3_array() {
     let tested_value: [f32; 3] = [0., 1., 1.];
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::Vec3(tested_value));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -241,7 +202,6 @@ fn uniform_from_f32_4_array() {
     let tested_value: [f32; 4] = [0., 2., 1., 1.];
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::Vec4(tested_value));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -249,7 +209,6 @@ fn uniform_from_f32_2_tuple() {
     let tested_value: (f32, f32) = (0., -1.);
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::Vec2([0., -1.]));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -257,7 +216,6 @@ fn uniform_from_f32_3_tuple() {
     let tested_value: (f32, f32, f32) = (0., -1., 1.);
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::Vec3([0., -1., 1.]));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -265,7 +223,6 @@ fn uniform_from_f32_4_tuple() {
     let tested_value: (f32, f32, f32, f32) = (0., -1., 1., -1.);
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::Vec4([0., -1., 1., -1.]));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -273,7 +230,6 @@ fn uniform_from_f64() {
     let tested_value: f64 = 1.;
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::Double(tested_value as f64));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -281,7 +237,6 @@ fn uniform_from_f64_2_array() {
     let tested_value: [f64; 2] = [0., 1.];
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::DoubleVec2(tested_value));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -289,7 +244,6 @@ fn uniform_from_f64_3_array() {
     let tested_value: [f64; 3] = [0., 1., 1.];
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::DoubleVec3(tested_value));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -297,7 +251,6 @@ fn uniform_from_f64_4_array() {
     let tested_value: [f64; 4] = [0., 2., 1., 1.];
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::DoubleVec4(tested_value));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -305,7 +258,6 @@ fn uniform_from_f64_2_tuple() {
     let tested_value: (f64, f64) = (0., -1.);
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::DoubleVec2([0., -1.]));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -313,7 +265,6 @@ fn uniform_from_f64_3_tuple() {
     let tested_value: (f64, f64, f64) = (0., -1., 1.);
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::DoubleVec3([0., -1., 1.]));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -321,7 +272,6 @@ fn uniform_from_f64_4_tuple() {
     let tested_value: (f64, f64, f64, f64) = (0., -1., 1., -1.);
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::DoubleVec4([0., -1., 1., -1.]));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -329,7 +279,6 @@ fn uniform_from_i64() {
     let tested_value: i64 = 1;
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::Int64(tested_value as i64));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -337,7 +286,6 @@ fn uniform_from_i64_2_array() {
     let tested_value: [i64; 2] = [0, 1];
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::Int64Vec2(tested_value));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -345,7 +293,6 @@ fn uniform_from_i64_3_array() {
     let tested_value: [i64; 3] = [0, 1, 1];
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::Int64Vec3(tested_value));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -353,7 +300,6 @@ fn uniform_from_i64_4_array() {
     let tested_value: [i64; 4] = [0, 2, 1, 1];
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::Int64Vec4(tested_value));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -361,7 +307,6 @@ fn uniform_from_i64_2_tuple() {
     let tested_value: (i64, i64) = (0, -1);
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::Int64Vec2([0, -1]));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -369,7 +314,6 @@ fn uniform_from_i64_3_tuple() {
     let tested_value: (i64, i64, i64) = (0, -1, 1);
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::Int64Vec3([0, -1, 1]));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -377,7 +321,6 @@ fn uniform_from_i64_4_tuple() {
     let tested_value: (i64, i64, i64, i64) = (0, -1, 1, -1);
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::Int64Vec4([0, -1, 1, -1]));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -385,7 +328,6 @@ fn uniform_from_u64() {
     let tested_value: u64 = 1;
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::UnsignedInt64(tested_value as u64));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -393,7 +335,6 @@ fn uniform_from_u64_2_array() {
     let tested_value: [u64; 2] = [0, 1];
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::UnsignedInt64Vec2(tested_value));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -401,7 +342,6 @@ fn uniform_from_u64_3_array() {
     let tested_value: [u64; 3] = [0, 1, 1];
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::UnsignedInt64Vec3(tested_value));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -409,7 +349,6 @@ fn uniform_from_u64_4_array() {
     let tested_value: [u64; 4] = [0, 2, 1, 1];
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::UnsignedInt64Vec4(tested_value));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -417,7 +356,6 @@ fn uniform_from_u64_2_tuple() {
     let tested_value: (u64, u64) = (0, 1);
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::UnsignedInt64Vec2([0, 1]));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -425,7 +363,6 @@ fn uniform_from_u64_3_tuple() {
     let tested_value: (u64, u64, u64) = (0, 1, 1);
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::UnsignedInt64Vec3([0, 1, 1]));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -433,7 +370,6 @@ fn uniform_from_u64_4_tuple() {
     let tested_value: (u64, u64, u64, u64) = (0, 1, 1, 1);
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::UnsignedInt64Vec4([0, 1, 1, 1]));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -441,7 +377,6 @@ fn unfirom_from_f32_2x2_matrix() {
     let tested_value: [[f32; 2]; 2] = [[1., 0.], [0., 1.]];
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::Mat2([[1., 0.], [0., 1.]]));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -452,7 +387,6 @@ fn unfirom_from_f32_3x3_matrix() {
         result,
         UniformValue::Mat3([[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]])
     );
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -475,7 +409,6 @@ fn unfirom_from_f32_4x4_matrix() {
             ],
         )
     );
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -483,7 +416,6 @@ fn unfirom_from_f64_2x2_matrix() {
     let tested_value: [[f64; 2]; 2] = [[1., 0.], [0., 1.]];
     let result: UniformValue = tested_value.into();
     assert_eq!(result, UniformValue::DoubleMat2([[1., 0.], [0., 1.]]));
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -494,7 +426,6 @@ fn unfirom_from_f64_3x3_matrix() {
         result,
         UniformValue::DoubleMat3([[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]])
     );
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }
 
 #[test]
@@ -517,5 +448,4 @@ fn unfirom_from_f64_4x4_matrix() {
             ],
         )
     );
-    compare_as_uniform_to_from(&tested_value, tested_value);
 }


### PR DESCRIPTION
## Goal
Replace AsUniformValue with `From<T> for UniformValue` equivalent

### Why?
I preferred the intent of Glium over other existing OpenGL implementations. However, I want to use some of the newer Stable Rust features such as Macros 1.1. This is one of many refactors to make that code more simple. 

### Notable Changes
https://github.com/glium/glium/pull/1632/files#diff-e4e6538764117aa97918d216423e804d
I made `struct Fences` to bypass issues with Inserters and lifetimes. 

### Tests
Other than the new tests for the UniformValue I asserted that examples rendered exactly the same on a MacbookPro on the previous commit as with the current commit. I also looked for Github projects that used `glium = "0.18.*"`. I ran their examples and also assert that the output was the same as the crate 

#### Resolves
https://github.com/glium/glium/issues/1629