### PR TITLE
Update glutin dependency to 0.17.0. Publish version 0.22.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+ - Updated glutin to version 0.16. Added 'icon_loading' feature.
+
 ## Version 0.21.0 (2018-04-11)
 
  - Updated glutin to version 0.14. Fixes handling of HiDPI on macOS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+ - Updated glutin to version 0.17.
  - Updated glutin to version 0.16. Added 'icon_loading' feature.
 
 ## Version 0.21.0 (2018-04-11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Unreleased
+## Version 0.22.0 (2018-07-02)
 
  - Updated glutin to version 0.17.
  - Updated glutin to version 0.16. Added 'icon_loading' feature.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ unstable = [] # used for benchmarks
 test_headless = []  # used for testing headless display
 
 [dependencies.glutin]
-version = "0.14"
+version = "0.16"
 features = []
 optional = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ unstable = [] # used for benchmarks
 test_headless = []  # used for testing headless display
 
 [dependencies.glutin]
-version = "0.16"
+version = "0.17"
 features = []
 optional = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ travis-ci = { repository = "glium/glium" }
 
 [features]
 default = ["glutin"]
+icon_loading = ["glutin/icon_loading"]
 unstable = [] # used for benchmarks
 test_headless = []  # used for testing headless display
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glium"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = """
 Elegant and safe OpenGL wrapper.

--- a/book/tuto-01-getting-started.md
+++ b/book/tuto-01-getting-started.md
@@ -55,7 +55,7 @@ fn main() {
 }
 ```
 
-But there is a problem: as soon as the window has been created, our main function exits and `display`'s destructor closes the window. To prevent this, we need to loop forever until we detect that a `Closed` event has been received:
+But there is a problem: as soon as the window has been created, our main function exits and `display`'s destructor closes the window. To prevent this, we need to loop forever until we detect that a `CloseRequested` event has been received:
 
 ```rust
 let mut closed = false;
