### PR TITLE
Cleanup Tutorial Example (tuto-01-getting-started.md)

### DIFF
--- a/book/tuto-01-getting-started.md
+++ b/book/tuto-01-getting-started.md
@@ -115,10 +115,12 @@ This call to `finish()` means that we have finished drawing. It destroys the `Fr
 Here is our full `main` function after this step:
 
 ```rust
-fn main() {
-    use glium::glutin;
+extern crate glium;
 
-    let mut event_loop = glutin::event_loop::EventLoop::new();
+fn main() {
+    use glium::{glutin, Surface};
+
+    let event_loop = glutin::event_loop::EventLoop::new();
     let wb = glutin::window::WindowBuilder::new();
     let cb = glutin::ContextBuilder::new();
     let display = glium::Display::new(wb, cb, &event_loop).unwrap();


### PR DESCRIPTION
The final example in the tuto-01-getting-started.md doesn't compile.
It's missing a use statement for Surface.

I added a use for Surface.  Additionally, I added 'extern crate glium'
at the top of the example.  Finally, I removed the 'mut' for the
event_loop as it seems to be unnecessary.