### PR TITLE
Update dependencies, unbreak examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Version 0.24.0 (2019-04-08)
+
+ - Updated glutin to version 0.20. See the glutin release notes [here](https://github.com/tomaka/glutin/blob/master/CHANGELOG.md#version-0200-2019-03-09).
+
 ## Version 0.23.0 (2018-12-05)
 
  - Updated glutin to version 0.19. See the glutin release notes [here](https://github.com/tomaka/glutin/blob/master/CHANGELOG.md#version-0190-2018-11-09).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 0.24.0 (2019-04-08)
 
  - Updated glutin to version 0.20. See the glutin release notes [here](https://github.com/tomaka/glutin/blob/master/CHANGELOG.md#version-0200-2019-03-09).
+ - Depth comparison and shadow mapping ([#1679](https://github.com/glium/glium/pull/1679)).
 
 ## Version 0.23.0 (2018-12-05)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glium"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = """
 Elegant and safe OpenGL wrapper.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ unstable = [] # used for benchmarks
 test_headless = []  # used for testing headless display
 
 [dependencies.glutin]
-version = "0.19"
+version = "0.20"
 features = []
 optional = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,11 +46,11 @@ smallvec = "0.6"
 fnv = "1.0.5"
 
 [build-dependencies]
-gl_generator = "0.10"
+gl_generator = "0.11"
 
 [dev-dependencies]
-cgmath = "0.16"
+cgmath = "0.17"
 genmesh = "0.6"
-image = "0.20"
+image = "0.21"
 obj = { version = "0.9", features = ["genmesh"] }
 rand = "0.6"

--- a/examples/gpgpu.rs
+++ b/examples/gpgpu.rs
@@ -2,11 +2,16 @@
 extern crate glium;
 extern crate rand;
 use glium::glutin;
+use glutin::dpi::PhysicalSize;
 
 fn main() {
     let event_loop = glium::glutin::EventsLoop::new();
     let context_builder = glutin::ContextBuilder::new();
-    let context = glutin::Context::new(&event_loop, context_builder, false).unwrap();
+    let size = PhysicalSize {
+        width: 800.0,
+        height: 600.0,
+    };
+    let context = glutin::Context::new_headless(&event_loop, context_builder, size).unwrap();
     let display = glium::backend::glutin::headless::Headless::new(context).unwrap();
 
     let program = glium::program::ComputeShader::from_source(&display, r#"\

--- a/examples/gpgpu.rs
+++ b/examples/gpgpu.rs
@@ -11,7 +11,7 @@ fn main() {
         width: 800.0,
         height: 600.0,
     };
-    let context = glutin::Context::new_headless(&event_loop, context_builder, size).unwrap();
+    let context = context_builder.build_headless(&event_loop, size).unwrap();
     let display = glium::backend::glutin::headless::Headless::new(context).unwrap();
 
     let program = glium::program::ComputeShader::from_source(&display, r#"\

--- a/examples/manual-creation.rs
+++ b/examples/manual-creation.rs
@@ -19,7 +19,7 @@ There are three concepts in play:
 extern crate glium;
 
 use glium::Surface;
-use glium::glutin::{self, GlContext};
+use glium::glutin::self;
 
 use std::rc::Rc;
 use std::os::raw::c_void;

--- a/examples/manual-creation.rs
+++ b/examples/manual-creation.rs
@@ -19,7 +19,7 @@ There are three concepts in play:
 extern crate glium;
 
 use glium::Surface;
-use glium::glutin::self;
+use glium::glutin::{self, ContextTrait};
 
 use std::rc::Rc;
 use std::os::raw::c_void;

--- a/examples/manual-creation.rs
+++ b/examples/manual-creation.rs
@@ -29,8 +29,8 @@ fn main() {
     // note that it's just `build` and not `build_glium`
     let mut events_loop = glutin::EventsLoop::new();
     let window = glutin::WindowBuilder::new();
-    let context = glutin::ContextBuilder::new();
-    let gl_window = Rc::new(glutin::WindowedContext::new_windowed(window, context, &events_loop).unwrap());
+    let context_builder = glutin::ContextBuilder::new();
+    let gl_window = Rc::new(context_builder.build_windowed(window, &events_loop).unwrap());
 
     // in order to create our context, we will need to provide an object which implements
     // the `Backend` trait

--- a/examples/manual-creation.rs
+++ b/examples/manual-creation.rs
@@ -30,12 +30,12 @@ fn main() {
     let mut events_loop = glutin::EventsLoop::new();
     let window = glutin::WindowBuilder::new();
     let context = glutin::ContextBuilder::new();
-    let gl_window = Rc::new(glutin::GlWindow::new(window, context, &events_loop).unwrap());
+    let gl_window = Rc::new(glutin::WindowedContext::new_windowed(window, context, &events_loop).unwrap());
 
     // in order to create our context, we will need to provide an object which implements
     // the `Backend` trait
     struct Backend {
-        gl_window: Rc<glutin::GlWindow>,
+        gl_window: Rc<glutin::WindowedContext>,
     }
 
     unsafe impl glium::backend::Backend for Backend {

--- a/examples/shadow_mapping.rs
+++ b/examples/shadow_mapping.rs
@@ -5,15 +5,19 @@ extern crate cgmath;
 use cgmath::SquareMatrix;
 use glium::{glutin, Surface};
 use std::time::Instant;
+use glutin::dpi::LogicalSize;
 
 fn main() {
-    let win_size = (800, 600);
+    let win_size = LogicalSize {
+        width: 800.0,
+        height: 600.0,
+    };
     let shadow_map_size = 1024;
 
     // Create the main window
     let mut events_loop = glutin::EventsLoop::new();
     let window = glutin::WindowBuilder::new()
-        .with_dimensions(win_size.0, win_size.1)
+        .with_dimensions(win_size)
         .with_title("Shadow Mapping");
     let context = glutin::ContextBuilder::new().with_vsync(true);
     let display = glium::Display::new(window, context, &events_loop).unwrap();
@@ -161,7 +165,7 @@ fn main() {
         // Handle events
         events_loop.poll_events(|event| match event {
             glutin::Event::WindowEvent { event, .. } => match event {
-                glutin::WindowEvent::Closed => exit = true,
+                glutin::WindowEvent::CloseRequested => exit = true,
                 glutin::WindowEvent::KeyboardInput { input, .. } => if input.state == glutin::ElementState::Pressed {
                     if let Some(key) = input.virtual_keycode {
                         match key {
@@ -227,7 +231,7 @@ fn main() {
 
         // Render the scene from the camera's point of view
         // ===============================================================================
-        let screen_ratio = (win_size.0 as f32) / (win_size.1 as f32);
+        let screen_ratio = (win_size.width / win_size.height) as f32;
         let perspective_matrix: cgmath::Matrix4<f32> = cgmath::perspective(cgmath::Deg(45.0), screen_ratio, 0.0001, 100.0);
         let camera_x = 3.0 * camera_t.cos();
         let camera_z = 3.0 * camera_t.sin();

--- a/src/backend/glutin/headless.rs
+++ b/src/backend/glutin/headless.rs
@@ -4,6 +4,7 @@ use {Frame, IncompatibleOpenGl, SwapBuffersError};
 use debug;
 use context;
 use backend::{self, Backend};
+use backend::glutin::glutin::ContextTrait;
 use std::rc::Rc;
 use std::ops::Deref;
 use std::os::raw::c_void;

--- a/src/backend/glutin/headless.rs
+++ b/src/backend/glutin/headless.rs
@@ -8,8 +8,6 @@ use std::rc::Rc;
 use std::ops::Deref;
 use std::os::raw::c_void;
 use super::glutin;
-use super::glutin::GlContext;
-
 
 /// A headless glutin context.
 pub struct Headless {

--- a/src/backend/glutin/mod.rs
+++ b/src/backend/glutin/mod.rs
@@ -67,7 +67,7 @@ impl Display {
         events_loop: &glutin::EventsLoop,
     ) -> Result<Self, DisplayCreationError>
     {
-        let gl_window = try!(glutin::WindowedContext::new_windowed(window_builder, context_builder, events_loop));
+        let gl_window = glutin::WindowedContext::new_windowed(window_builder, context_builder, events_loop)?;
         Self::from_gl_window(gl_window).map_err(From::from)
     }
 
@@ -135,7 +135,7 @@ impl Display {
         let new_gl_window = {
             let gl_window = self.gl_window.borrow();
             let context_builder = context_builder.with_shared_lists(gl_window.context());
-            try!(glutin::WindowedContext::new_windowed(window_builder, context_builder, events_loop))
+            glutin::WindowedContext::new_windowed(window_builder, context_builder, events_loop)?
         };
 
         {

--- a/src/backend/glutin/mod.rs
+++ b/src/backend/glutin/mod.rs
@@ -18,6 +18,7 @@ use context;
 use backend;
 use backend::Context;
 use backend::Backend;
+use backend::glutin::glutin::ContextTrait;
 use std;
 use std::cell::{Cell, RefCell, Ref};
 use std::error::Error;

--- a/src/backend/glutin/mod.rs
+++ b/src/backend/glutin/mod.rs
@@ -18,7 +18,6 @@ use context;
 use backend;
 use backend::Context;
 use backend::Backend;
-use glutin::GlContext;
 use std;
 use std::cell::{Cell, RefCell, Ref};
 use std::error::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ Easy-to-use, high-level, OpenGL3+ wrapper.
 Glium is based on glutin - a cross-platform crate for building an OpenGL window and handling
 application events.
 
-Glium provides a **Display** which extends the **glutin::GlWindow** with a high-level, safe API.
+Glium provides a **Display** which extends the **glutin::WindowedContext** with a high-level, safe API.
 
 # Initialization
 


### PR DESCRIPTION
This PR updates the glutin dependency to 0.20, as well as some other dependencies, so that cargo-outdated doesn't complain any more. Also, it issues a new release and unbreaks the shadow mapping example which previously failed to compile.