@@ -64,7 +64,7 @@ while !closed {
     events_loop.poll_events(|ev| {
         match ev {
             glutin::Event::WindowEvent { event, .. } => match event {
-                glutin::WindowEvent::Closed => closed = true,
+                glutin::WindowEvent::CloseRequested => closed = true,
                 _ => (),
             },
             _ => (),
@@ -132,7 +132,7 @@ fn main() {
         events_loop.poll_events(|ev| {
             match ev {
                 glutin::Event::WindowEvent { event, .. } => match event {
-                    glutin::WindowEvent::Closed => closed = true,
+                    glutin::WindowEvent::CloseRequested => closed = true,
                     _ => (),
                 },
                 _ => (),

--- a/book/tuto-03-animated-triangle.md
+++ b/book/tuto-03-animated-triangle.md
@@ -33,7 +33,7 @@ while !closed {
     events_loop.poll_events(|event| {
         match event {
             glutin::Event::WindowEvent { event, .. } => match event {
-                glutin::WindowEvent::Closed => closed = true,
+                glutin::WindowEvent::CloseRequested => closed = true,
                 _ => ()
             },
             _ => (),
@@ -83,7 +83,7 @@ while !closed {
     events_loop.poll_events(|event| {
         match event {
             glutin::Event::WindowEvent { event, .. } => match event {
-                glutin::WindowEvent::Closed => closed = true,
+                glutin::WindowEvent::CloseRequested => closed = true,
                 _ => ()
             },
             _ => (),

--- a/examples/blitting.rs
+++ b/examples/blitting.rs
@@ -57,7 +57,7 @@ fn main() {
         events_loop.poll_events(|event| {
             match event {
                 glutin::Event::WindowEvent { event, .. } => match event {
-                    glutin::WindowEvent::Closed => action = support::Action::Stop,
+                    glutin::WindowEvent::CloseRequested => action = support::Action::Stop,
                     _ => (),
                 },
                 _ => (),

--- a/examples/deferred.rs
+++ b/examples/deferred.rs
@@ -364,7 +364,7 @@ fn main() {
         events_loop.poll_events(|event| {
             match event {
                 glutin::Event::WindowEvent { event, .. } => match event {
-                    glutin::WindowEvent::Closed => action = support::Action::Stop,
+                    glutin::WindowEvent::CloseRequested => action = support::Action::Stop,
                     _ => (),
                 },
                 _ => (),

--- a/examples/deferred.rs
+++ b/examples/deferred.rs
@@ -14,7 +14,7 @@ fn main() {
 
     let mut events_loop = glutin::EventsLoop::new();
     let window = glutin::WindowBuilder::new()
-        .with_dimensions(800, 500)
+        .with_dimensions((800, 500).into())
         .with_title("Glium Deferred Example");
     let context = glutin::ContextBuilder::new();
     let display = glium::Display::new(window, context, &events_loop).unwrap();

--- a/examples/displacement_mapping.rs
+++ b/examples/displacement_mapping.rs
@@ -221,7 +221,7 @@ fn main() {
         // polling and handling the events received by the window
         events_loop.poll_events(|event| {
             match event {
-                glutin::Event::WindowEvent { event: glutin::WindowEvent::Closed, .. } =>
+                glutin::Event::WindowEvent { event: glutin::WindowEvent::CloseRequested, .. } =>
                     action = support::Action::Stop,
                 _ => ()
             }

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -103,7 +103,7 @@ fn main() {
             Event::WindowEvent { event, window_id } =>
                 if window_id == display.gl_window().id() {
                     match event {
-                        WindowEvent::Closed => action = support::Action::Stop,
+                        WindowEvent::CloseRequested => action = support::Action::Stop,
                         WindowEvent::KeyboardInput { input, .. } => {
                             if let ElementState::Pressed = input.state {
                                 if let Some(VirtualKeyCode::Return) = input.virtual_keycode {

--- a/examples/fxaa.rs
+++ b/examples/fxaa.rs
@@ -378,7 +378,7 @@ fn main() {
             glutin::Event::WindowEvent { event, .. } => {
                 camera.process_input(&event);
                 match event {
-                    glutin::WindowEvent::Closed => action = support::Action::Stop,
+                    glutin::WindowEvent::CloseRequested => action = support::Action::Stop,
                     glutin::WindowEvent::KeyboardInput { input, .. } => match input.state {
                         glutin::ElementState::Pressed => match input.virtual_keycode {
                             Some(glutin::VirtualKeyCode::Escape) => action = support::Action::Stop,

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -159,7 +159,7 @@ fn main() {
         events_loop.poll_events(|event| {
             match event {
                 glutin::Event::WindowEvent { event, .. } => match event {
-                    glutin::WindowEvent::Closed => action = support::Action::Stop,
+                    glutin::WindowEvent::CloseRequested => action = support::Action::Stop,
                     _ => ()
                 },
                 _ => (),

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -125,7 +125,7 @@ fn main() {
         events_loop.poll_events(|event| {
             match event {
                 glutin::Event::WindowEvent { event, .. } => match event {
-                    glutin::WindowEvent::Closed => action = support::Action::Stop,
+                    glutin::WindowEvent::CloseRequested => action = support::Action::Stop,
                     _ => (),
                 },
                 _ => (),

--- a/examples/manual-creation.rs
+++ b/examples/manual-creation.rs
@@ -95,7 +95,7 @@ fn main() {
     events_loop.run_forever(|event| {
         match event {
             glutin::Event::WindowEvent { event, .. } => match event {
-                glutin::WindowEvent::Closed => return glutin::ControlFlow::Break,
+                glutin::WindowEvent::CloseRequested => return glutin::ControlFlow::Break,
                 _ => (),
             },
             _ => (),

--- a/examples/manual-creation.rs
+++ b/examples/manual-creation.rs
@@ -56,7 +56,7 @@ fn main() {
         // the whole window
         fn get_framebuffer_dimensions(&self) -> (u32, u32) {
             // we default to a dummy value is the window no longer exists
-            self.gl_window.get_inner_size().unwrap_or((128, 128))
+            self.gl_window.get_inner_size().map(Into::into).unwrap_or((128, 128))
         }
 
         fn is_current(&self) -> bool {

--- a/examples/picking.rs
+++ b/examples/picking.rs
@@ -232,7 +232,7 @@ fn main() {
         events_loop.poll_events(|event| {
             match event {
                 glutin::Event::WindowEvent { event, .. } => match event {
-                    glutin::WindowEvent::Closed => action = support::Action::Stop,
+                    glutin::WindowEvent::CloseRequested => action = support::Action::Stop,
                     glutin::WindowEvent::CursorMoved { position: (x,y), .. } => cursor_position = Some((x as i32, y as i32)),
                     ev => camera.process_input(&ev),
                 },

--- a/examples/picking.rs
+++ b/examples/picking.rs
@@ -233,7 +233,9 @@ fn main() {
             match event {
                 glutin::Event::WindowEvent { event, .. } => match event {
                     glutin::WindowEvent::CloseRequested => action = support::Action::Stop,
-                    glutin::WindowEvent::CursorMoved { position: (x,y), .. } => cursor_position = Some((x as i32, y as i32)),
+                    glutin::WindowEvent::CursorMoved { position, .. } => {
+                        cursor_position = Some(position.into());
+                    }
                     ev => camera.process_input(&ev),
                 },
                 _ => (),

--- a/examples/screenshot-asynchronous.rs
+++ b/examples/screenshot-asynchronous.rs
@@ -249,7 +249,7 @@ fn main() {
 
             match event {
                 Event::WindowEvent { event, .. } => match event {
-                    WindowEvent::Closed => closed = true,
+                    WindowEvent::CloseRequested => closed = true,
                     WindowEvent::KeyboardInput { input, .. } => {
                         if let ElementState::Pressed = input.state {
                             if let Some(VirtualKeyCode::S) = input.virtual_keycode {

--- a/examples/sprites-batching.rs
+++ b/examples/sprites-batching.rs
@@ -248,7 +248,7 @@ fn main() {
         events_loop.poll_events(|event| {
             match event {
                 glutin::Event::WindowEvent { event, .. } => match event {
-                    glutin::WindowEvent::Closed => action = support::Action::Stop,
+                    glutin::WindowEvent::CloseRequested => action = support::Action::Stop,
                     _ => ()
                 },
                 _ => (),

--- a/examples/subroutines.rs
+++ b/examples/subroutines.rs
@@ -120,7 +120,7 @@ fn main() {
         events_loop.poll_events(|event| {
             match event {
                 glutin::Event::WindowEvent { event, .. } => match event {
-                    glutin::WindowEvent::Closed => action = support::Action::Stop,
+                    glutin::WindowEvent::CloseRequested => action = support::Action::Stop,
                     _ => ()
                 },
                 _ => (),

--- a/examples/teapot.rs
+++ b/examples/teapot.rs
@@ -158,7 +158,7 @@ fn main() {
         events_loop.poll_events(|event| {
             match event {
                 glutin::Event::WindowEvent { event, .. } => match event {
-                    glutin::WindowEvent::Closed => action = support::Action::Stop,
+                    glutin::WindowEvent::CloseRequested => action = support::Action::Stop,
                     ev => camera.process_input(&ev),
                 },
                 _ => (),

--- a/examples/tessellation.rs
+++ b/examples/tessellation.rs
@@ -152,7 +152,7 @@ fn main() {
         events_loop.poll_events(|event| {
             match event {
                 glutin::Event::WindowEvent { event, .. } => match event {
-                    glutin::WindowEvent::Closed => action = support::Action::Stop,
+                    glutin::WindowEvent::CloseRequested => action = support::Action::Stop,
                     glutin::WindowEvent::KeyboardInput { input, .. } => match input.state {
                         glutin::ElementState::Pressed => match input.virtual_keycode {
                             Some(glutin::VirtualKeyCode::Up) => {

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -151,7 +151,7 @@ fn main() {
         match event {
             glutin::Event::WindowEvent { event, .. } => match event {
                 // Break from the main loop when the window is closed.
-                glutin::WindowEvent::Closed => return glutin::ControlFlow::Break,
+                glutin::WindowEvent::CloseRequested => return glutin::ControlFlow::Break,
                 // Redraw the triangle when the window is resized.
                 glutin::WindowEvent::Resized(..) => draw(),
                 _ => (),

--- a/examples/tutorial-01.rs
+++ b/examples/tutorial-01.rs
@@ -17,7 +17,7 @@ fn main() {
         events_loop.poll_events(|ev| {
             match ev {
                 glutin::Event::WindowEvent { event, .. } => match event {
-                    glutin::WindowEvent::Closed => closed = true,
+                    glutin::WindowEvent::CloseRequested => closed = true,
                     _ => (),
                 },
                 _ => (),

--- a/examples/tutorial-02.rs
+++ b/examples/tutorial-02.rs
@@ -57,7 +57,7 @@ fn main() {
         events_loop.poll_events(|event| {
             match event {
                 glutin::Event::WindowEvent { event, .. } => match event {
-                    glutin::WindowEvent::Closed => closed = true,
+                    glutin::WindowEvent::CloseRequested => closed = true,
                     _ => ()
                 },
                 _ => (),

--- a/examples/tutorial-03.rs
+++ b/examples/tutorial-03.rs
@@ -68,7 +68,7 @@ fn main() {
         events_loop.poll_events(|event| {
             match event {
                 glutin::Event::WindowEvent { event, .. } => match event {
-                    glutin::WindowEvent::Closed => closed = true,
+                    glutin::WindowEvent::CloseRequested => closed = true,
                     _ => ()
                 },
                 _ => (),

--- a/examples/tutorial-04.rs
+++ b/examples/tutorial-04.rs
@@ -76,7 +76,7 @@ fn main() {
         events_loop.poll_events(|event| {
             match event {
                 glutin::Event::WindowEvent { event, .. } => match event {
-                    glutin::WindowEvent::Closed => closed = true,
+                    glutin::WindowEvent::CloseRequested => closed = true,
                     _ => ()
                 },
                 _ => (),

--- a/examples/tutorial-05.rs
+++ b/examples/tutorial-05.rs
@@ -79,7 +79,7 @@ fn main() {
         events_loop.poll_events(|event| {
             match event {
                 glutin::Event::WindowEvent { event, .. } => match event {
-                    glutin::WindowEvent::Closed => closed = true,
+                    glutin::WindowEvent::CloseRequested => closed = true,
                     _ => ()
                 },
                 _ => (),

--- a/examples/tutorial-06.rs
+++ b/examples/tutorial-06.rs
@@ -93,7 +93,7 @@ fn main() {
         events_loop.poll_events(|event| {
             match event {
                 glutin::Event::WindowEvent { event, .. } => match event {
-                    glutin::WindowEvent::Closed => closed = true,
+                    glutin::WindowEvent::CloseRequested => closed = true,
                     _ => ()
                 },
                 _ => (),

--- a/examples/tutorial-07.rs
+++ b/examples/tutorial-07.rs
@@ -62,7 +62,7 @@ fn main() {
         events_loop.poll_events(|event| {
             match event {
                 glutin::Event::WindowEvent { event, .. } => match event {
-                    glutin::WindowEvent::Closed => closed = true,
+                    glutin::WindowEvent::CloseRequested => closed = true,
                     _ => ()
                 },
                 _ => (),

--- a/examples/tutorial-08.rs
+++ b/examples/tutorial-08.rs
@@ -73,7 +73,7 @@ fn main() {
         events_loop.poll_events(|event| {
             match event {
                 glutin::Event::WindowEvent { event, .. } => match event {
-                    glutin::WindowEvent::Closed => closed = true,
+                    glutin::WindowEvent::CloseRequested => closed = true,
                     _ => ()
                 },
                 _ => (),

--- a/examples/tutorial-09.rs
+++ b/examples/tutorial-09.rs
@@ -81,7 +81,7 @@ fn main() {
         events_loop.poll_events(|event| {
             match event {
                 glutin::Event::WindowEvent { event, .. } => match event {
-                    glutin::WindowEvent::Closed => closed = true,
+                    glutin::WindowEvent::CloseRequested => closed = true,
                     _ => ()
                 },
                 _ => (),

--- a/examples/tutorial-10.rs
+++ b/examples/tutorial-10.rs
@@ -101,7 +101,7 @@ fn main() {
         events_loop.poll_events(|event| {
             match event {
                 glutin::Event::WindowEvent { event, .. } => match event {
-                    glutin::WindowEvent::Closed => closed = true,
+                    glutin::WindowEvent::CloseRequested => closed = true,
                     _ => ()
                 },
                 _ => (),

--- a/examples/tutorial-12.rs
+++ b/examples/tutorial-12.rs
@@ -106,7 +106,7 @@ fn main() {
         events_loop.poll_events(|event| {
             match event {
                 glutin::Event::WindowEvent { event, .. } => match event {
-                    glutin::WindowEvent::Closed => closed = true,
+                    glutin::WindowEvent::CloseRequested => closed = true,
                     _ => ()
                 },
                 _ => (),

--- a/examples/tutorial-13.rs
+++ b/examples/tutorial-13.rs
@@ -118,7 +118,7 @@ fn main() {
         events_loop.poll_events(|event| {
             match event {
                 glutin::Event::WindowEvent { event, .. } => match event {
-                    glutin::WindowEvent::Closed => closed = true,
+                    glutin::WindowEvent::CloseRequested => closed = true,
                     _ => ()
                 },
                 _ => (),

--- a/examples/tutorial-14.rs
+++ b/examples/tutorial-14.rs
@@ -169,7 +169,7 @@ fn main() {
         events_loop.poll_events(|event| {
             match event {
                 glutin::Event::WindowEvent { event, .. } => match event {
-                    glutin::WindowEvent::Closed => closed = true,
+                    glutin::WindowEvent::CloseRequested => closed = true,
                     _ => ()
                 },
                 _ => (),

--- a/src/backend/glutin/mod.rs
+++ b/src/backend/glutin/mod.rs
@@ -258,12 +258,12 @@ unsafe impl Backend for GlutinBackend {
 
     #[inline]
     fn get_framebuffer_dimensions(&self) -> (u32, u32) {
-        // TODO: 800x600 ?
         let gl_window = self.borrow();
-        // get_inner_size() returns size in pixels (changed in winit 0.9 - this
-        // used to return a hidpi scaled size)
-        let (width, height) = gl_window.get_inner_size().map(Into::into).unwrap_or((800, 600));
-
+        let (width, height) = gl_window.get_inner_size()
+            .map(|logical_size| logical_size.to_physical(gl_window.get_hidpi_factor()))
+            .map(Into::into)
+            // TODO: 800x600 ?
+            .unwrap_or((800, 600));
         (width, height)
     }
 

--- a/src/backend/glutin/mod.rs
+++ b/src/backend/glutin/mod.rs
@@ -173,7 +173,7 @@ impl Display {
         // If the size of the framebuffer has changed, resize the context.
         if self.last_framebuffer_dimensions.get() != (w, h) {
             self.last_framebuffer_dimensions.set((w, h));
-            self.gl_window.borrow().resize(w, h);
+            self.gl_window.borrow().resize((w, h).into());
         }
 
         Frame::new(self.context.clone(), (w, h))
@@ -262,7 +262,7 @@ unsafe impl Backend for GlutinBackend {
         let gl_window = self.borrow();
         // get_inner_size() returns size in pixels (changed in winit 0.9 - this
         // used to return a hidpi scaled size)
-        let (width, height) = gl_window.get_inner_size().unwrap_or((800, 600));
+        let (width, height) = gl_window.get_inner_size().map(Into::into).unwrap_or((800, 600));
 
         (width, height)
     }


### PR DESCRIPTION
This supersedes #1689, adding the necessary changes for `0.17` on top of @senet4er's existing work for updating to `0.16`.

The primary relevant upstream changes are the winit version `0.15` and `0.16` changes - see the [CHANGELOG](https://github.com/tomaka/winit/blob/v0.16.0/CHANGELOG.md#version-0160-2018-06-25) here.

Closes #1689.