### PR TITLE
Remove #[allow(deprecated)]

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -113,7 +113,6 @@ macro_rules! implement_vertex {
                             Cow::Borrowed(stringify!($field_name)),
                             {
                                 // calculate the offset of the struct fields
-                                #[allow(deprecated)]
                                 let dummy: $struct_name = unsafe {
                                   // Note(Lokathor): This is potentially
                                   // dangerous and needs to be fixed more in the

--- a/src/texture/get_format.rs
+++ b/src/texture/get_format.rs
@@ -149,7 +149,6 @@ pub fn get_format(ctxt: &mut CommandContext, texture: &TextureAny)
                   -> Result<InternalFormat, GetFormatError>
 {
     if ctxt.version >= &Version(Api::Gl, 3, 0) || ctxt.version >= &Version(Api::GlEs, 3, 0) {
-        #[allow(deprecated)] // For uninitialized()
         let (red_sz, red_ty, green_sz, green_ty, blue_sz, blue_ty,
              alpha_sz, alpha_ty, depth_sz, depth_ty) = unsafe
         {


### PR DESCRIPTION
These became obsolete from the changes of #1759.