### PR TITLE
Remove deprecated Error::description usage and definition

### DIFF
--- a/src/backend/glutin/mod.rs
+++ b/src/backend/glutin/mod.rs
@@ -188,19 +188,14 @@ impl Display {
 
 impl fmt::Display for DisplayCreationError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", self.description())
+        match self {
+            DisplayCreationError::GlutinCreationError(err) => write!(fmt, "{}", err),
+            DisplayCreationError::IncompatibleOpenGl(err) => write!(fmt, "{}", err),
+        }
     }
 }
 
 impl Error for DisplayCreationError {
-    #[inline]
-    fn description(&self) -> &str {
-        match *self {
-            DisplayCreationError::GlutinCreationError(ref err) => err.description(),
-            DisplayCreationError::IncompatibleOpenGl(ref err) => err.description(),
-        }
-    }
-
     #[inline]
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match *self {

--- a/src/buffer/alloc.rs
+++ b/src/buffer/alloc.rs
@@ -32,19 +32,16 @@ pub enum ReadError {
 
 impl fmt::Display for ReadError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}", self.description())
+        use self::ReadError::*;
+        let desc = match *self {
+            NotSupported => "The backend doesn't support reading from a buffer",
+            ContextLost => "The context has been lost. Reading from the buffer would return garbage data",
+        };
+        fmt.write_str(desc)
     }
 }
 
-impl Error for ReadError {
-    fn description(&self) -> &str {
-        use self::ReadError::*;
-        match *self {
-            NotSupported => "The backend doesn't support reading from a buffer",
-            ContextLost => "The context has been lost. Reading from the buffer would return garbage data",
-        }
-    }
-}
+impl Error for ReadError {}
 
 /// Error that can happen when copying data between buffers.
 #[derive(Debug, Copy, Clone)]
@@ -55,18 +52,15 @@ pub enum CopyError {
 
 impl fmt::Display for CopyError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}", self.description())
+        use self::CopyError::*;
+        let desc = match *self {
+            NotSupported => "The backend doesn't support copying between buffers",
+        };
+        fmt.write_str(desc)
     }
 }
 
-impl Error for CopyError {
-    fn description(&self) -> &str {
-        use self::CopyError::*;
-        match *self {
-            NotSupported => "The backend doesn't support copying between buffers",
-        }
-    }
-}
+impl Error for CopyError {}
 
 /// A buffer in the graphics card's memory.
 pub struct Alloc {

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -192,18 +192,15 @@ pub enum BufferCreationError {
 
 impl fmt::Display for BufferCreationError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}", self.description())
+        let desc = match self {
+            BufferCreationError::OutOfMemory => "Not enough memory to create the buffer",
+            BufferCreationError::BufferTypeNotSupported => "This type of buffer is not supported",
+        };
+        fmt.write_str(desc)
     }
 }
 
-impl Error for BufferCreationError {
-    fn description(&self) -> &str {
-        match self {
-            &BufferCreationError::OutOfMemory => "Not enough memory to create the buffer",
-            &BufferCreationError::BufferTypeNotSupported => "This type of buffer is not supported",
-        }
-    }
-}
+impl Error for BufferCreationError {}
 
 /// How the buffer is created.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/src/draw_parameters/query.rs
+++ b/src/draw_parameters/query.rs
@@ -67,18 +67,15 @@ pub enum QueryCreationError {
 
 impl fmt::Display for QueryCreationError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}", self.description())
+        use self::QueryCreationError::*;
+        let desc = match *self {
+            NotSupported => "The given query type is not supported",
+        };
+        fmt.write_str(desc)
     }
 }
 
-impl Error for QueryCreationError {
-    fn description(&self) -> &str {
-        use self::QueryCreationError::*;
-        match *self {
-            NotSupported => "The given query type is not supported",
-        }
-    }
-}
+impl Error for QueryCreationError {}
 
 /// Error that can happen when writing the value of a query to a buffer.
 #[derive(Copy, Clone, Debug)]
