### PR TITLE
Add proper deprecation notices

### DIFF
--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -50,15 +50,20 @@ pub use self::alloc::{Mapping, WriteMapping, ReadMapping, ReadError, CopyError};
 pub use self::alloc::{is_buffer_read_supported};
 pub use self::fences::Inserter;
 
-/// DEPRECATED. Only here for backward compatibility.
+/// DEPRECATED. Only here for backwards compatibility.
+#[deprecated(note = "Only here for backwards compatibility")]
 pub use self::view::Buffer as BufferView;
-/// DEPRECATED. Only here for backward compatibility.
+/// DEPRECATED. Only here for backwards compatibility.
+#[deprecated(note = "Only here for backwards compatibility")]
 pub use self::view::BufferSlice as BufferViewSlice;
-/// DEPRECATED. Only here for backward compatibility.
+/// DEPRECATED. Only here for backwards compatibility.
+#[deprecated(note = "Only here for backwards compatibility")]
 pub use self::view::BufferMutSlice as BufferViewMutSlice;
-/// DEPRECATED. Only here for backward compatibility.
+/// DEPRECATED. Only here for backwards compatibility.
+#[deprecated(note = "Only here for backwards compatibility")]
 pub use self::view::BufferAny as BufferViewAny;
-/// DEPRECATED. Only here for backward compatibility.
+/// DEPRECATED. Only here for backwards compatibility.
+#[deprecated(note = "Only here for backwards compatibility")]
 pub use self::view::BufferAnySlice as BufferViewAnySlice;
 
 use gl;

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -320,8 +320,9 @@ impl Context {
         err
     }
 
-    /// DEPRECATED. Use `get_opengl_version` instead.
+    /// Returns the OpenGL version
     #[inline]
+    #[deprecated(note = "use `get_opengl_version` instead.")]
     pub fn get_version(&self) -> &Version {
         &self.version
     }

--- a/src/pixel_buffer.rs
+++ b/src/pixel_buffer.rs
@@ -1,2 +1,3 @@
-//! DEPRECATED. Moved to the `texture` module.
+//! Moved to the `texture` module.
+#![deprecated(note = "Moved to the `texture` module")]
 pub use texture::pixel_buffer::*;

--- a/src/vertex/buffer.rs
+++ b/src/vertex/buffer.rs
@@ -335,9 +335,9 @@ impl<T> VertexBuffer<T> where T: Copy {
 }
 
 impl<T> VertexBuffer<T> where T: Copy + Send + 'static {
-    /// DEPRECATED: use `.into()` instead.
     /// Discard the type information and turn the vertex buffer into a `VertexBufferAny`.
     #[inline]
+    #[deprecated(note = "use .into() instead.")]
     pub fn into_vertex_buffer_any(self) -> VertexBufferAny {
         VertexBufferAny {
             buffer: self.buffer.into(),


### PR DESCRIPTION
This gives actual warnings for users.
Later we can remove the deprecated things,
but only after warning.