### PR TITLE
Update dependencies & add changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Unreleased
+
+ - Updated glutin to version 0.12.
+ - Updated smallvec from version 0.4 to 0.6.
+ - Updated misc internal dependencies and dev-dependencies (lazy_static, cgmath, rand, image, gl_generator).
+
 ## Version 0.14.0 (2016-04-11)
 
  - Updated glutin to version 0.5.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,47 @@
  - Updated smallvec from version 0.4 to 0.6.
  - Updated misc internal dependencies and dev-dependencies (lazy_static, cgmath, rand, image, gl_generator).
 
+## Version 0.19.0 (2017-12-11)
+
+ - Updated glutin to version 0.11. Notably includes the [winit 0.9 update](https://github.com/tomaka/winit/blob/master/CHANGELOG.md#version-090-2017-12-01).
+ - Updated gl_generator to 0.7 (internal dependency).
+
+## Version 0.18.1 (2017-11-05)
+
+ - Fixed links pointing to tomaka/glium instead of glium/glium
+ - Various documentation updates, bugfixes, and dependency updates.
+
+## Version 0.18.0 (2017-10-15)
+
+ - Updated glutin to version 0.10.
+ - Added support for is_buffer_supported usage on all buffer types.
+ - Various documentation updates and bugfixes.
+
+## Version 0.17.1 (2017-08-27)
+
+ - Changed documentation to docs.rs.
+ - Various bugfixes and updates to internal dependencies.
+
+## Version 0.17.0 (2017-07-12)
+
+ - Updated glutin to version 0.9.
+ - Redesigned API around EventsLoop to match updated winit design.
+ - Added support for vector normalization.
+ - Various bugfixes.
+
+## Version 0.16.0 (2017-01-07)
+
+ - Added asynchronous screenshot example.
+ - Updated tutorials to compile on Mac OS X.
+ - Various tutorial documentation updates.
+ - Fix buffer reads which could fail being safe.
+ - Various bugfixes.
+
+## Version 0.15.0 (2016-07-03)
+
+ - Updated glutin to version 0.6.1
+ - Various internal dependency updates.
+
 ## Version 0.14.0 (2016-04-11)
 
  - Updated glutin to version 0.5.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,22 +33,22 @@ unstable = [] # used for benchmarks
 test_headless = []  # used for testing headless display
 
 [dependencies.glutin]
-version = "0.11"
+version = "0.12"
 features = []
 optional = true
 
 [dependencies]
 backtrace = "0.3.2"
-lazy_static = "0.2"
-smallvec = "0.4.2"
+lazy_static = "1.0"
+smallvec = "0.6"
 fnv = "1.0.5"
 
 [build-dependencies]
-gl_generator = "0.7"
+gl_generator = "0.8"
 
 [dev-dependencies]
-cgmath = "0.15"
+cgmath = "0.16"
 genmesh = "0.5"
-image = "0.16"
+image = "0.18"
 obj = { version = "0.8", features = ["genmesh"] }
-rand = "0.3"
+rand = "0.4"


### PR DESCRIPTION
Dependencies updated, and noted changes:

- glutin 0.11->0.12: most notably large change, I'm assuming we're going to want to do this. There don't seem to be any incompatible API changes.
- lazy_static 0.2->1.0: same code, just stable version
- smallvec: 0.4->0.6: only changes features we don't use, this might matter for crates depending on us though it shouldn't be a hard migation if they do.
- cgmath: 0.15->0.16: no changes to features we use
- image: 0.16->0.18: substantial changes, but examples using it still work alright.
- rand 0.3->0.4: substantial changes, but examples using it still work
- gl_generator 0.7->0.8: seems to be mostly a bugfix? I'm not too familiar with this.

All the examples that worked previously on my machine still work, and all tests which passed previously still pass, so these changes seem to work. I don't have a Mac or Windows machine to test with, but I assume CI will catch anything obvious.

I went through and re-added changelog entries up to this release mostly for completeness.