@@ -89,18 +86,15 @@ pub enum ToBufferError {
 
 impl fmt::Display for ToBufferError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}", self.description())
+        use self::ToBufferError::*;
+        let desc = match *self {
+            NotSupported => "Writing the result to a buffer is not supported",
+        };
+        fmt.write_str(desc)
     }
 }
 
-impl Error for ToBufferError {
-    fn description(&self) -> &str {
-        use self::ToBufferError::*;
-        match *self {
-            NotSupported => "Writing the result to a buffer is not supported",
-        }
-    }
-}
+impl Error for ToBufferError {}
 
 impl RawQuery {
     /// Builds a new query. Returns `None` if the backend doesn't support this type.

--- a/src/fbo.rs
+++ b/src/fbo.rs
@@ -603,19 +603,7 @@ pub enum ValidationError {
 impl fmt::Display for ValidationError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         use self::ValidationError::*;
-        match *self {
-            TooManyColorAttachments{ ref maximum, ref obtained } =>
-                write!(fmt, "{}: found {}, maximum: {}", self.description(), obtained, maximum),
-            _ =>
-                write!(fmt, "{}", self.description()),
-        }
-    }
-}
-
-impl Error for ValidationError {
-    fn description(&self) -> &str {
-        use self::ValidationError::*;
-        match *self {
+        let desc = match self {
             EmptyFramebufferObjectsNotSupported =>
                 "You requested an empty framebuffer object, but they are not supported",
             EmptyFramebufferUnsupportedDimensions =>
@@ -626,9 +614,17 @@ impl Error for ValidationError {
                 "All attachments must have the same number of samples",
             TooManyColorAttachments {..} =>
                 "Backends only support a certain number of color attachments",
+        };
+        match self {
+            TooManyColorAttachments{ ref maximum, ref obtained } =>
+                write!(fmt, "{}: found {}, maximum: {}", desc, obtained, maximum),
+            _ =>
+                fmt.write_str(desc),
         }
     }
 }
+
+impl Error for ValidationError {}
 
 /// Data structure stored in the hashmap.
 ///

--- a/src/framebuffer/render_buffer.rs
+++ b/src/framebuffer/render_buffer.rs
@@ -38,18 +38,15 @@ pub enum CreationError {
 
 impl fmt::Display for CreationError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}", self.description())
+        use self::CreationError::*;
+        let desc = match *self {
+            FormatNotSupported => "The requested format is not supported",
+        };
+        fmt.write_str(desc)
     }
 }
 
-impl Error for CreationError {
-    fn description(&self) -> &str {
-        use self::CreationError::*;
-        match *self {
-            FormatNotSupported => "The requested format is not supported",
-        }
-    }
-}
+impl Error for CreationError {}
 
 impl From<image_format::FormatNotSupportedError> for CreationError {
     fn from(_: image_format::FormatNotSupportedError) -> CreationError {

--- a/src/image_format.rs
+++ b/src/image_format.rs
@@ -18,15 +18,11 @@ pub struct FormatNotSupportedError;
 
 impl fmt::Display for FormatNotSupportedError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}", self.description())
+        write!(fmt, "Format is not supported by OpenGL")
     }
 }
 
-impl Error for FormatNotSupportedError {
-    fn description(&self) -> &str {
-        "Format is not supported by OpenGL"
-    }
-}
+impl Error for FormatNotSupportedError {}
 
 /// Texture format request.
 #[derive(Copy, Clone, Debug)]

--- a/src/index/buffer.rs
+++ b/src/index/buffer.rs
@@ -30,23 +30,20 @@ pub enum CreationError {
 
 impl fmt::Display for CreationError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}", self.description())
-    }
-}
-
-impl Error for CreationError {
-    fn description(&self) -> &str {
         use self::CreationError::*;
-        match *self {
+        let desc = match *self {
             IndexTypeNotSupported =>
                 "The type of index is not supported by the backend",
             PrimitiveTypeNotSupported =>
                 "The type of primitives is not supported by the backend",
             BufferCreationError(_) =>
                 "An error happened while creating the buffer",
-        }
+        };
+        fmt.write_str(desc)
     }
+}
 
