### PR TITLE
Remove the check of naming when buiding TransformFeedbackSession.

### DIFF
--- a/src/program/raw.rs
+++ b/src/program/raw.rs
@@ -405,6 +405,10 @@ impl RawProgram {
     /// and `stride`.
     ///
     /// The `stride` is the number of bytes between two vertices.
+    ///
+    /// This function only check the identity for type and offset(exclude the naming) between vertex attributes.
+    ///
+    /// The correctness of semantic meaning(i.e. naming) between vertex attributes is the responsibility of user.
     pub fn transform_feedback_matches(&self, format: &VertexFormat, stride: usize) -> bool {
         // TODO: doesn't support multiple buffers
 
@@ -419,7 +423,7 @@ impl RawProgram {
         }
 
         for elem in buf.elements.iter() {
-            if format.iter().find(|e| &e.0 == &*elem.name && e.1 == elem.offset && e.2 == elem.ty)
+            if format.iter().find(|e| e.1 == elem.offset && e.2 == elem.ty)
                             .is_none()
             {
                 return false;

--- a/src/program/raw.rs
+++ b/src/program/raw.rs
@@ -428,6 +428,11 @@ impl RawProgram {
             {
                 return false;
             }
+            
+
+            if format.iter().any(|e| e.1 != elem.offset && e.0 == elem.name) {
+                return false;
+            }
         }
 
         true


### PR DESCRIPTION
When creating `TransformFeedbackSession`, `glium` would check the consistent of naming, offset and type between the input attributes of output buffer and output attributes of input buffer(both are attributes in vertex buffer).
The offset and type checking is OK. But the check of naming make TransformFeedback difficult to use.

Because when implementing particles system, we usually use two transformfeedback buffer(`buffer1` and `buffer2`) with the same vertex type. In first render pass, `buffer1` is for input and `buffer2` is for output. Then in the second render pass, we swap the position of them(e.g. `buffer1` is for output, `buffer2` is for input).
The problem is that `glium` will stop me due to a fact that the naming of input and output attributes are different. But they must be different, or we can't distinguish what is input attributes and output attributes. This causes a self-contradiction condition.

So we just need to remove the check for naming in TransformFeedback buffer and then everything works fine.