### PR TITLE
Fix fullscreen example

### DIFF
--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -100,17 +100,20 @@ fn main() {
         // polling and handling the events received by the window
         let mut enter_pressed = false;
         events_loop.poll_events(|event| match event {
-            Event::WindowEvent { event, .. } => match event {
-                WindowEvent::Closed => action = support::Action::Stop,
-                WindowEvent::KeyboardInput { input, .. } => {
-                    if let ElementState::Pressed = input.state {
-                        if let Some(VirtualKeyCode::Return) = input.virtual_keycode {
-                            enter_pressed = true;
-                        }
+            Event::WindowEvent { event, window_id } =>
+                if window_id == display.gl_window().id() {
+                    match event {
+                        WindowEvent::Closed => action = support::Action::Stop,
+                        WindowEvent::KeyboardInput { input, .. } => {
+                            if let ElementState::Pressed = input.state {
+                                if let Some(VirtualKeyCode::Return) = input.virtual_keycode {
+                                    enter_pressed = true;
+                                }
+                            }
+                        },
+                        _ => ()
                     }
                 },
-                _ => ()
-            },
             _ => (),
         });
 

--- a/src/backend/glutin/mod.rs
+++ b/src/backend/glutin/mod.rs
@@ -138,9 +138,11 @@ impl Display {
             try!(glutin::GlWindow::new(window_builder, context_builder, events_loop))
         };
 
-        // Replace the stored GlWindow with the new one.
-        let mut gl_window = self.gl_window.borrow_mut();
-        std::mem::replace(&mut (*gl_window), new_gl_window);
+        {
+            // Replace the stored GlWindow with the new one.
+            let mut gl_window = self.gl_window.borrow_mut();
+            std::mem::replace(&mut (*gl_window), new_gl_window);
+        }
 
         // Rebuild the Context.
         let backend = GlutinBackend(self.gl_window.clone());


### PR DESCRIPTION
Fixes #1619 
1. Fix borrowing issue: narrow the scope.
2. Fix fullscreen example so that is don't exit right after display rebuild: listen only to current window events.
