### PR TITLE
Update to glutin 0.11, gl_generator 0.7. Publish 0.19.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glium"
-version = "0.18.1"
+version = "0.19.0"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = """
 Elegant and safe OpenGL wrapper.
@@ -33,7 +33,7 @@ unstable = [] # used for benchmarks
 test_headless = []  # used for testing headless display
 
 [dependencies.glutin]
-version = "0.10"
+version = "0.11"
 features = []
 optional = true
 
@@ -44,7 +44,7 @@ smallvec = "0.4.2"
 fnv = "1.0.5"
 
 [build-dependencies]
-gl_generator = "0.6"
+gl_generator = "0.7"
 
 [dev-dependencies]
 cgmath = "0.15"

--- a/examples/picking.rs
+++ b/examples/picking.rs
@@ -233,7 +233,7 @@ fn main() {
             match event {
                 glutin::Event::WindowEvent { event, .. } => match event {
                     glutin::WindowEvent::Closed => action = support::Action::Stop,
-                    glutin::WindowEvent::MouseMoved { position: (x,y), .. } => cursor_position = Some((x as i32, y as i32)),
+                    glutin::WindowEvent::CursorMoved { position: (x,y), .. } => cursor_position = Some((x as i32, y as i32)),
                     ev => camera.process_input(&ev),
                 },
                 _ => (),


### PR DESCRIPTION
This closes #1648, an issue originally caused by brendanzab/gl-rs#438.

This includes the winit 0.9 update. Changelog details [here](https://github.com/tomaka/winit/blob/master/CHANGELOG.md#version-090-2017-12-01).