### PR TITLE
Fix UBO name lookup on OpenGL ES 3.0

### DIFF
--- a/src/context/capabilities.rs
+++ b/src/context/capabilities.rs
@@ -489,7 +489,9 @@ pub unsafe fn get_capabilities(gl: &gl::Gl, version: &Version, extensions: &Exte
         },
 
         max_indexed_uniform_buffer: {
-            if version >= &Version(Api::Gl, 3, 1) || extensions.gl_arb_uniform_buffer_object {      // TODO: GLES
+            if version >= &Version(Api::Gl, 3, 1) ||
+               version >= &Version(Api::GlEs, 3, 0) ||
+               extensions.gl_arb_uniform_buffer_object {
                 let mut val = mem::uninitialized();
                 gl.GetIntegerv(gl::MAX_UNIFORM_BUFFER_BINDINGS, &mut val);
                 val

--- a/src/program/reflection.rs
+++ b/src/program/reflection.rs
@@ -460,8 +460,19 @@ pub unsafe fn reflect_uniform_blocks(ctxt: &mut CommandContext, program: Handle)
         {
             let mut name_tmp: Vec<u8> = Vec::with_capacity(1 + name_len as usize);
             let mut name_len_tmp = name_len;
+            // Supported on both OpenGL and GLES 3.0
+            ctxt.gl.GetActiveUniform(program,
+                                     index,
+                                     name_len,
+                                     &mut name_len_tmp,
+                                     ptr::null_mut(),
+                                     ptr::null_mut(),
+                                     name_tmp.as_mut_ptr() as *mut gl::types::GLchar
+            );
+            /*
             ctxt.gl.GetActiveUniformName(program, index, name_len, &mut name_len_tmp,
                                          name_tmp.as_mut_ptr() as *mut gl::types::GLchar);
+                                         */
             name_tmp.set_len(name_len_tmp as usize);
 
             String::from_utf8(name_tmp).unwrap()


### PR DESCRIPTION
`GetActiveUniformName` Fails on OpenGL ES 3.0. This function is specified in [ARB_uniform_buffer_object](https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_uniform_buffer_object.txt) which is in Core OpenGL since version 3.1, but isn't available on OpenGL ES.

`GetActiveUniform` provides same information, and is in both OpenGL ( Version 2.1+ [SPEC](https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/) ) and OpenGL ES 3.0 ( [SPEC](https://www.khronos.org/registry/OpenGL-Refpages/es3.0/) )

Test behavior with changes is same on my machine, all but few tests pass. 
Testing with ```cargo test -- --test-threads=1 --skip primitive_bounding_box --skip empty_stenciltexture1d --skip empty_stenciltexture2d --skip transform_feedback```