### PR TITLE
Enable GL_TEXTURE_CUBE_MAP_SEAMLESS when available

### DIFF
--- a/build/main.rs
+++ b/build/main.rs
@@ -49,6 +49,7 @@ fn generate_gl_bindings<W>(dest: &mut W) where W: Write {
             "GL_ARB_occlusion_query",
             "GL_ARB_pixel_buffer_object",
             "GL_ARB_robustness",
+            "GL_ARB_seamless_cube_map",
             "GL_ARB_shader_image_load_store",
             "GL_ARB_shader_objects",
             "GL_ARB_texture_buffer_object",

--- a/src/context/extensions.rs
+++ b/src/context/extensions.rs
@@ -91,6 +91,7 @@ extensions! {
     "GL_ARB_robustness" => gl_arb_robustness,
     "GL_ARB_robust_buffer_access_behavior" => gl_arb_robust_buffer_access_behavior,
     "GL_ARB_sampler_objects" => gl_arb_sampler_objects,
+    "GL_ARB_seamless_cube_map" => gl_arb_seamless_cube_map,
     "GL_ARB_shader_atomic_counters" => gl_arb_shader_atomic_counters,
     "GL_ARB_shader_image_load_store" => gl_arb_shader_image_load_store,
     "GL_ARB_shader_objects" => gl_arb_shader_objects,

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -227,6 +227,9 @@ impl Context {
             /*assert!(::get_gl_error(&mut ctxt).is_none(),
                     "glium has triggered an OpenGL error during initialization. Please report \
                      this error: https://github.com/tomaka/glium/issues");*/
+            if ctxt.version >= &Version(Api::Gl, 3, 2) && ctxt.extensions.gl_arb_seamless_cube_map {
+                ctxt.gl.Enable(gl::TEXTURE_CUBE_MAP_SEAMLESS);
+            }
         }
 
         Ok(context)


### PR DESCRIPTION
Fixes https://github.com/glium/glium/issues/1728 (and maybe https://github.com/glium/glium/issues/644).

https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glEnable.xhtml
> GL_TEXTURE_CUBE_MAP_SEAMLESS is available only if the GL version is 3.2 or greater.

---

(Not sure if I really have to add `"GL_ARB_seamless_cube_map"` to the `Registry` in `build/main.rs`. It also compiles without that.)
