### PR TITLE
Bump glutin -> 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ unstable = [] # used for benchmarks
 test_headless = []  # used for testing headless display
 
 [dependencies.glutin]
-version = "0.11"
+version = "0.12"
 features = []
 optional = true
 


### PR DESCRIPTION
Fixes HDPI awareness on Windows/other minor issues, [glium #1654](https://github.com/glium/glium/issues/1654)