### PR TITLE
Remove some unused std::mem imports

### DIFF
--- a/src/context/capabilities.rs
+++ b/src/context/capabilities.rs
@@ -6,7 +6,6 @@ use std::cmp;
 use std::collections::HashMap;
 use std::ffi::CStr;
 use std::hash::BuildHasherDefault;
-use std::mem;
 
 use fnv::FnvHasher;
 

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -10,7 +10,6 @@ use version::Api;
 use version::Version;
 use gl;
 use std::rc::Rc;
-use std::mem;
 
 pub use context::DebugCallbackBehavior;
 

--- a/src/draw_parameters/mod.rs
+++ b/src/draw_parameters/mod.rs
@@ -76,7 +76,6 @@ use Rect;
 use ToGlEnum;
 use vertex::TransformFeedbackSession;
 
-use std::mem;
 use std::ops::Range;
 
 pub use self::blend::{Blend, BlendingFunction, LinearBlendingFactor};

--- a/src/draw_parameters/query.rs
+++ b/src/draw_parameters/query.rs
@@ -9,7 +9,6 @@ use QueryExt;
 
 use std::cell::Cell;
 use std::fmt;
-use std::mem;
 use std::rc::Rc;
 use std::error::Error;
 

--- a/src/framebuffer/render_buffer.rs
+++ b/src/framebuffer/render_buffer.rs
@@ -9,7 +9,7 @@ the data of the render buffer.
 */
 use std::rc::Rc;
 use std::ops::{Deref, DerefMut};
-use std::{ mem, fmt };
+use std::fmt;
 use std::error::Error;
 
 use framebuffer::{ColorAttachment, ToColorAttachment};

--- a/src/program/raw.rs
+++ b/src/program/raw.rs
@@ -9,7 +9,7 @@ use context::Context;
 use ContextExt;
 use UniformsExt;
 
-use std::{ffi, fmt, mem};
+use std::{ffi, fmt};
 use std::collections::hash_map::{self, HashMap};
 use std::rc::Rc;
 use std::cell::RefCell;

--- a/src/program/reflection.rs
+++ b/src/program/reflection.rs
@@ -3,7 +3,6 @@ use gl;
 use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
 use std::ffi;
-use std::mem;
 use std::ptr;
 use std::os::raw;
 

--- a/src/program/shader.rs
+++ b/src/program/shader.rs
@@ -7,7 +7,7 @@ use backend::Facade;
 use context::Context;
 use ContextExt;
 
-use std::{ffi, mem, ptr};
+use std::{ffi, ptr};
 use std::rc::Rc;
 
 use GlObject;

--- a/src/texture/get_format.rs
+++ b/src/texture/get_format.rs
@@ -3,7 +3,7 @@ use version::Version;
 use version::Api;
 use gl;
 
-use std::{ mem, fmt };
+use std::fmt;
 use std::error::Error;
 
 use texture::any::TextureAny;


### PR DESCRIPTION
Fixes some warnings introduced by #1759