### PR TITLE
Update glutin to 0.24.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ unstable = [] # used for benchmarks
 test_headless = []  # used for testing headless display
 
 [dependencies.glutin]
-version = "0.23"
+version = "0.24"
 features = []
 optional = true
 


### PR DESCRIPTION
The `glutin` dependency should be updated to `0.24.0`, as the following simple program crashes with a `BorrowError` when using `glutin` version `0.23.0`:
```Rust
use glutin::event_loop::{ControlFlow, EventLoop};
use glutin::window::WindowBuilder;

fn main() {
    let el = EventLoop::new();
    let wb = WindowBuilder::new();
    let windowed_context = glutin::ContextBuilder::new()
        .build_windowed(wb, &el)
        .unwrap();

    let windowed_context = unsafe { windowed_context.make_current().unwrap() };

    el.run(move |_, _, control_flow| {
        windowed_context.window().set_maximized(true);
        *control_flow = ControlFlow::Exit;
    })
}
```
results in
```
thread 'main' panicked at 'already mutably borrowed: BorrowError'
```
This code doesn't use `glium` but similar crashes can happen in a program using `glium`.