+impl Error for CreationError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         use self::CreationError::*;
         match *self {

--- a/src/ops/read.rs
+++ b/src/ops/read.rs
@@ -78,23 +78,20 @@ pub enum ReadError {
 
 impl fmt::Display for ReadError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}", self.description())
-    }
-}
-
-impl Error for ReadError {
-    fn description(&self) -> &str {
         use self::ReadError::*;
-        match *self {
+        let desc = match *self {
             OutputFormatNotSupported =>
                 "The implementation doesn't support converting to the requested output format",
             AttachmentTypeNotSupported =>
                 "The implementation doesn't support reading a depth, depth-stencil or stencil attachment",
             ClampingNotSupported =>
                 "Clamping the values is not supported by the implementation",
-        }
+        };
+        fmt.write_str(desc)
     }
 }
+
+impl Error for ReadError {}
 
 /// Reads pixels from the source into the destination.
 ///

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -140,21 +140,7 @@ pub enum ProgramCreationError {
 impl fmt::Display for ProgramCreationError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         use self::ProgramCreationError::*;
-        match *self {
-            CompilationError(ref s, _) =>
-                write!(fmt, "{}: {}", self.description(), s),
-            LinkingError(ref s) =>
-                write!(fmt, "{}: {}", self.description(), s),
-            _ =>
-                write!(fmt, "{}", self.description()),
-        }
-    }
-}
-
-impl Error for ProgramCreationError {
-    fn description(&self) -> &str {
-        use self::ProgramCreationError::*;
-        match *self {
+        let desc = match *self {
             CompilationError(_,typ) => {
                 match typ {
                     ShaderType::Vertex => "Compilation error in vertex shader",
@@ -177,9 +163,19 @@ impl Error for ProgramCreationError {
                 "Point size is not supported by the backend.",
             BinaryHeaderError =>
                 "The glium-specific binary header was not found or is corrupt.",
+        };
+        match *self {
+            CompilationError(ref s, _) =>
+                write!(fmt, "{}: {}", desc, s),
+            LinkingError(ref s) =>
+                write!(fmt, "{}: {}", desc, s),
+            _ =>
+                write!(fmt, "{}", desc),
         }
     }
 }
+
+impl Error for ProgramCreationError {}
 
 /// Error type that is returned by the `program!` macro.
 #[derive(Clone, Debug)]
@@ -194,20 +190,15 @@ pub enum ProgramChooserCreationError {
 impl fmt::Display for ProgramChooserCreationError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", self.description())
+        use self::ProgramChooserCreationError::*;
+        match *self {
+            ProgramCreationError(ref err) => write!(fmt, "{}", err),
+            NoVersion => fmt.write_str("No version of the program has been found for the current OpenGL version."),
+        }
     }
 }
 
 impl Error for ProgramChooserCreationError {
-    #[inline]
-    fn description(&self) -> &str {
-        use self::ProgramChooserCreationError::*;
-        match *self {
-            ProgramCreationError(ref err) => err.description(),
-            NoVersion => "No version of the program has been found for the current OpenGL version.",
-        }
-    }
-
     #[inline]
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         use self::ProgramChooserCreationError::*;
@@ -235,19 +226,16 @@ pub enum GetBinaryError {
 
 impl fmt::Display for GetBinaryError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}", self.description())
+        use self::GetBinaryError::*;
+        let desc = match *self {
+            NotSupported => "The backend doesn't support binary",
+            NoFormats => "The backend does not supply any binary formats.",
+        };
+        fmt.write_str(desc)
     }
 }
 
-impl Error for GetBinaryError {
-    fn description(&self) -> &str {
-        use self::GetBinaryError::*;
-        match *self {
-            NotSupported => "The backend doesn't support binary",
-            NoFormats => "The backend does not supply any binary formats.",
-        }
-    }
-}
+impl Error for GetBinaryError {}
 
 /// Input when creating a program.
 pub enum ProgramCreationInput<'a> {

--- a/src/texture/buffer_texture.rs
+++ b/src/texture/buffer_texture.rs
@@ -94,23 +94,20 @@ pub enum TextureCreationError {
 
 impl fmt::Display for TextureCreationError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}", self.description())
-    }
-}
-
-impl Error for TextureCreationError {
-    fn description(&self) -> &str {
         use self::TextureCreationError::*;
-        match *self {
+        let desc = match *self {
             NotSupported =>
                 "Buffer textures are not supported at all",
             FormatNotSupported =>
                 "The requested format is not supported in combination with the given texture buffer type",
             TooLarge =>
                 "The size of the buffer that you are trying to bind exceeds `GL_MAX_TEXTURE_BUFFER_SIZE`",
-        }
+        };
+        fmt.write_str(desc)
     }
 }
