### PR TITLE
Fix minus sign in picking example camera position

### DIFF
--- a/examples/picking.rs
+++ b/examples/picking.rs
@@ -102,7 +102,7 @@ fn main() {
     ).unwrap();
 
     let mut camera = support::camera::CameraState::new();
-    camera.set_position((0.0, 0.0, 1.5));
+    camera.set_position((0.0, 0.0, -1.5));
     camera.set_direction((0.0, 0.0, 1.0));
 
     //id's must be unique and != 0


### PR DESCRIPTION
Fix issue #1538. I couldn't replicate the subtract with overflow component of the issue on ubuntu though.