### PR TITLE
Adds unsafe `as_typed_slice{,mut}` methods to `BufferAny`.

### DIFF
--- a/src/buffer/view.rs
+++ b/src/buffer/view.rs
@@ -1091,6 +1091,32 @@ impl BufferAny {
         }
     }
 
+    /// Builds a mutable typed slice containing the whole subbuffer, without checking the type.
+    #[inline]
+    pub unsafe fn as_typed_slice_mut<T: ?Sized + Content>(&mut self) -> BufferMutSlice<T> {
+        assert_eq!(<T as Content>::get_elements_size(), self.elements_size);
+        BufferMutSlice {
+            alloc: &mut self.alloc,
+            bytes_start: 0,
+            bytes_end: self.size,
+            fence: &self.fence,
+            marker: PhantomData,
+        }
+    }
+
+    /// Builds a typed slice containing the whole subbuffer, without checking the type.
+    #[inline]
+    pub unsafe fn as_typed_slice<T: ?Sized + Content>(&self) -> BufferSlice<T> {
+        assert_eq!(<T as Content>::get_elements_size(), self.elements_size);
+        BufferSlice {
+            alloc: &self.alloc,
+            bytes_start: 0,
+            bytes_end: self.size,
+            fence: &self.fence,
+            marker: PhantomData,
+        }
+    }
+
     /// Returns the size in bytes of each element in the buffer.
     // TODO: clumbsy, remove this function
     #[inline]

--- a/src/vertex/buffer.rs
+++ b/src/vertex/buffer.rs
@@ -501,6 +501,22 @@ impl<T> From<Buffer<[T]>> for VertexBufferAny where T: Vertex + Copy + Send + 's
     }
 }
 
+impl Deref for VertexBufferAny {
+    type Target = BufferAny;
+
+    #[inline]
+    fn deref(&self) -> &BufferAny {
+        &self.buffer
+    }
+}
+
+impl DerefMut for VertexBufferAny {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut BufferAny {
+        &mut self.buffer
+    }
+}
+
 impl<'a> IntoVerticesSource<'a> for &'a VertexBufferAny {
     #[inline]
     fn into_vertices_source(self) -> VerticesSource<'a> {


### PR DESCRIPTION
This small PR allows type-unchecked slicing as `BufferSlice<T>` or `BufferMutSlice<T>` if you know that the buffer is of type `T`.

This PR also adds a `Deref{,Mut}` impl-s for `VertexBufferAny` to give out `BufferAny` references. Similar `Deref{,Mut}` impls already exist in `IndexBufferAny`.

#### Why is this needed?
I store all my meshes centrally in a `Vec<VertexBufferAny>`-like container and refer to them by ID in other places (this allows multiple render passes and sorting to happen transparently).

To support dynamic meshes though, I need to be able to write to some of those meshes after they're created.

My plan is to have a `TypeId` guard ensuring that the types are correct, but these glium changes are the minimal required so I can actually implement what I want.

Basic idea is:

<details>
<summary> Code </summary>

```rust
extern crate glium;

use glium::vertex::{Vertex, VertexBuffer, VertexBufferAny, IntoVerticesSource, VerticesSource};
use glium::buffer::{BufferSlice, BufferMutSlice};
use std::any::TypeId;
use std::ops::Deref;
use std::error::Error;
use std::fmt::{Display, Formatter, Result as FmtResult};

/// A type-erased `VertexBuffer` which can be safely borrowed as the original `VertexBuffer<T>`
/// using a dynamic type check.
pub struct TypedVertexBufferAny {
    type_id: TypeId,
    buffer: VertexBufferAny,
}

impl TypedVertexBufferAny {
    /// Borrows buffer immutably as typed, checking the type at runtime.
    ///
    /// Returns an error if the type is not the one given on construction.
    pub fn as_typed_slice<T: Vertex + Send + 'static>(
        &self,
    ) -> Result<BufferSlice<[T]>, IncorrectTypeError> {
        if self.type_id == TypeId::of::<T>() {
            Ok(unsafe { self.buffer.deref().as_typed_slice() })
        } else {
            Err(IncorrectTypeError)
        }
    }

    /// Borrows the buffer mutably as typed, checking the type at runtime.
    ///
    /// Returns an error if the type is not the one given on construction.
    pub fn as_typed_slice_mut<T: Vertex + Send + 'static>(
        &mut self,
    ) -> Result<BufferMutSlice<[T]>, IncorrectTypeError> {
        if self.type_id == TypeId::of::<T>() {
            Ok(unsafe { self.buffer.as_typed_slice_mut() })
        } else {
            Err(IncorrectTypeError)
        }
    }
}

impl<T> From<VertexBuffer<T>> for TypedVertexBufferAny
where
    T: Vertex + Send + 'static,
{
    fn from(buffer: VertexBuffer<T>) -> TypedVertexBufferAny {
        TypedVertexBufferAny {
            type_id: TypeId::of::<T>(),
            buffer: buffer.into(),
        }
    }
}

impl<'a> IntoVerticesSource<'a> for &'a TypedVertexBufferAny {
    fn into_vertices_source(self) -> VerticesSource<'a> {
        self.buffer.into_vertices_source()
    }
}
```

</details>


Hope this makes sense, and thanks for this great library!