### PR TITLE
Fix two compiler warnings

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -526,7 +526,8 @@ impl Context {
 
         let mut data = Vec::with_capacity(0);
         ops::read(&mut ctxt, ops::Source::DefaultFramebuffer(gl::FRONT_LEFT), &rect,
-                          &mut data, false);
+                  &mut data, false)
+            .unwrap();
         T::from_raw(Cow::Owned(data), dimensions.0, dimensions.1)
     }
 

--- a/src/texture/any.rs
+++ b/src/texture/any.rs
@@ -202,7 +202,7 @@ pub fn new_texture<'a, F: ?Sized, P>(facade: &F, format: TextureFormatRequest,
         let has_mipmaps = texture_levels > 1;
         let data = data;
         let data_raw = if let Some((_, ref data)) = data {
-            data.as_ptr() as *const _
+            data.as_ptr() as *const ::std::os::raw::c_void
         } else {
             ptr::null()
         };


### PR DESCRIPTION
* Warning 1: the type of this value must be known in this context
  (src/texture/any.rs:289:30)
  Give the raw pointer a type to fix warning that will become a hard error in
  future Rust releases.
  See https://github.com/rust-lang/rust/issues/46906

* Warning 2: unused `std::result::Result` which must be used
  (src/context/mod.rs:528:9)
  Unwrap `Result` of `ops::read` just like in other invocations of this method.