### PR TITLE
Update: gl_generator 0.8->0.9 and fix an ignored error return from context::read_front_buffer(..)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ smallvec = "0.6"
 fnv = "1.0.5"
 
 [build-dependencies]
-gl_generator = "0.8"
+gl_generator = "0.9"
 
 [dev-dependencies]
 cgmath = "0.16"

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -525,9 +525,13 @@ impl Context {
         let rect = ::Rect { left: 0, bottom: 0, width: dimensions.0, height: dimensions.1 };
 
         let mut data = Vec::with_capacity(0);
-        ops::read(&mut ctxt, ops::Source::DefaultFramebuffer(gl::FRONT_LEFT), &rect,
+        let result = ops::read(&mut ctxt, ops::Source::DefaultFramebuffer(gl::FRONT_LEFT), &rect,
                           &mut data, false);
-        T::from_raw(Cow::Owned(data), dimensions.0, dimensions.1)
+
+        match result {
+            Ok(_) => T::from_raw(Cow::Owned(data), dimensions.0, dimensions.1),
+            Err(e) => panic!("Unable to read front buffer: {}", e),
+        }
     }
 
     /// Execute an arbitrary closure with the OpenGL context active. Useful if another


### PR DESCRIPTION
Fix: context::read_front_buffer(..) was ignoring error results passed to
it. Now it will panic with a message if stars do not line up.