### PR TITLE
Fix rendering on dpi-scaled screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
  - Updated smallvec from version 0.4 to 0.6.
  - Updated misc internal dependencies and dev-dependencies (lazy_static, cgmath, rand, image, gl_generator).
  - Replaced the `IntoVerticesSource` trait with `Into<VerticesSource>`.
+ - Fixed [rendering bug](https://github.com/glium/glium/issues/1657) on high-DPI screens.
 
 ## Version 0.19.0 (2017-12-11)
 

--- a/src/backend/glutin/mod.rs
+++ b/src/backend/glutin/mod.rs
@@ -260,9 +260,11 @@ unsafe impl Backend for GlutinBackend {
     fn get_framebuffer_dimensions(&self) -> (u32, u32) {
         // TODO: 800x600 ?
         let gl_window = self.borrow();
+        // get_inner_size() returns size in pixels (changed in winit 0.9 - this
+        // used to return a hidpi scaled size)
         let (width, height) = gl_window.get_inner_size().unwrap_or((800, 600));
-        let scale = gl_window.hidpi_factor();
-        ((width as f32 * scale) as u32, (height as f32 * scale) as u32)
+
+        (width, height)
     }
 
     #[inline]


### PR DESCRIPTION
This accounts for a change in what `get_inner_size()` returns which changed from a dpi-scaled size to an absolute pixel size in https://github.com/tomaka/winit/commit/48902297b7bd02fc20f3ae7012074c6b93674980.

I believe this is the best local fix, as get_inner_size() seems to be (as of winit 0.9) the canonical way to get size-in-pixels of a window.

Fixes #1657.

Thanks to @FauxFaux and @spearman for isolating this issue and finding the specific commit that caused it.