### PR TITLE
Update use of with_dimensions in the documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ fn main() {
     let mut events_loop = glium::glutin::EventsLoop::new();
     // 2. Parameters for building the Window.
     let window = glium::glutin::WindowBuilder::new()
-        .with_dimensions(1024, 768)
+        .with_dimensions((1024, 768).into())
         .with_title("Hello world");
     // 3. Parameters for building the OpenGL context.
     let context = glium::glutin::ContextBuilder::new();


### PR DESCRIPTION
With update to Glutin 0.17 and hence winit 0.16, the API for
with_dimensions changed. Update the example to reflect this.