### PR TITLE
Update glutin dependency to 0.19.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 
-## Version 0.23.0 (2018-10-22)
+## Version 0.23.0 (2018-12-05)
 
- - Updated glutin to version 0.18.
+ - Updated glutin to version 0.19. See the glutin release notes [here](https://github.com/tomaka/glutin/blob/master/CHANGELOG.md#version-0190-2018-11-09).
 
 ## Version 0.22.0 (2018-07-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Version 0.23.0 (2018-10-22)
+
+ - Updated glutin to version 0.18.
+
 ## Version 0.22.0 (2018-07-02)
 
  - Updated glutin to version 0.17.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ unstable = [] # used for benchmarks
 test_headless = []  # used for testing headless display
 
 [dependencies.glutin]
-version = "0.18"
+version = "0.19"
 features = []
 optional = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glium"
-version = "0.22.0"
+version = "0.23.0"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = """
 Elegant and safe OpenGL wrapper.
@@ -35,7 +35,7 @@ unstable = [] # used for benchmarks
 test_headless = []  # used for testing headless display
 
 [dependencies.glutin]
-version = "0.17"
+version = "0.18"
 features = []
 optional = true
 

--- a/examples/gpgpu.rs
+++ b/examples/gpgpu.rs
@@ -4,9 +4,10 @@ extern crate rand;
 use glium::glutin;
 
 fn main() {
-
-    let context = glutin::HeadlessRendererBuilder::new(1024, 1024).build().unwrap();
-    let display = glium::HeadlessRenderer::new(context).unwrap();
+    let event_loop = glium::glutin::EventsLoop::new();
+    let context_builder = glutin::ContextBuilder::new();
+    let context = glutin::Context::new(&event_loop, context_builder, false).unwrap();
+    let display = glium::backend::glutin::headless::Headless::new(context).unwrap();
 
     let program = glium::program::ComputeShader::from_source(&display, r#"\
 

--- a/examples/manual-creation.rs
+++ b/examples/manual-creation.rs
@@ -43,6 +43,7 @@ fn main() {
             match self.gl_window.swap_buffers() {
                 Ok(()) => Ok(()),
                 Err(glutin::ContextError::IoError(_)) => panic!(),
+                Err(glutin::ContextError::OsError(_)) => panic!(),
                 Err(glutin::ContextError::ContextLost) => Err(glium::SwapBuffersError::ContextLost),
             }
         }

--- a/src/backend/glutin/headless.rs
+++ b/src/backend/glutin/headless.rs
@@ -14,11 +14,11 @@ use super::glutin::GlContext;
 /// A headless glutin context.
 pub struct Headless {
     context: Rc<context::Context>,
-    glutin: Rc<glutin::HeadlessContext>,
+    glutin: Rc<glutin::Context>,
 }
 
 /// An implementation of the `Backend` trait for a glutin headless context.
-pub struct GlutinBackend(Rc<glutin::HeadlessContext>);
+pub struct GlutinBackend(Rc<glutin::Context>);
 
 impl Deref for Headless {
     type Target = context::Context;
@@ -28,8 +28,8 @@ impl Deref for Headless {
 }
 
 impl Deref for GlutinBackend {
-    type Target = glutin::HeadlessContext;
-    fn deref(&self) -> &glutin::HeadlessContext {
+    type Target = glutin::Context;
+    fn deref(&self) -> &glutin::Context {
         &self.0
     }
 }
@@ -73,7 +73,7 @@ impl Headless {
     ///
     /// Performs a compatibility check to make sure that all core elements of glium are supported
     /// by the implementation.
-    pub fn new(context: glutin::HeadlessContext) -> Result<Self, IncompatibleOpenGl> {
+    pub fn new(context: glutin::Context) -> Result<Self, IncompatibleOpenGl> {
         Self::with_debug(context, Default::default())
     }
 
@@ -81,12 +81,12 @@ impl Headless {
     ///
     /// This function does the same as `build_glium`, except that the resulting context
     /// will assume that the current OpenGL context will never change.
-    pub unsafe fn unchecked(context: glutin::HeadlessContext) -> Result<Self, IncompatibleOpenGl> {
+    pub unsafe fn unchecked(context: glutin::Context) -> Result<Self, IncompatibleOpenGl> {
         Self::unchecked_with_debug(context, Default::default())
     }
 
     /// The same as the `new` constructor, but allows for specifying debug callback behaviour.
-    pub fn with_debug(context: glutin::HeadlessContext, debug: debug::DebugCallbackBehavior)
+    pub fn with_debug(context: glutin::Context, debug: debug::DebugCallbackBehavior)
         -> Result<Self, IncompatibleOpenGl>
     {
         Self::new_inner(context, debug, true)
@@ -94,7 +94,7 @@ impl Headless {
 
     /// The same as the `unchecked` constructor, but allows for specifying debug callback behaviour.
     pub unsafe fn unchecked_with_debug(
-        context: glutin::HeadlessContext,
+        context: glutin::Context,
         debug: debug::DebugCallbackBehavior,
     ) -> Result<Self, IncompatibleOpenGl>
     {
@@ -102,7 +102,7 @@ impl Headless {
     }
 
     fn new_inner(
-        context: glutin::HeadlessContext,
+        context: glutin::Context,
         debug: debug::DebugCallbackBehavior,
         checked: bool,
     ) -> Result<Self, IncompatibleOpenGl>

--- a/src/backend/glutin/mod.rs
+++ b/src/backend/glutin/mod.rs
@@ -246,7 +246,8 @@ unsafe impl Backend for GlutinBackend {
     fn swap_buffers(&self) -> Result<(), SwapBuffersError> {
         match self.borrow().swap_buffers() {
             Ok(()) => Ok(()),
-            Err(glutin::ContextError::IoError(e)) => panic!("Error while swapping buffers: {:?}", e),
+            Err(glutin::ContextError::IoError(e)) => panic!("I/O Error while swapping buffers: {:?}", e),
+            Err(glutin::ContextError::OsError(e)) => panic!("OS Error while swapping buffers: {:?}", e),
             Err(glutin::ContextError::ContextLost) => Err(SwapBuffersError::ContextLost),
         }
     }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -524,6 +524,8 @@ impl Context {
         let dimensions = self.get_framebuffer_dimensions();
         let rect = ::Rect { left: 0, bottom: 0, width: dimensions.0, height: dimensions.1 };
 
+        // FIXME: See https://github.com/glium/glium/pull/1682#issuecomment-375596152
+        // Leave it unchecked for now, it will generate warning as a reminder it needs fixing.
         let mut data = Vec::with_capacity(0);
         ops::read(&mut ctxt, ops::Source::DefaultFramebuffer(gl::FRONT_LEFT), &rect,
                           &mut data, false);


### PR DESCRIPTION
Based on @Lycowolf's #1711 branch, but updates the version to 0.19 rather than 0.18. This includes accounting for the recent consolidation of the `glutin::HeadlessContext` type into the `glutin::Context` type. I've updated the glium CHANGELOG with a link to the glutin 0.19 CHANGELOG entry for further details.

Closes #1711.
Closes #1704.

cc @Lycowolf, @daboross 