### PR TITLE
Report which shader stage failed to compile

### DIFF
--- a/src/program/program.rs
+++ b/src/program/program.rs
@@ -18,7 +18,7 @@ use ProgramExt;
 use Handle;
 use RawUniformValue;
 
-use program::{COMPILER_GLOBAL_LOCK, ProgramCreationInput, ProgramCreationError, Binary};
+use program::{COMPILER_GLOBAL_LOCK, ProgramCreationInput, ProgramCreationError, ShaderType, Binary};
 use program::GetBinaryError;
 
 use program::reflection::{Uniform, UniformBlock, OutputPrimitives};
@@ -55,22 +55,22 @@ impl Program {
                 let mut has_tessellation_evaluation_shader = false;
 
                 let mut shaders = vec![
-                    (vertex_shader, gl::VERTEX_SHADER),
-                    (fragment_shader, gl::FRAGMENT_SHADER)
+                    (vertex_shader, ShaderType::Vertex),
+                    (fragment_shader, ShaderType::Fragment)
                 ];
 
                 if let Some(gs) = geometry_shader {
-                    shaders.push((gs, gl::GEOMETRY_SHADER));
+                    shaders.push((gs, ShaderType::Geometry));
                     has_geometry_shader = true;
                 }
 
                 if let Some(ts) = tessellation_control_shader {
-                    shaders.push((ts, gl::TESS_CONTROL_SHADER));
+                    shaders.push((ts, ShaderType::TesselationControl));
                     has_tessellation_control_shader = true;
                 }
 
                 if let Some(ts) = tessellation_evaluation_shader {
-                    shaders.push((ts, gl::TESS_EVALUATION_SHADER));
+                    shaders.push((ts, ShaderType::TesselationEvaluation));
                     has_tessellation_evaluation_shader = true;
                 }
 
@@ -91,7 +91,7 @@ impl Program {
                 let shaders_store = {
                     let mut shaders_store = Vec::new();
                     for (src, ty) in shaders.into_iter() {
-                        shaders_store.push(build_shader(facade, ty, src)?);
+                        shaders_store.push(build_shader(facade, ty.to_opengl_type(), src)?);
                     }
                     shaders_store
                 };

--- a/src/program/shader.rs
+++ b/src/program/shader.rs
@@ -13,7 +13,7 @@ use std::rc::Rc;
 use GlObject;
 use Handle;
 
-use program::ProgramCreationError;
+use program::{ProgramCreationError, ShaderType};
 
 /// A single, compiled but unlinked, shader.
 pub struct Shader {
@@ -172,10 +172,10 @@ pub fn build_shader<F: ?Sized>(facade: &F, shader_type: gl::types::GLenum, sourc
             error_log.set_len(error_log_size as usize);
 
             match String::from_utf8(error_log) {
-                Ok(msg) => Err(ProgramCreationError::CompilationError(msg)),
+                Ok(msg) => Err(ProgramCreationError::CompilationError(msg, ShaderType::from_opengl_type(shader_type))),
                 Err(_) => Err(
                     ProgramCreationError::CompilationError("Could not convert the log \
-                                                            message to UTF-8".to_owned())
+                                                            message to UTF-8".to_owned(), ShaderType::from_opengl_type(shader_type))
                 ),
             }
         }

--- a/tests/framebuffer.rs
+++ b/tests/framebuffer.rs
@@ -209,7 +209,7 @@ fn multioutput() {
         ",
         None)
     {
-        Err(glium::CompilationError(_)) => return,
+        Err(glium::CompilationError(..)) => return,
         Ok(p) => p,
         e => e.unwrap()
     };

--- a/tests/shaders.rs
+++ b/tests/shaders.rs
@@ -70,7 +70,7 @@ fn program_compilation_error() {
         None);
 
     match program {
-        Err(glium::CompilationError(_)) => (),
+        Err(glium::CompilationError(..)) => (),
         _ => panic!()
     };
 


### PR DESCRIPTION
When compiling a program composed of multiple shader stages, glium would not previously report which shader stage failed to compile. The error message from the driver would include line numbers, but the user had to guess which file actually failed to compile.

This commit makes the error data type include which shader stage actually failed to compile.