### PR TITLE
Update README information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,15 @@
 # glium
 
-[![Build Status](https://travis-ci.org/glium/glium.svg?branch=master)](https://travis-ci.org/glium/glium) [![Circle CI](https://circleci.com/gh/glium/glium/tree/master.svg?style=svg)](https://circleci.com/gh/glium/glium/tree/master) [![Coverage Status](https://coveralls.io/repos/tomaka/glium/badge.svg?branch=master&service=github)](https://coveralls.io/github/tomaka/glium?branch=master)
+[![Build Status](https://travis-ci.org/glium/glium.svg?branch=master)](https://travis-ci.org/glium/glium)
+[![Coverage Status](https://coveralls.io/repos/tomaka/glium/badge.svg?branch=master&service=github)](https://coveralls.io/github/tomaka/glium?branch=master)
 
-[![](http://meritbadge.herokuapp.com/glium)](https://crates.io/crates/glium)
+[![crates.io page](http://meritbadge.herokuapp.com/glium)](https://crates.io/crates/glium)
 
-## Note to current and future Glium users: 
+## Note to current and future Glium users:
 
 Glium is [no longer actively developed by its original
 author](https://users.rust-lang.org/t/glium-post-mortem/7063). That said, PRs
-are still welcome and maintenance is continued by the surrounding community. If
-you use Glium and would be interested in seeing it moved to its own
-organisation, you can express your interest
-[here](https://github.com/glium/glium/issues/532).
+are still welcome and maintenance is continued by the surrounding community.
 
 ##
 
@@ -36,7 +34,7 @@ Its objectives:
 
 If you have some knowledge of OpenGL, the documentation and the examples should get you easily started.
 
-## [Link to a work-in-progress tutorial](http://glium.github.io/glium/book)
+## [Link to a work-in-progress tutorial](https://github.com/glium/glium/tree/master/book)
 
 ## Why should I use Glium instead of raw OpenGL calls?
 


### PR DESCRIPTION
This:
- Removes the unused CircleCI badge
- Removes reference to issue regarding moving glium to independent organization now that it is in an glium/glium
- Changes the book link to reference the up-to-date but less nicely formatted in-tree book rather than the nicely formatted but out of date website.

I hope it's alright to keep making these small metadata PRs: I definitely like using glium, and want to support it as a library, but don't have enough knowledge to actually work on the core. Hopefully keeping the extraneous stuff up to date is helpful enough.

Thank you for keeping this somewhat maintained through merging PRs while there isn't someone actively working on it!