### PR TITLE
Update to glutin 0.14 and gl_generator 0.9. Publish 0.21.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## Version 0.21.0 (2018-04-11)
+
+ - Updated glutin to version 0.14. Fixes handling of HiDPI on macOS.
+ - Updated gl_generator to version 0.9.
+
 ## Version 0.20.0 (2018-01-22)
 
  - Updated glutin to version 0.12.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glium"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = """
 Elegant and safe OpenGL wrapper.
@@ -34,7 +34,7 @@ unstable = [] # used for benchmarks
 test_headless = []  # used for testing headless display
 
 [dependencies.glutin]
-version = "0.12"
+version = "0.14"
 features = []
 optional = true
 
@@ -45,7 +45,7 @@ smallvec = "0.6"
 fnv = "1.0.5"
 
 [build-dependencies]
-gl_generator = "0.8"
+gl_generator = "0.9"
 
 [dev-dependencies]
 cgmath = "0.16"


### PR DESCRIPTION
The CHANGELOG has been updated accordingly.

Closes #1682.
Closes #1674.
Closes #1673.
Closes #1672.