### PR TITLE
Bump to glutin 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ unstable = [] # used for benchmarks
 test_headless = []  # used for testing headless display
 
 [dependencies.glutin]
-version = "0.17"
+version = "0.18"
 features = []
 optional = true
 

--- a/src/backend/glutin/mod.rs
+++ b/src/backend/glutin/mod.rs
@@ -246,6 +246,7 @@ unsafe impl Backend for GlutinBackend {
     fn swap_buffers(&self) -> Result<(), SwapBuffersError> {
         match self.borrow().swap_buffers() {
             Ok(()) => Ok(()),
+            Err(glutin::ContextError::OsError(s)) => panic!("Error while swapping buffers: {:?}", s),
             Err(glutin::ContextError::IoError(e)) => panic!("Error while swapping buffers: {:?}", e),
             Err(glutin::ContextError::ContextLost) => Err(SwapBuffersError::ContextLost),
         }


### PR DESCRIPTION
Added `OsError` variant to `ContextError` to match the change in glutin (https://github.com/tomaka/glutin/commit/3a0854ce2104dcf1549d7c46959154e02dbba347#diff-b4aea3e418ccdb71239b96952d9cddb6).

Please review carefully as I'm just a package maintainer, not  a Rust developer.