+
+impl Error for TextureCreationError {}
 
 /// Error that can happen while building a buffer texture.
 #[derive(Copy, Clone, Debug)]
@@ -124,21 +121,18 @@ pub enum CreationError {
 
 impl fmt::Display for CreationError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}", self.description())
-    }
-}
-
-impl Error for CreationError {
-    fn description(&self) -> &str {
         use self::CreationError::*;
-        match *self {
+        let desc = match *self {
             BufferCreationError(_) =>
                 "Failed to create the buffer",
             TextureCreationError(_) =>
                 "Failed to create the texture",
-        }
+        };
+        fmt.write_str(desc)
     }
+}
 
+impl Error for CreationError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         use self::CreationError::*;
         match *self {

--- a/src/texture/get_format.rs
+++ b/src/texture/get_format.rs
@@ -19,19 +19,15 @@ pub enum GetFormatError {
 
 impl fmt::Display for GetFormatError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}", self.description())
+        use self::GetFormatError::*;
+        let desc = match self {
+            NotSupported => "The backend doesn't support retrieving the internal format",
+        };
+        fmt.write_str(desc)
     }
 }
 
-impl Error for GetFormatError {
-    fn description(&self) -> &str {
-        use self::GetFormatError::*;
-        match *self {
-            NotSupported =>
-                "The backend doesn't support retrieving the internal format",
-        }
-    }
-}
+impl Error for GetFormatError {}
 
 /// Internal format of a texture.
 ///

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -805,23 +805,20 @@ pub enum TextureCreationError {
 
 impl fmt::Display for TextureCreationError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}", self.description())
-    }
-}
-
-impl Error for TextureCreationError {
-    fn description(&self) -> &str {
         use self::TextureCreationError::*;
-        match *self {
+        let desc = match *self {
             FormatNotSupported =>
                 "The requested format is not supported by the backend",
             DimensionsNotSupported =>
                 "The requested texture dimensions are not supported",
             TypeNotSupported =>
                 "The texture format is not supported by the backend",
-        }
+        };
+        fmt.write_str(desc)
     }
 }
