### PR TITLE
Implement RawImage1d::from_rgb(a)

### DIFF
--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -359,6 +359,29 @@ impl<'a, P: PixelValue> Texture1dDataSource<'a> for &'a[P] where P: Copy + Clone
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1003,6 +1003,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -497,6 +497,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1532,6 +1532,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -635,6 +635,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -520,6 +520,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1095,6 +1095,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -612,6 +612,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1716,6 +1716,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1693,6 +1693,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1417,6 +1417,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1440,6 +1440,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1394,6 +1394,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1624,6 +1624,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -911,6 +911,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -934,6 +934,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1578,6 +1578,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1187,6 +1187,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -819,6 +819,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1210,6 +1210,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1463,6 +1463,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1256,6 +1256,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -451,6 +451,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1233,6 +1233,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1072,6 +1072,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1371,6 +1371,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -589,6 +589,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -842,6 +842,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -980,6 +980,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -957,6 +957,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -474,6 +474,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -382,6 +382,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1785,6 +1785,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1808,6 +1808,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1486,6 +1486,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1601,6 +1601,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1026,6 +1026,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -543,6 +543,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -888,6 +888,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -796,6 +796,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1302,6 +1302,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -727,6 +727,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -773,6 +773,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -704,6 +704,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -750,6 +750,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -658,6 +658,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1141,6 +1141,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -865,6 +865,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1348,6 +1348,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -681,6 +681,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1325,6 +1325,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1739,6 +1739,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1670,6 +1670,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1049,6 +1049,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1647,6 +1647,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1509,6 +1509,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1279,6 +1279,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -428,6 +428,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1762,6 +1762,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -405,6 +405,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1118,6 +1118,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1555,6 +1555,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1164,6 +1164,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -566,6 +566,29 @@ impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
     }
 }
 
+impl<'a, T: Clone + 'a> RawImage1d<'a, T> {
+
+    /// Builds a raw 1d image from a vector of interleaved RGB values.
+    pub fn from_raw_rgb(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 3) as u32,
+            data: Cow::Owned(data),
+            format: T::rgb_format(),
+        }
+    }
+
+    /// Builds a raw 1d image from a vector of interleaved RGBA values.
+    pub fn from_raw_rgba(data: Vec<T>) -> RawImage1d<'a, T>
+        where T: ToClientFormat {
+        RawImage1d {
+            width: (data.len() / 4) as u32,
+            data: Cow::Owned(data),
+            format: T::rgba_format(),
+        }
+    }
+}
+
 /// Trait that describes data for a two-dimensional texture.
 pub trait Texture2dDataSource<'a> {
     /// The type of each pixel.


### PR DESCRIPTION
The `from_raw_rgb`, and `from_raw_rgba` methods on `RawImage1d` provide easy
construction from a vector of pixels.

Fixes #1732