### PR TITLE
remove unnecessary build hack

### DIFF
--- a/build/main.rs
+++ b/build/main.rs
@@ -15,17 +15,8 @@ fn main() {
     textures::build_texture_file(&mut File::create(&dest.join("textures.rs")).unwrap());
     println!("cargo:rerun-if-changed=build/main.rs");
 
-
-    // There is a `#[derive(Clone)]` line in the bindings that triggers a stack overflow
-    // in rustc (https://github.com/rust-lang/rust/issues/26467).
-    // Therefore we write the bindings to memory first, then remove this line, and then copy
-    // to the file.
-    let mut gl_bindings = Vec::new();
-    generate_gl_bindings(&mut gl_bindings);
-    let gl_bindings = String::from_utf8(gl_bindings).unwrap();
-    let gl_bindings = gl_bindings.replace("#[derive(Clone)]", "");
     let mut file_output = File::create(&dest.join("gl_bindings.rs")).unwrap();
-    file_output.write_all(&gl_bindings.into_bytes()).unwrap();
+    generate_gl_bindings(&mut file_output);
 }
 
 fn generate_gl_bindings<W>(dest: &mut W) where W: Write {


### PR DESCRIPTION
with rust 1.23.0 which is stable now, this compiler stack overflow crash not occured
related to https://github.com/rust-lang/rust/issues/26467