### PR TITLE
Add readme tag to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ keywords = ["opengl", "gamedev"]
 categories = ["api-bindings", "rendering::graphics-api"]
 documentation = "https://docs.rs/glium"
 repository = "https://github.com/glium/glium"
+readme = "README.md"
 license = "Apache-2.0"
 build = "build/main.rs"
 exclude = ["doc", ".travis.yml", "circle.yml"]


### PR DESCRIPTION
This enables crates.io rendering the README in the crate page.