### PR TITLE
Lokathor removes mem::uninitialized

### DIFF
--- a/src/buffer/alloc.rs
+++ b/src/buffer/alloc.rs
@@ -1179,8 +1179,7 @@ unsafe fn create_buffer<D: ?Sized>(mut ctxt: &mut CommandContext, size: usize, d
     };
 
     // will store the actual size of the buffer so that we can compare it with the expected size
-    #[allow(deprecated)]
-    let mut obtained_size: gl::types::GLint = mem::uninitialized();
+    let mut obtained_size: gl::types::GLint = 0;
 
     // the value of `immutable` is determined below
     // if true, the buffer won't be modifiable with regular OpenGL function calls

--- a/src/buffer/alloc.rs
+++ b/src/buffer/alloc.rs
@@ -1124,8 +1124,7 @@ unsafe fn create_buffer<D: ?Sized>(mut ctxt: &mut CommandContext, size: usize, d
 
     // creating the id of the buffer
     let id = {
-        #[allow(deprecated)]
-        let mut id: gl::types::GLuint = mem::uninitialized();
+        let mut id: gl::types::GLuint = 0;
         if ctxt.version >= &Version(Api::Gl, 4, 5) || ctxt.extensions.gl_arb_direct_state_access {
             ctxt.gl.CreateBuffers(1, &mut id);
         } else if ctxt.version >= &Version(Api::Gl, 1, 5) ||

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -99,8 +99,11 @@ unsafe impl<T> Content for T where T: Copy {
     #[inline]
     fn read<F, E>(size: usize, f: F) -> Result<T, E> where F: FnOnce(&mut T) -> Result<(), E> {
         assert!(size == mem::size_of::<T>());
-        #[allow(deprecated)]
-        let mut value = unsafe { mem::uninitialized() };
+        // Note(Lokathor): This is brittle and dangerous if `T` isn't a type
+        // that can be zeroed. However, it's a breaking change to adjust the API
+        // here (eg: extra trait bound or something) so someone with more
+        // authority than me needs to look at and fix this.
+        let mut value = unsafe { mem::zeroed() };
         try!(f(&mut value));
         Ok(value)
     }

--- a/src/context/capabilities.rs
+++ b/src/context/capabilities.rs
@@ -248,7 +248,7 @@ pub unsafe fn get_capabilities(gl: &gl::Gl, version: &Version, extensions: &Exte
 
         can_lose_context: if version >= &Version(Api::Gl, 4, 5) || extensions.gl_khr_robustness ||
                              extensions.gl_arb_robustness || extensions.gl_ext_robustness
-        {0
+        {
             let mut val = 0;
             gl.GetIntegerv(gl::RESET_NOTIFICATION_STRATEGY, &mut val);
 

--- a/src/context/capabilities.rs
+++ b/src/context/capabilities.rs
@@ -170,8 +170,7 @@ pub unsafe fn get_capabilities(gl: &gl::Gl, version: &Version, extensions: &Exte
 {
     // GL_CONTEXT_FLAGS are only available from GL 3.0 onwards
     let (debug, forward_compatible) = if version >= &Version(Api::Gl, 3, 0) {
-        #[allow(deprecated)]
-        let mut val = mem::uninitialized();
+        let mut val = 0;
         gl.GetIntegerv(gl::CONTEXT_FLAGS, &mut val);
         let val = val as gl::types::GLenum;
         ((val & gl::CONTEXT_FLAG_DEBUG_BIT) != 0,
@@ -209,8 +208,7 @@ pub unsafe fn get_capabilities(gl: &gl::Gl, version: &Version, extensions: &Exte
 
         profile: {
             if version >= &Version(Api::Gl, 3, 2) {
-                #[allow(deprecated)]
-                let mut val = mem::uninitialized();
+                let mut val = 0;
                 gl.GetIntegerv(gl::CONTEXT_PROFILE_MASK, &mut val);
                 let val = val as gl::types::GLenum;
                 if (val & gl::CONTEXT_COMPATIBILITY_PROFILE_BIT) != 0 {
@@ -234,15 +232,13 @@ pub unsafe fn get_capabilities(gl: &gl::Gl, version: &Version, extensions: &Exte
         {
             // TODO: there seems to be no way to query `GL_CONTEXT_FLAGS` before OpenGL 3.0, even
             //       if `GL_ARB_robustness` is there
-            #[allow(deprecated)]
-            let mut val = mem::uninitialized();
+            let mut val = 0;
             gl.GetIntegerv(gl::CONTEXT_FLAGS, &mut val);
             let val = val as gl::types::GLenum;
             (val & gl::CONTEXT_FLAG_ROBUST_ACCESS_BIT) != 0
 
         } else if extensions.gl_khr_robustness || extensions.gl_ext_robustness {
-            #[allow(deprecated)]
-            let mut val = mem::uninitialized();
+            let mut val = 0;
             gl.GetBooleanv(gl::CONTEXT_ROBUST_ACCESS, &mut val);
             val != 0
 
@@ -252,9 +248,8 @@ pub unsafe fn get_capabilities(gl: &gl::Gl, version: &Version, extensions: &Exte
 
         can_lose_context: if version >= &Version(Api::Gl, 4, 5) || extensions.gl_khr_robustness ||
                              extensions.gl_arb_robustness || extensions.gl_ext_robustness
-        {
-            #[allow(deprecated)]
-            let mut val = mem::uninitialized();
+        {0
+            let mut val = 0;
             gl.GetIntegerv(gl::RESET_NOTIFICATION_STRATEGY, &mut val);
 
             match val as gl::types::GLenum {
@@ -277,8 +272,7 @@ pub unsafe fn get_capabilities(gl: &gl::Gl, version: &Version, extensions: &Exte
         },
 
         release_behavior: if extensions.gl_khr_context_flush_control {
-            #[allow(deprecated)]
-            let mut val = mem::uninitialized();
+            let mut val = 0;
             gl.GetIntegerv(gl::CONTEXT_RELEASE_BEHAVIOR, &mut val);
 
             match val as gl::types::GLenum {
@@ -293,8 +287,7 @@ pub unsafe fn get_capabilities(gl: &gl::Gl, version: &Version, extensions: &Exte
 
         stereo: {
             if version >= &Version(Api::Gl, 1, 0) {
-                #[allow(deprecated)]
-                let mut val: gl::types::GLboolean = mem::uninitialized();
+                let mut val: gl::types::GLboolean = 0;
                 gl.GetBooleanv(gl::STEREO, &mut val);
                 val != 0
             } else {
@@ -306,16 +299,14 @@ pub unsafe fn get_capabilities(gl: &gl::Gl, version: &Version, extensions: &Exte
             // `glGetFramebufferAttachmentParameteriv` incorrectly returns GL_INVALID_ENUM on some
             // drivers, so we prefer using `glGetIntegerv` if possible.
             if version >= &Version(Api::Gl, 3, 0) && !extensions.gl_ext_framebuffer_srgb {
-                #[allow(deprecated)]
-                let mut value = mem::uninitialized();
+                let mut value = 0;
                 gl.GetFramebufferAttachmentParameteriv(gl::FRAMEBUFFER, gl::FRONT_LEFT,
                                                        gl::FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING,
                                                        &mut value);
                 value as gl::types::GLenum == gl::SRGB
 
             } else if extensions.gl_ext_framebuffer_srgb {
-                #[allow(deprecated)]
-                let mut value = mem::uninitialized();
+                let mut value = 0;
                 gl.GetBooleanv(gl::FRAMEBUFFER_SRGB_CAPABLE_EXT, &mut value);
                 value != 0
 
@@ -325,8 +316,7 @@ pub unsafe fn get_capabilities(gl: &gl::Gl, version: &Version, extensions: &Exte
         },
 
         depth_bits: {
-            #[allow(deprecated)]
-            let mut value = mem::uninitialized();
+            let mut value = 0;
 
             // `glGetFramebufferAttachmentParameteriv` incorrectly returns GL_INVALID_ENUM on some
             // drivers, so we prefer using `glGetIntegerv` if possible.
@@ -335,8 +325,7 @@ pub unsafe fn get_capabilities(gl: &gl::Gl, version: &Version, extensions: &Exte
             // doesn't even though it provides this extension. I'm not sure whether this is a bug
             // with OS/X or just the extension actually not providing it.
             if version >= &Version(Api::Gl, 3, 0) && !extensions.gl_arb_compatibility {
-                #[allow(deprecated)]
-                let mut ty = mem::uninitialized();
+                let mut ty = 0;
                 gl.GetFramebufferAttachmentParameteriv(gl::FRAMEBUFFER, gl::DEPTH,
                                                        gl::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE,
                                                        &mut ty);
@@ -360,8 +349,7 @@ pub unsafe fn get_capabilities(gl: &gl::Gl, version: &Version, extensions: &Exte
         },
 
         stencil_bits: {
-            #[allow(deprecated)]
-            let mut value = mem::uninitialized();
+            let mut value = 0;
 
             // `glGetFramebufferAttachmentParameteriv` incorrectly returns GL_INVALID_ENUM on some
             // drivers, so we prefer using `glGetIntegerv` if possible.
@@ -370,8 +358,7 @@ pub unsafe fn get_capabilities(gl: &gl::Gl, version: &Version, extensions: &Exte
             // doesn't even though it provides this extension. I'm not sure whether this is a bug
             // with OS/X or just the extension actually not providing it.
             if version >= &Version(Api::Gl, 3, 0) && !extensions.gl_arb_compatibility {
-                #[allow(deprecated)]
-                let mut ty = mem::uninitialized();
+                let mut ty = 0;
                 gl.GetFramebufferAttachmentParameteriv(gl::FRAMEBUFFER, gl::STENCIL,
                                                        gl::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE,
                                                        &mut ty);
@@ -415,8 +402,7 @@ pub unsafe fn get_capabilities(gl: &gl::Gl, version: &Version, extensions: &Exte
 
         } else {
             Some({
-                #[allow(deprecated)]
-                let mut val = mem::uninitialized();
+                let mut val = 0.0;
                 gl.GetFloatv(gl::MAX_TEXTURE_MAX_ANISOTROPY_EXT, &mut val);
                 val
             })
@@ -428,8 +414,7 @@ pub unsafe fn get_capabilities(gl: &gl::Gl, version: &Version, extensions: &Exte
                extensions.gl_ext_texture_buffer
             {
                 Some({
-                    #[allow(deprecated)]
-                    let mut val = mem::uninitialized();
+                    let mut val = 0;
                     gl.GetIntegerv(gl::MAX_TEXTURE_BUFFER_SIZE, &mut val);
                     val
                 })
@@ -462,8 +447,7 @@ pub unsafe fn get_capabilities(gl: &gl::Gl, version: &Version, extensions: &Exte
             extensions.gl_arb_tessellation_shader
         {
             Some({
-                #[allow(deprecated)]
-                let mut val = mem::uninitialized();
+                let mut val = 0;
                 gl.GetIntegerv(gl::MAX_PATCH_VERTICES, &mut val);
                 val
             })
@@ -473,8 +457,7 @@ pub unsafe fn get_capabilities(gl: &gl::Gl, version: &Version, extensions: &Exte
         },
 
         max_indexed_atomic_counter_buffer: if version >= &Version(Api::Gl, 4, 2) {      // TODO: ARB_shader_atomic_counters   // TODO: GLES
-            #[allow(deprecated)]
-            let mut val = mem::uninitialized();
+            let mut val = 0;
             gl.GetIntegerv(gl::MAX_ATOMIC_COUNTER_BUFFER_BINDINGS, &mut val);
             val
         } else {
@@ -483,8 +466,7 @@ pub unsafe fn get_capabilities(gl: &gl::Gl, version: &Version, extensions: &Exte
 
         max_indexed_shader_storage_buffer: {
             if version >= &Version(Api::Gl, 4, 3) || extensions.gl_arb_shader_storage_buffer_object {      // TODO: GLES
-                #[allow(deprecated)]
-                let mut val = mem::uninitialized();
+                let mut val = 0;
                 gl.GetIntegerv(gl::MAX_SHADER_STORAGE_BUFFER_BINDINGS, &mut val);
                 val
             } else {
@@ -494,13 +476,11 @@ pub unsafe fn get_capabilities(gl: &gl::Gl, version: &Version, extensions: &Exte
 
         max_indexed_transform_feedback_buffer: {
             if version >= &Version(Api::Gl, 4, 0) || extensions.gl_arb_transform_feedback3 {      // TODO: GLES
-                #[allow(deprecated)]
-                let mut val = mem::uninitialized();
+                let mut val = 0;
                 gl.GetIntegerv(gl::MAX_TRANSFORM_FEEDBACK_BUFFERS, &mut val);
                 val
             } else if version >= &Version(Api::Gl, 3, 0) || extensions.gl_ext_transform_feedback {
-                #[allow(deprecated)]
-                let mut val = mem::uninitialized();
+                let mut val = 0;
                 gl.GetIntegerv(gl::MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS_EXT, &mut val);
                 val
             } else {
@@ -510,8 +490,7 @@ pub unsafe fn get_capabilities(gl: &gl::Gl, version: &Version, extensions: &Exte
 
         max_indexed_uniform_buffer: {
             if version >= &Version(Api::Gl, 3, 1) || extensions.gl_arb_uniform_buffer_object {      // TODO: GLES
-                #[allow(deprecated)]
-                let mut val = mem::uninitialized();
+                let mut val = 0;
                 gl.GetIntegerv(gl::MAX_UNIFORM_BUFFER_BINDINGS, &mut val);
                 val
             } else {
@@ -523,12 +502,9 @@ pub unsafe fn get_capabilities(gl: &gl::Gl, version: &Version, extensions: &Exte
                                          version >= &Version(Api::GlEs, 3, 1) ||
                                          extensions.gl_arb_compute_shader
         {
-            #[allow(deprecated)]
-            let mut val1 = mem::uninitialized();
-            #[allow(deprecated)]
-            let mut val2 = mem::uninitialized();
-            #[allow(deprecated)]
-            let mut val3 = mem::uninitialized();
+            let mut val1 = 0;
+            let mut val2 = 0;
+            let mut val3 = 0;
             gl.GetIntegeri_v(gl::MAX_COMPUTE_WORK_GROUP_COUNT, 0, &mut val1);
             gl.GetIntegeri_v(gl::MAX_COMPUTE_WORK_GROUP_COUNT, 1, &mut val2);
             gl.GetIntegeri_v(gl::MAX_COMPUTE_WORK_GROUP_COUNT, 2, &mut val3);
@@ -625,8 +601,7 @@ pub unsafe fn get_supported_glsl(gl: &gl::Gl, version: &Version, extensions: &Ex
     // checking if the implementation has a shader compiler
     // a compiler is optional in OpenGL ES
     if version.0 == Api::GlEs {
-        #[allow(deprecated)]
-        let mut val = mem::uninitialized();
+        let mut val = 0;
         gl.GetBooleanv(gl::SHADER_COMPILER, &mut val);
         if val == 0 {
             return vec![];
@@ -749,8 +724,7 @@ pub fn get_internal_format(gl: &gl::Gl, version: &Version, extensions: &Extensio
                           version >= &Version(Api::Gl, 4, 2) ||
                           extensions.gl_arb_internalformat_query)
         {
-            #[allow(deprecated)]
-            let mut num = mem::uninitialized();
+            let mut num = 0;
             gl.GetInternalformativ(target, format.to_glenum(), gl::NUM_SAMPLE_COUNTS, 1, &mut num);
 
             if num >= 1 {

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -484,8 +484,7 @@ impl Context {
         unsafe {
             let ctxt = self.make_current();
 
-            #[allow(deprecated)]
-            let mut value: [gl::types::GLint; 4] = mem::uninitialized();
+            let mut value: [gl::types::GLint; 4] = [0; 4];
 
             if ctxt.extensions.gl_nvx_gpu_memory_info {
                 ctxt.gl.GetIntegerv(gl::GPU_MEMORY_INFO_CURRENT_AVAILABLE_VIDMEM_NVX,

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -128,8 +128,7 @@ impl TimestampQuery {
 
         let id = if ctxt.version >= &Version(Api::Gl, 3, 2) {    // TODO: extension
             unsafe {
-                #[allow(deprecated)]
-                let mut id = mem::uninitialized();
+                let mut id = 0;
                 ctxt.gl.GenQueries(1, &mut id);
 
                 ctxt.gl.QueryCounter(id, gl::TIMESTAMP);
@@ -139,8 +138,7 @@ impl TimestampQuery {
 
         } else if ctxt.extensions.gl_ext_disjoint_timer_query {
             unsafe {
-                #[allow(deprecated)]
-                let mut id = mem::uninitialized();
+                let mut id = 0;
                 ctxt.gl.GenQueriesEXT(1, &mut id);
 
                 ctxt.gl.QueryCounterEXT(id, gl::TIMESTAMP);
@@ -167,16 +165,14 @@ impl TimestampQuery {
 
         if ctxt.version >= &Version(Api::Gl, 3, 2) {    // TODO: extension
             unsafe {
-                #[allow(deprecated)]
-                let mut value = mem::uninitialized();
+                let mut value = 0;
                 ctxt.gl.GetQueryObjectiv(self.id, gl::QUERY_RESULT_AVAILABLE, &mut value);
                 value != 0
             }
 
         } else if ctxt.extensions.gl_ext_disjoint_timer_query {
             unsafe {
-                #[allow(deprecated)]
-                let mut value = mem::uninitialized();
+                let mut value = 0;
                 ctxt.gl.GetQueryObjectivEXT(self.id, gl::QUERY_RESULT_AVAILABLE_EXT, &mut value);
                 value != 0
             }
@@ -194,8 +190,7 @@ impl TimestampQuery {
 
         if ctxt.version >= &Version(Api::Gl, 3, 2) {    // TODO: extension
             unsafe {
-                #[allow(deprecated)]
-                let mut value = mem::uninitialized();
+                let mut value = 0;
                 ctxt.gl.GetQueryObjectui64v(self.id, gl::QUERY_RESULT, &mut value);
                 ctxt.gl.DeleteQueries(1, [self.id].as_ptr());
                 value
@@ -203,8 +198,7 @@ impl TimestampQuery {
 
         } else if ctxt.extensions.gl_ext_disjoint_timer_query {
             unsafe {
-                #[allow(deprecated)]
-                let mut value = mem::uninitialized();
+                let mut value = 0;
                 ctxt.gl.GetQueryObjectui64vEXT(self.id, gl::QUERY_RESULT_EXT, &mut value);
                 ctxt.gl.DeleteQueriesEXT(1, [self.id].as_ptr());
                 value

--- a/src/draw_parameters/mod.rs
+++ b/src/draw_parameters/mod.rs
@@ -598,8 +598,7 @@ fn sync_polygon_mode(ctxt: &mut context::CommandContext, backface_culling: Backf
 fn sync_clip_planes_bitmask(ctxt: &mut context::CommandContext, clip_planes_bitmask: u32)
                             -> Result<(), DrawError> {
     unsafe {
-        #[allow(deprecated)]
-        let mut max_clip_planes: gl::types::GLint = mem::uninitialized();
+        let mut max_clip_planes: gl::types::GLint = 0;
         ctxt.gl.GetIntegerv(gl::MAX_CLIP_DISTANCES, &mut max_clip_planes);
         for i in 0..32 {
             if clip_planes_bitmask & (1 << i) != 0 {

--- a/src/draw_parameters/query.rs
+++ b/src/draw_parameters/query.rs
@@ -114,8 +114,7 @@ impl RawQuery {
         // FIXME: handle Timestamp separately
 
         let id = unsafe {
-            #[allow(deprecated)]
-            let mut id = mem::uninitialized();
+            let mut id = 0;
 
             if ctxt.version >= &Version(Api::Gl, 3, 3) {
                 match ty {
@@ -212,8 +211,7 @@ impl RawQuery {
         Buffer::<u8>::unbind_query(&mut ctxt);
 
         unsafe {
-            #[allow(deprecated)]
-            let mut value = mem::uninitialized();
+            let mut value = 0;
 
             if ctxt.version >= &Version(Api::Gl, 1, 5) ||
                ctxt.version >= &Version(Api::GlEs, 3, 0)
@@ -250,8 +248,7 @@ impl RawQuery {
         Buffer::<u8>::unbind_query(&mut ctxt);
 
         unsafe {
-            #[allow(deprecated)]
-            let mut value = mem::uninitialized();
+            let mut value = 0;
             self.raw_get_u32(&mut ctxt, &mut value);
             value
         }
@@ -316,14 +313,12 @@ impl RawQuery {
         Buffer::<u8>::unbind_query(&mut ctxt);
 
         unsafe {
-            #[allow(deprecated)]
-            let mut value = mem::uninitialized();
+            let mut value = 0;
             if let Ok(_) = self.raw_get_u64(&mut ctxt, &mut value) {
                 return value;
             }
 
-            #[allow(deprecated)]
-            let mut value = mem::uninitialized();
+            let mut value = 0;
             self.raw_get_u32(&mut ctxt, &mut value);
             value as u64
         }

--- a/src/fbo.rs
+++ b/src/fbo.rs
@@ -965,8 +965,7 @@ impl FrameBufferObject {
 
         // building the FBO
         let id = unsafe {
-            #[allow(deprecated)]
-            let mut id = mem::uninitialized();
+            let mut id = 0;
 
             if ctxt.version >= &Version(Api::Gl, 4, 5) ||
                 ctxt.extensions.gl_arb_direct_state_access

--- a/src/framebuffer/render_buffer.rs
+++ b/src/framebuffer/render_buffer.rs
@@ -288,8 +288,7 @@ impl RenderBufferAny {
             // TODO: check that dimensions don't exceed GL_MAX_RENDERBUFFER_SIZE
             // FIXME: gles2 only supports very few formats
             let mut ctxt = facade.get_context().make_current();
-            #[allow(deprecated)]
-            let mut id = mem::uninitialized();
+            let mut id = 0;
 
             if ctxt.version >= &Version(Api::Gl, 4, 5) ||
                ctxt.extensions.gl_arb_direct_state_access
@@ -434,10 +433,8 @@ impl RenderBufferAny {
     pub fn get_depth_stencil_bits(&self) -> (u16, u16) {
         unsafe {
             let ctxt = self.context.make_current();
-            #[allow(deprecated)]
-            let mut depth_bits: gl::types::GLint = mem::uninitialized();
-            #[allow(deprecated)]
-            let mut stencil_bits: gl::types::GLint = mem::uninitialized();
+            let mut depth_bits: gl::types::GLint = 0;
+            let mut stencil_bits: gl::types::GLint = 0;
             ctxt.gl.BindRenderbuffer(gl::RENDERBUFFER, self.id);
             // FIXME: GL version considerations
             ctxt.gl.GetRenderbufferParameteriv(gl::RENDERBUFFER, gl::RENDERBUFFER_DEPTH_SIZE, &mut depth_bits);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -119,7 +119,7 @@ macro_rules! implement_vertex {
                                   // dangerous and needs to be fixed more in the
                                   // future. Basically, the problem is that the
                                   // struct might not be allowed to be all
-                                  // zeroes. At least it's safe than uninitialized().
+                                  // zeroes. At least it's safer than uninitialized().
                                   ::std::mem::zeroed()
                                 };
                                 let offset: usize = {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -77,6 +77,10 @@ macro_rules! uniform {
 ///
 /// The parameters must be the name of the struct and the names of its fields.
 ///
+/// ## Safety
+///
+/// You must not use this macro on any struct with fields that cannot be zeroed.
+///
 /// ## Example
 ///
 /// ```
@@ -110,7 +114,14 @@ macro_rules! implement_vertex {
                             {
                                 // calculate the offset of the struct fields
                                 #[allow(deprecated)]
-                                let dummy: $struct_name = unsafe { ::std::mem::uninitialized() };
+                                let dummy: $struct_name = unsafe {
+                                  // Note(Lokathor): This is potentially
+                                  // dangerous and needs to be fixed more in the
+                                  // future. Basically, the problem is that the
+                                  // struct might not be allowed to be all
+                                  // zeroes. At least it's safe than uninitialized().
+                                  ::std::mem::zeroed()
+                                };
                                 let offset: usize = {
                                     let dummy_ref = &dummy;
                                     let field_ref = &dummy.$field_name;

--- a/src/program/raw.rs
+++ b/src/program/raw.rs
@@ -287,19 +287,16 @@ impl RawProgram {
                     Handle::Handle(_) => unreachable!()
                 };
 
-                #[allow(deprecated)]
-                let mut num_supported_formats = mem::uninitialized();
+                let mut num_supported_formats = 0;
                 ctxt.gl.GetIntegerv(gl::NUM_PROGRAM_BINARY_FORMATS, &mut num_supported_formats);
                 if num_supported_formats == 0 {
                     return Err(GetBinaryError::NoFormats)
                 }
 
-                #[allow(deprecated)]
-                let mut buf_len = mem::uninitialized();
+                let mut buf_len = 0;
                 ctxt.gl.GetProgramiv(id, gl::PROGRAM_BINARY_LENGTH, &mut buf_len);
 
-                #[allow(deprecated)]
-                let mut format = mem::uninitialized();
+                let mut format = 0;
                 let mut storage: Vec<u8> = Vec::with_capacity(buf_len as usize);
                 ctxt.gl.GetProgramBinary(id, buf_len, &mut buf_len, &mut format,
                                          storage.as_mut_ptr() as *mut _);
@@ -730,8 +727,7 @@ unsafe fn create_program(ctxt: &mut CommandContext) -> Handle {
 unsafe fn check_program_link_errors(ctxt: &mut CommandContext, id: Handle)
                                     -> Result<(), ProgramCreationError>
 {
-    #[allow(deprecated)]
-    let mut link_success: gl::types::GLint = mem::uninitialized();
+    let mut link_success: gl::types::GLint = 0;
 
     match id {
         Handle::Id(id) => {
@@ -765,8 +761,7 @@ unsafe fn check_program_link_errors(ctxt: &mut CommandContext, id: Handle)
             }
         };
 
-        #[allow(deprecated)]
-        let mut error_log_size: gl::types::GLint = mem::uninitialized();
+        let mut error_log_size: gl::types::GLint = 0;
 
         match id {
             Handle::Id(id) => {

--- a/src/program/reflection.rs
+++ b/src/program/reflection.rs
@@ -181,8 +181,7 @@ pub unsafe fn reflect_uniforms(ctxt: &mut CommandContext, program: Handle)
 {
     // number of active uniforms
     let active_uniforms = {
-        #[allow(deprecated)]
-        let mut active_uniforms: gl::types::GLint = mem::uninitialized();
+        let mut active_uniforms: gl::types::GLint = 0;
         match program {
             Handle::Id(program) => {
                 assert!(ctxt.version >= &Version(Api::Gl, 2, 0) ||
@@ -206,10 +205,8 @@ pub unsafe fn reflect_uniforms(ctxt: &mut CommandContext, program: Handle)
         let mut uniform_name_tmp: Vec<u8> = Vec::with_capacity(64);
         let mut uniform_name_tmp_len = 63;
 
-        #[allow(deprecated)]
-        let mut data_type: gl::types::GLenum = mem::uninitialized();
-        #[allow(deprecated)]
-        let mut data_size: gl::types::GLint = mem::uninitialized();
+        let mut data_type: gl::types::GLenum = 0;
+        let mut data_size: gl::types::GLint = 0;
 
         match program {
             Handle::Id(program) => {
@@ -289,8 +286,7 @@ pub unsafe fn reflect_attributes(ctxt: &mut CommandContext, program: Handle)
 {
     // number of active attributes
     let active_attributes = {
-        #[allow(deprecated)]
-        let mut active_attributes: gl::types::GLint = mem::uninitialized();
+        let mut active_attributes: gl::types::GLint = 0;
         match program {
             Handle::Id(program) => {
                 assert!(ctxt.version >= &Version(Api::Gl, 2, 0) ||
@@ -314,10 +310,8 @@ pub unsafe fn reflect_attributes(ctxt: &mut CommandContext, program: Handle)
         let mut attr_name_tmp: Vec<u8> = Vec::with_capacity(64);
         let mut attr_name_tmp_len = 63;
 
-        #[allow(deprecated)]
-        let mut data_type: gl::types::GLenum = mem::uninitialized();
-        #[allow(deprecated)]
-        let mut data_size: gl::types::GLint = mem::uninitialized();
+        let mut data_type: gl::types::GLenum = 0;
+        let mut data_size: gl::types::GLint = 0;
 
         match program {
             Handle::Id(program) => {
@@ -383,8 +377,7 @@ pub unsafe fn reflect_uniform_blocks(ctxt: &mut CommandContext, program: Handle)
         _ => unreachable!()
     };
 
-    #[allow(deprecated)]
-    let mut active_blocks: gl::types::GLint = mem::uninitialized();
+    let mut active_blocks: gl::types::GLint = 0;
     ctxt.gl.GetProgramiv(program, gl::ACTIVE_UNIFORM_BLOCKS, &mut active_blocks);
 
     // WORK-AROUND: AMD OpenGL ES drivers don't accept `GL_ACTIVE_UNIFORM_BLOCK_MAX_NAME_LENGTH`
@@ -394,8 +387,7 @@ pub unsafe fn reflect_uniform_blocks(ctxt: &mut CommandContext, program: Handle)
         return HashMap::with_hasher(Default::default());
     }
 
-    #[allow(deprecated)]
-    let mut active_blocks_max_name_len: gl::types::GLint = mem::uninitialized();
+    let mut active_blocks_max_name_len: gl::types::GLint = 0;
     ctxt.gl.GetProgramiv(program, gl::ACTIVE_UNIFORM_BLOCK_MAX_NAME_LENGTH,
                          &mut active_blocks_max_name_len);
 
@@ -417,20 +409,17 @@ pub unsafe fn reflect_uniform_blocks(ctxt: &mut CommandContext, program: Handle)
         };
 
         // binding point for this block
-        #[allow(deprecated)]
-        let mut binding: gl::types::GLint = mem::uninitialized();
+        let mut binding: gl::types::GLint = 0;
         ctxt.gl.GetActiveUniformBlockiv(program, block_id as gl::types::GLuint,
                                         gl::UNIFORM_BLOCK_BINDING, &mut binding);
 
         // number of bytes
-        #[allow(deprecated)]
-        let mut block_size: gl::types::GLint = mem::uninitialized();
+        let mut block_size: gl::types::GLint = 0;
         ctxt.gl.GetActiveUniformBlockiv(program, block_id as gl::types::GLuint,
                                         gl::UNIFORM_BLOCK_DATA_SIZE, &mut block_size);
 
         // number of members
-        #[allow(deprecated)]
-        let mut num_members: gl::types::GLint = mem::uninitialized();
+        let mut num_members: gl::types::GLint = 0;
         ctxt.gl.GetActiveUniformBlockiv(program, block_id as gl::types::GLuint,
                                         gl::UNIFORM_BLOCK_ACTIVE_UNIFORMS, &mut num_members);
 
@@ -513,8 +502,7 @@ pub unsafe fn reflect_transform_feedback(ctxt: &mut CommandContext, program: Han
 
     // querying the number of varying
     let num_varyings = {
-        #[allow(deprecated)]
-        let mut num_varyings: gl::types::GLint = mem::uninitialized();
+        let mut num_varyings: gl::types::GLint = 0;
 
         if ctxt.version >= &Version(Api::Gl, 3, 0) {
             ctxt.gl.GetProgramiv(program, gl::TRANSFORM_FEEDBACK_VARYINGS, &mut num_varyings);
@@ -534,8 +522,7 @@ pub unsafe fn reflect_transform_feedback(ctxt: &mut CommandContext, program: Han
 
     // querying "interleaved" or "separate"
     let buffer_mode = {
-        #[allow(deprecated)]
-        let mut buffer_mode: gl::types::GLint = mem::uninitialized();
+        let mut buffer_mode: gl::types::GLint = 0;
 
         if ctxt.version >= &Version(Api::Gl, 3, 0) {
             ctxt.gl.GetProgramiv(program, gl::TRANSFORM_FEEDBACK_BUFFER_MODE, &mut buffer_mode);
@@ -549,8 +536,7 @@ pub unsafe fn reflect_transform_feedback(ctxt: &mut CommandContext, program: Han
     };
 
     // the max length includes the null terminator
-    #[allow(deprecated)]
-    let mut max_buffer_len: gl::types::GLint = mem::uninitialized();
+    let mut max_buffer_len: gl::types::GLint = 0;
     if ctxt.version >= &Version(Api::Gl, 3, 0) {
         ctxt.gl.GetProgramiv(program, gl::TRANSFORM_FEEDBACK_VARYING_MAX_LENGTH,
                              &mut max_buffer_len);
@@ -567,10 +553,8 @@ pub unsafe fn reflect_transform_feedback(ctxt: &mut CommandContext, program: Han
         let mut name_tmp: Vec<u8> = Vec::with_capacity(max_buffer_len as usize);
         let mut name_tmp_len = max_buffer_len;
 
-        #[allow(deprecated)]
-        let mut size = mem::uninitialized();
-        #[allow(deprecated)]
-        let mut ty = mem::uninitialized();
+        let mut size = 0;
+        let mut ty = 0;
 
         if ctxt.version >= &Version(Api::Gl, 3, 0) {
             ctxt.gl.GetTransformFeedbackVarying(program, index, name_tmp_len, &mut name_tmp_len,
@@ -641,8 +625,7 @@ pub unsafe fn reflect_transform_feedback(ctxt: &mut CommandContext, program: Han
 pub unsafe fn reflect_geometry_output_type(ctxt: &mut CommandContext, program: Handle)
                                            -> OutputPrimitives
 {
-    #[allow(deprecated)]
-    let mut value = mem::uninitialized();
+    let mut value = 0;
 
     match program {
         Handle::Id(program) => {
@@ -673,8 +656,7 @@ pub unsafe fn reflect_geometry_output_type(ctxt: &mut CommandContext, program: H
 pub unsafe fn reflect_tess_eval_output_type(ctxt: &mut CommandContext, program: Handle)
                                             -> OutputPrimitives
 {
-    #[allow(deprecated)]
-    let mut value = mem::uninitialized();
+    let mut value = 0;
 
     match program {
         Handle::Id(program) => {
@@ -714,8 +696,7 @@ pub unsafe fn reflect_shader_storage_blocks(ctxt: &mut CommandContext, program: 
 
     // number of active SSBOs
     let active_blocks = {
-        #[allow(deprecated)]
-        let mut active_blocks: gl::types::GLint = mem::uninitialized();
+        let mut active_blocks: gl::types::GLint = 0;
         ctxt.gl.GetProgramInterfaceiv(program, gl::SHADER_STORAGE_BLOCK,
                                       gl::ACTIVE_RESOURCES, &mut active_blocks);
         active_blocks as gl::types::GLuint
@@ -728,8 +709,7 @@ pub unsafe fn reflect_shader_storage_blocks(ctxt: &mut CommandContext, program: 
     for block_id in 0 .. active_blocks {
         // getting basic infos
         let (name_len, num_variables, binding, total_size) = {
-            #[allow(deprecated)]
-            let mut output: [gl::types::GLint; 4] = mem::uninitialized();
+            let mut output: [gl::types::GLint; 4] = [0; 4];
             ctxt.gl.GetProgramResourceiv(program, gl::SHADER_STORAGE_BLOCK, block_id, 4,
                                          [gl::NAME_LENGTH, gl::NUM_ACTIVE_VARIABLES,
                                           gl::BUFFER_BINDING, gl::BUFFER_DATA_SIZE].as_ptr(), 4,
@@ -763,8 +743,7 @@ pub unsafe fn reflect_shader_storage_blocks(ctxt: &mut CommandContext, program: 
         // iterator over variables
         let members = active_variables.into_iter().map(|variable| {
             let (ty, array_size, offset, _array_stride, name_len, top_level_array_size) = {
-                #[allow(deprecated)]
-                let mut output: [gl::types::GLint; 6] = mem::uninitialized();
+                let mut output: [gl::types::GLint; 6] = [0; 6];
                 ctxt.gl.GetProgramResourceiv(program, gl::BUFFER_VARIABLE,
                                              variable as gl::types::GLuint, 6,
                                              [gl::TYPE, gl::ARRAY_SIZE, gl::OFFSET,
@@ -1193,22 +1172,19 @@ pub unsafe fn reflect_subroutine_data(ctxt: &mut CommandContext, program: Handle
     let mut subroutine_uniforms = HashMap::with_hasher(Default::default());
     let mut location_counts = HashMap::with_hasher(Default::default());
     for stage in shader_stages.iter() {
-        #[allow(deprecated)]
-        let mut location_count: gl::types::GLint = mem::uninitialized();
+        let mut location_count: gl::types::GLint = 0;
         ctxt.gl.GetProgramStageiv(program, stage.to_gl_enum(),
                                   gl::ACTIVE_SUBROUTINE_UNIFORM_LOCATIONS,
                                   &mut location_count);
         location_counts.insert(*stage, location_count as usize);
-        #[allow(deprecated)]
-        let mut subroutine_count: gl::types::GLint = mem::uninitialized();
+        let mut subroutine_count: gl::types::GLint = 0;
         ctxt.gl.GetProgramStageiv(program, stage.to_gl_enum(),
                                   gl::ACTIVE_SUBROUTINE_UNIFORMS,
                                   &mut subroutine_count);
         for i in 0..subroutine_count {
             // Get the name of the uniform
             let mut uniform_name_tmp: Vec<u8> = vec![0; 64];
-            #[allow(deprecated)]
-            let mut name_len: gl::types::GLsizei = mem::uninitialized();
+            let mut name_len: gl::types::GLsizei = 0;
             ctxt.gl.GetActiveSubroutineUniformName(program, stage.to_gl_enum(),
                                                    i as gl::types::GLuint,
                                                    (uniform_name_tmp.len() - 1) as gl::types::GLint,
@@ -1221,8 +1197,7 @@ pub unsafe fn reflect_subroutine_data(ctxt: &mut CommandContext, program: Handle
             uniform_name_tmp.set_len(name_len as usize);
             let uniform_name = String::from_utf8(uniform_name_tmp).unwrap();
 
-            #[allow(deprecated)]
-            let mut size: gl::types::GLint = mem::uninitialized();
+            let mut size: gl::types::GLint = 0;
             ctxt.gl.GetActiveSubroutineUniformiv(program, stage.to_gl_enum(), i as u32,
                                          gl::UNIFORM_SIZE, &mut size);
             let size = if size == 1 {
@@ -1232,8 +1207,7 @@ pub unsafe fn reflect_subroutine_data(ctxt: &mut CommandContext, program: Handle
             };
 
             // Get the number of compatible subroutines.
-            #[allow(deprecated)]
-            let mut compatible_count: gl::types::GLint = mem::uninitialized();
+            let mut compatible_count: gl::types::GLint = 0;
             ctxt.gl.GetActiveSubroutineUniformiv(program, stage.to_gl_enum(), i as u32,
                                                  gl::NUM_COMPATIBLE_SUBROUTINES, &mut compatible_count);
 
@@ -1247,8 +1221,7 @@ pub unsafe fn reflect_subroutine_data(ctxt: &mut CommandContext, program: Handle
             for j in 0..compatible_count {
                 // Get the names of compatible subroutines.
                 let mut subroutine_name_tmp: Vec<u8> = vec![0; 64];
-                #[allow(deprecated)]
-                let mut name_len: gl::types::GLsizei = mem::uninitialized();
+                let mut name_len: gl::types::GLsizei = 0;
                 ctxt.gl.GetActiveSubroutineName(program, stage.to_gl_enum(), compatible_sr_indices[j as usize],
                                                 subroutine_name_tmp.len() as gl::types::GLint,
                                                 &mut name_len,

--- a/src/program/shader.rs
+++ b/src/program/shader.rs
@@ -114,8 +114,7 @@ pub fn build_shader<F: ?Sized>(facade: &F, shader_type: gl::types::GLenum, sourc
 
         // checking compilation success by reading a flag on the shader
         let compilation_success = {
-            #[allow(deprecated)]
-            let mut compilation_success: gl::types::GLint = mem::uninitialized();
+            let mut compilation_success: gl::types::GLint = 0;
             match id {
                 Handle::Id(id) => {
                     assert!(ctxt.version >= &Version(Api::Gl, 2, 0) ||
@@ -139,8 +138,7 @@ pub fn build_shader<F: ?Sized>(facade: &F, shader_type: gl::types::GLenum, sourc
 
         } else {
             // compilation error
-            #[allow(deprecated)]
-            let mut error_log_size: gl::types::GLint = mem::uninitialized();
+            let mut error_log_size: gl::types::GLint = 0;
 
             match id {
                 Handle::Id(id) => {

--- a/src/sampler_object.rs
+++ b/src/sampler_object.rs
@@ -24,9 +24,7 @@ impl SamplerObject {
                 ctxt.extensions.gl_arb_sampler_objects);
 
         let sampler = unsafe {
-            use std::mem;
-            #[allow(deprecated)]
-            let mut sampler: gl::types::GLuint = mem::uninitialized();
+            let mut sampler: gl::types::GLuint = 0;
             ctxt.gl.GenSamplers(1, &mut sampler);
             sampler
         };

--- a/src/texture/any.rs
+++ b/src/texture/any.rs
@@ -1240,16 +1240,13 @@ impl<'t> TextureMipmapExt for TextureAnyMipmap<'t> {
         unsafe {
             let bind_point = texture.bind_to_current(&mut ctxt);
 
-            #[allow(deprecated)]
-            let mut is_compressed = mem::uninitialized();
+            let mut is_compressed = 0;
             ctxt.gl.GetTexLevelParameteriv(bind_point, level, gl::TEXTURE_COMPRESSED, &mut is_compressed);
             if is_compressed != 0 {
 
-                #[allow(deprecated)]
-                let mut buffer_size = mem::uninitialized();
+                let mut buffer_size = 0;
                 ctxt.gl.GetTexLevelParameteriv(bind_point, level, gl::TEXTURE_COMPRESSED_IMAGE_SIZE, &mut buffer_size);
-                #[allow(deprecated)]
-                let mut internal_format = mem::uninitialized();
+                let mut internal_format = 0;
                 ctxt.gl.GetTexLevelParameteriv(bind_point, level, gl::TEXTURE_INTERNAL_FORMAT, &mut internal_format);
 
                 match ClientFormatAny::from_internal_compressed_format(internal_format as gl::types::GLenum) {

--- a/src/texture/any.rs
+++ b/src/texture/any.rs
@@ -215,8 +215,7 @@ pub fn new_texture<'a, F: ?Sized, P>(facade: &F, format: TextureFormatRequest,
 
         BufferAny::unbind_pixel_unpack(&mut ctxt);
 
-        #[allow(deprecated)]
-        let id: gl::types::GLuint = mem::uninitialized();
+        let id: gl::types::GLuint = 0;
         ctxt.gl.GenTextures(1, mem::transmute(&id));
 
         {
@@ -654,10 +653,8 @@ impl TextureAny {
     pub fn get_depth_stencil_bits(&self) -> (u16, u16) {
         unsafe {
             let ctxt = self.context.make_current();
-            #[allow(deprecated)]
-            let mut depth_bits: gl::types::GLint = mem::uninitialized();
-            #[allow(deprecated)]
-            let mut stencil_bits: gl::types::GLint = mem::uninitialized();
+            let mut depth_bits: gl::types::GLint = 0;
+            let mut stencil_bits: gl::types::GLint = 0;
             // FIXME: GL version considerations
             ctxt.gl.GetTextureLevelParameteriv(self.id, 0, gl::TEXTURE_DEPTH_SIZE, &mut depth_bits);
             ctxt.gl.GetTextureLevelParameteriv(self.id, 0, gl::TEXTURE_STENCIL_SIZE, &mut stencil_bits);

--- a/src/texture/buffer_texture.rs
+++ b/src/texture/buffer_texture.rs
@@ -397,8 +397,7 @@ impl<T> BufferTexture<T> where [T]: BufferContent, T: TextureBufferContent + Cop
                     ctxt.extensions.gl_arb_direct_state_access
         {
             unsafe {
-                #[allow(deprecated)]
-                let mut id = mem::uninitialized();
+                let mut id = 0;
                 ctxt.gl.CreateTextures(gl::TEXTURE_BUFFER, 1, &mut id);
                 ctxt.gl.TextureBuffer(id, internal_format, buffer.get_id());
                 id
@@ -407,8 +406,7 @@ impl<T> BufferTexture<T> where [T]: BufferContent, T: TextureBufferContent + Cop
         } else {
             // reserving the ID
             let id = unsafe {
-                #[allow(deprecated)]
-                let mut id = mem::uninitialized();
+                let mut id = 0;
                 ctxt.gl.GenTextures(1, &mut id);
                 id
             };

--- a/src/texture/get_format.rs
+++ b/src/texture/get_format.rs
@@ -153,16 +153,16 @@ pub fn get_format(ctxt: &mut CommandContext, texture: &TextureAny)
         let (red_sz, red_ty, green_sz, green_ty, blue_sz, blue_ty,
              alpha_sz, alpha_ty, depth_sz, depth_ty) = unsafe
         {
-            let mut red_sz = mem::uninitialized();
-            let mut red_ty = mem::uninitialized();
-            let mut green_sz = mem::uninitialized();
-            let mut green_ty = mem::uninitialized();
-            let mut blue_sz = mem::uninitialized();
-            let mut blue_ty = mem::uninitialized();
-            let mut alpha_sz = mem::uninitialized();
-            let mut alpha_ty = mem::uninitialized();
-            let mut depth_sz = mem::uninitialized();
-            let mut depth_ty = mem::uninitialized();
+            let mut red_sz = 0;
+            let mut red_ty = 0;
+            let mut green_sz = 0;
+            let mut green_ty = 0;
+            let mut blue_sz = 0;
+            let mut blue_ty = 0;
+            let mut alpha_sz = 0;
+            let mut alpha_ty = 0;
+            let mut depth_sz = 0;
+            let mut depth_ty = 0;
 
             if ctxt.version >= &Version(Api::Gl, 4, 5) ||
                ctxt.extensions.gl_arb_direct_state_access

--- a/src/vertex_array_object.rs
+++ b/src/vertex_array_object.rs
@@ -292,8 +292,7 @@ impl VertexArrayObject {
 
         // building the VAO
         let id = {
-            #[allow(deprecated)]
-            let mut id = mem::uninitialized();
+            let mut id = 0;
             if ctxt.version >= &Version(Api::Gl, 3, 0) ||
                 ctxt.version >= &Version(Api::GlEs, 3, 0) ||
                 ctxt.extensions.gl_arb_vertex_array_object


### PR DESCRIPTION
Closes https://github.com/glium/glium/issues/1753

* https://github.com/glium/glium/commit/a5529204ae8925aa2ad6912b42fe64d34b838b78 isn't a complete fix, this is still a dangerous thing to do but people are _not likely_ to actually make it go wrong. There is a soundness hole here, people are just unlikely to walk into it.
* https://github.com/glium/glium/commit/4609e7caf8c523ebe14e038b9ab523e53db9de04 is still dangerous but I've at least documented a bit about what you're not supposed to do, and I don't think people are making many vertex structs that can't be zeroed.
* Everything else was just ints, floats, or arrays of ints. Absolutely trivial, we don't even need `MaybeUninit`, we just use a literal `0`.