### PR TITLE
Enable double precision vertex attributes.

### DIFF
--- a/src/program/reflection.rs
+++ b/src/program/reflection.rs
@@ -1034,6 +1034,7 @@ fn glenum_to_attribute_type(value: gl::types::GLenum) -> AttributeType {
         gl::FLOAT_MAT3x4 => AttributeType::F32x3x4,
         gl::FLOAT_MAT4x2 => AttributeType::F32x4x2,
         gl::FLOAT_MAT4x3 => AttributeType::F32x4x3,
+        gl::DOUBLE_VEC4 => AttributeType::F64F64F64F64,
         v => panic!("Unknown value returned by OpenGL attribute type: {}", v)
     }
 }

--- a/src/program/reflection.rs
+++ b/src/program/reflection.rs
@@ -1034,6 +1034,9 @@ fn glenum_to_attribute_type(value: gl::types::GLenum) -> AttributeType {
         gl::FLOAT_MAT3x4 => AttributeType::F32x3x4,
         gl::FLOAT_MAT4x2 => AttributeType::F32x4x2,
         gl::FLOAT_MAT4x3 => AttributeType::F32x4x3,
+        gl::DOUBLE => AttributeType::F64,
+        gl::DOUBLE_VEC2 => AttributeType::F64F64,
+        gl::DOUBLE_VEC3 => AttributeType::F64F64F64,
         gl::DOUBLE_VEC4 => AttributeType::F64F64F64F64,
         v => panic!("Unknown value returned by OpenGL attribute type: {}", v)
     }


### PR DESCRIPTION
I needed to pass double precision vertex attributes, so I just added 4 additional match arms corresponding to double, dvec2, dvec3, and dvec4.