### PR TITLE
Use glutin 0.22.0-alpha6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ unstable = [] # used for benchmarks
 test_headless = []  # used for testing headless display
 
 [dependencies.glutin]
-version = "=0.22.0-alpha5"
+version = "=0.22.0-alpha6"
 features = []
 optional = true
 


### PR DESCRIPTION
0.22.0-alpha6 locks winit to a compatible version, it fails to compile otherwise because it tries to use winit 0.20.0 instead of 0.20.0-alpha4 (see https://github.com/rust-windowing/glutin/commit/5947a22bbd62fe3b39601d6100563aaab352a315#diff-1b6d60f3f005be6e1e05f2803da7ccc6)