### PR TITLE
Remove `backend.is_current` assertion

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -644,7 +644,8 @@ impl ContextExt for Context {
             let backend = self.backend.borrow();
             if !backend.is_current() {
                 unsafe { backend.make_current() };
-                debug_assert!(backend.is_current());
+                // `backend.is_current` may not always be true here on macOS; see
+                // https://github.com/maps4print/azul/issues/50
             }
         }
 


### PR DESCRIPTION
Originally added in [this](https://github.com/glium/glium/commit/1913af102744d8bfd74902d8a8667d72d6f1dd74) commit, we can't always assert that `backend.is_current` is true after `backend.make_current` is called The issue seems to be an issue specifically on the later versions of macOS – likely specifically in Mojave. For more information, see [this](https://github.com/maps4print/azul/issues/50) issue.