### PR TITLE
Release version 0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## Version 0.20.0 (2018-01-22)
+
  - Updated glutin to version 0.12.
  - Updated smallvec from version 0.4 to 0.6.
  - Updated misc internal dependencies and dev-dependencies (lazy_static, cgmath, rand, image, gl_generator).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glium"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = """
 Elegant and safe OpenGL wrapper.


### PR DESCRIPTION
This releases 0.20.0 with glutin 0.12, and other changes mentioned in changelog.

I can't think of anything else breaking or otherwise to add to this unless https://github.com/glium/glium/pull/1656 is a go. If it is, I think this PR could just be delayed until that's pulled and a changelog entry is added?

Thanks!