+
+impl Error for TextureCreationError {}
 
 impl From<FormatNotSupportedError> for TextureCreationError {
     #[inline]

--- a/src/uniforms/mod.rs
+++ b/src/uniforms/mod.rs
@@ -213,22 +213,6 @@ pub enum LayoutMismatchError {
 }
 
 impl Error for LayoutMismatchError {
-    fn description(&self) -> &str {
-        use self::LayoutMismatchError::*;
-        match *self {
-            TypeMismatch { .. } =>
-                "There is a mismatch in the type of one element",
-            LayoutMismatch { .. } =>
-                "The expected layout is totally different from what we have",
-            OffsetMismatch { .. } =>
-                "The type of data is good, but there is a misalignment",
-            MemberMismatch { .. } =>
-                "There is a mismatch in a submember of this layout",
-            MissingField { .. } =>
-                "A field is missing in either the expected of the input data layout",
-        }
-    }
-
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         use self::LayoutMismatchError::*;
         match *self {
@@ -241,13 +225,25 @@ impl Error for LayoutMismatchError {
 impl fmt::Display for LayoutMismatchError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         use self::LayoutMismatchError::*;
+        let desc = match *self {
+            TypeMismatch { .. } =>
+                "There is a mismatch in the type of one element",
+            LayoutMismatch { .. } =>
+                "The expected layout is totally different from what we have",
+            OffsetMismatch { .. } =>
+                "The type of data is good, but there is a misalignment",
+            MemberMismatch { .. } =>
+                "There is a mismatch in a submember of this layout",
+            MissingField { .. } =>
+                "A field is missing in either the expected of the input data layout",
+        };
         match *self {
             //duplicate Patternmatching, different Types can't be condensed
             TypeMismatch { ref expected, ref obtained } =>
                 write!(
                     fmt,
                     "{}, got: {:?}, expected: {:?}",
-                    self.description(),
+                    desc,
                     obtained,
                     expected,
                 ),
@@ -255,7 +251,7 @@ impl fmt::Display for LayoutMismatchError {
                 write!(
                     fmt,
                     "{}, got: {:?}, expected: {:?}",
-                    self.description(),
+                    desc,
                     obtained,
                     expected,
                 ),
@@ -263,7 +259,7 @@ impl fmt::Display for LayoutMismatchError {
                 write!(
                     fmt,
                     "{}, got: {}, expected: {}",
-                    self.description(),
+                    desc,
                     obtained,
                     expected,
                 ),
@@ -271,7 +267,7 @@ impl fmt::Display for LayoutMismatchError {
                 write!(
                     fmt,
                     "{}, {}: {}",
-                    self.description(),
+                    desc,
                     member,
                     err,
                 ),
@@ -279,7 +275,7 @@ impl fmt::Display for LayoutMismatchError {
                 write!(
                     fmt,
                     "{}: {}",
-                    self.description(),
+                    desc,
                     name,
                 ),
         }

--- a/src/vertex/buffer.rs
+++ b/src/vertex/buffer.rs
@@ -35,19 +35,16 @@ impl From<BufferCreationError> for CreationError {
 
 impl fmt::Display for CreationError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}", self.description())
+        use self::CreationError::*;
+        let desc = match self {
+            FormatNotSupported => "The vertex format is not supported by the backend",
+            BufferCreationError(_) => "Error while creating the vertex buffer",
+        };
+        fmt.write_str(desc)
     }
 }
 
 impl Error for CreationError {
-    fn description(&self) -> &str {
-        use self::CreationError::*;
-        match *self {
-            FormatNotSupported => "The vertex format is not supported by the backend",
-            BufferCreationError(_) => "Error while creating the vertex buffer",
-        }
-    }
-
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         use self::CreationError::*;
         match *self {

--- a/src/vertex/transform_feedback.rs
+++ b/src/vertex/transform_feedback.rs
@@ -108,21 +108,18 @@ pub enum TransformFeedbackSessionCreationError {
 
 impl fmt::Display for TransformFeedbackSessionCreationError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}", self.description())
-    }
-}
-
-impl Error for TransformFeedbackSessionCreationError {
-    fn description(&self) -> &str {
         use self::TransformFeedbackSessionCreationError::*;
-        match *self {
+        let desc = match *self {
             NotSupported =>
                 "Transform feedback is not supported by the OpenGL implementation",
             WrongVertexFormat =>
                 "The format of the output doesn't match what the program is expected to output",
-        }
+        };
+        fmt.write_str(desc)
     }
 }
+
+impl Error for TransformFeedbackSessionCreationError {}
 
 /// Returns true if transform feedback is supported by the OpenGL implementation.
 #[inline]


### PR DESCRIPTION
Error descriptions are soft-deprecated
since 1.27.0, and hard-deprecated since
1.42.0.

See https://github.com/rust-lang/rust/pull/66919