### PR TITLE
Remove deprecated get_version and into_vertex_buffer_any

### DIFF
--- a/examples/support/mod.rs
+++ b/examples/support/mod.rs
@@ -95,5 +95,5 @@ pub fn load_wavefront(display: &Display, data: &[u8]) -> VertexBufferAny {
         }
     }
 
-    glium::vertex::VertexBuffer::new(display, &vertex_data).unwrap().into_vertex_buffer_any()
+    glium::vertex::VertexBuffer::new(display, &vertex_data).unwrap().into()
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -82,7 +82,7 @@ pub trait Facade {
 
 impl<T: ?Sized> CapabilitiesSource for T where T: Facade {
     fn get_version(&self) -> &Version {
-        self.get_context().deref().get_version()
+        self.get_context().deref().get_opengl_version()
     }
 
     fn get_extensions(&self) -> &ExtensionsList {

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -336,7 +336,7 @@ impl Context {
     /// Returns the GLSL version guaranteed to be supported.
     #[inline]
     pub fn get_supported_glsl_version(&self) -> Version {
-        version::get_supported_glsl_version(self.get_version())
+        version::get_supported_glsl_version(self.get_opengl_version())
     }
 
     /// Returns true if the given GLSL version is supported.

--- a/src/draw_parameters/mod.rs
+++ b/src/draw_parameters/mod.rs
@@ -471,7 +471,7 @@ pub fn validate(context: &Context, params: &DrawParameters) -> Result<(), DrawEr
         return Err(DrawError::InvalidDepthRange);
     }
 
-    if !params.draw_primitives && context.get_version() < &Version(Api::Gl, 3, 0) &&
+    if !params.draw_primitives && context.get_opengl_version() < &Version(Api::Gl, 3, 0) &&
         !context.get_extensions().gl_ext_transform_feedback
     {
         return Err(DrawError::RasterizerDiscardNotSupported);

--- a/src/image_format.rs
+++ b/src/image_format.rs
@@ -1646,7 +1646,7 @@ pub fn format_request_to_glenum(context: &Context, format: TextureFormatRequest,
                                 rq_ty: RequestType)
                                 -> Result<gl::types::GLenum, FormatNotSupportedError>
 {
-    let version = context.get_version();
+    let version = context.get_opengl_version();
     let extensions = context.get_extensions();
 
     let is_client_compressed = match rq_ty.get_client_format() {

--- a/src/vertex/buffer.rs
+++ b/src/vertex/buffer.rs
@@ -489,7 +489,7 @@ impl VertexBufferAny {
 impl<T> From<VertexBuffer<T>> for VertexBufferAny where T: Copy + Send + 'static {
     #[inline]
     fn from(buf: VertexBuffer<T>) -> VertexBufferAny {
-        buf.into_vertex_buffer_any()
+        buf.into()
     }
 }
 
@@ -497,7 +497,7 @@ impl<T> From<Buffer<[T]>> for VertexBufferAny where T: Vertex + Copy + Send + 's
     #[inline]
     fn from(buf: Buffer<[T]>) -> VertexBufferAny {
         let buf: VertexBuffer<T> = buf.into();
-        buf.into_vertex_buffer_any()
+        buf.into()
     }
 }
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -106,7 +106,7 @@ pub fn build_fullscreen_red_pipeline<F: ?Sized>(facade: &F) -> (glium::vertex::V
         glium::VertexBuffer::new(facade, &[
             Vertex { position: [-1.0,  1.0] }, Vertex { position: [1.0,  1.0] },
             Vertex { position: [-1.0, -1.0] }, Vertex { position: [1.0, -1.0] },
-        ]).unwrap().into_vertex_buffer_any(),
+        ]).unwrap().into(),
 
         glium::IndexBuffer::new(facade, PrimitiveType::TriangleStrip, &[0u8, 1, 2, 3]).unwrap().into(),
 
@@ -168,7 +168,7 @@ pub fn build_rectangle_vb_ib<F: ?Sized>(facade: &F)
         glium::VertexBuffer::new(facade, &[
             Vertex { position: [-1.0,  1.0] }, Vertex { position: [1.0,  1.0] },
             Vertex { position: [-1.0, -1.0] }, Vertex { position: [1.0, -1.0] },
-        ]).unwrap().into_vertex_buffer_any(),
+        ]).unwrap().into(),
 
         glium::IndexBuffer::new(facade, PrimitiveType::TriangleStrip, &[0u8, 1, 2, 3]).unwrap().into(),
     )


### PR DESCRIPTION
They were deprecated (properly) by #1801.