### PR TITLE
Tutorial03 fix

### DIFF
--- a/examples/tutorial-03.rs
+++ b/examples/tutorial-03.rs
@@ -52,9 +52,6 @@ fn main() {
 
     let mut t: f32 = -0.5;
     event_loop.run(move |event, _, control_flow| {
-        let next_frame_time = std::time::Instant::now() +
-            std::time::Duration::from_nanos(16_666_667);
-        *control_flow = glutin::event_loop::ControlFlow::WaitUntil(next_frame_time);
 
         match event {
             glutin::event::Event::WindowEvent { event, .. } => match event {
@@ -71,6 +68,10 @@ fn main() {
             },
             _ => return,
         }
+
+        let next_frame_time = std::time::Instant::now() +
+            std::time::Duration::from_nanos(16_666_667);
+        *control_flow = glutin::event_loop::ControlFlow::WaitUntil(next_frame_time);
 
         // we update `t`
         t += 0.0002;

--- a/examples/tutorial-04.rs
+++ b/examples/tutorial-04.rs
@@ -51,9 +51,6 @@ fn main() {
 
     let mut t: f32 = -0.5;
     event_loop.run(move |event, _, control_flow| {
-        let next_frame_time = std::time::Instant::now() +
-            std::time::Duration::from_nanos(16_666_667);
-        *control_flow = glutin::event_loop::ControlFlow::WaitUntil(next_frame_time);
 
         match event {
             glutin::event::Event::WindowEvent { event, .. } => match event {
@@ -70,6 +67,10 @@ fn main() {
             },
             _ => return,
         }
+
+        let next_frame_time = std::time::Instant::now() +
+            std::time::Duration::from_nanos(16_666_667);
+         *control_flow = glutin::event_loop::ControlFlow::WaitUntil(next_frame_time);
 
         // we update `t`
         t += 0.0002;

--- a/examples/tutorial-05.rs
+++ b/examples/tutorial-05.rs
@@ -54,9 +54,6 @@ fn main() {
 
     let mut t = -0.5;
     event_loop.run(move |event, _, control_flow| {
-        let next_frame_time = std::time::Instant::now() +
-            std::time::Duration::from_nanos(16_666_667);
-        *control_flow = glutin::event_loop::ControlFlow::WaitUntil(next_frame_time);
 
         match event {
             glutin::event::Event::WindowEvent { event, .. } => match event {
@@ -73,6 +70,10 @@ fn main() {
             },
             _ => return,
         }
+
+        let next_frame_time = std::time::Instant::now() +
+            std::time::Duration::from_nanos(16_666_667);
+        *control_flow = glutin::event_loop::ControlFlow::WaitUntil(next_frame_time);
 
         // we update `t`
         t += 0.0002;

--- a/examples/tutorial-06.rs
+++ b/examples/tutorial-06.rs
@@ -67,9 +67,6 @@ fn main() {
 
     let mut t = -0.5;
     event_loop.run(move |event, _, control_flow| {
-        let next_frame_time = std::time::Instant::now() +
-            std::time::Duration::from_nanos(16_666_667);
-        *control_flow = glutin::event_loop::ControlFlow::WaitUntil(next_frame_time);
 
         match event {
             glutin::event::Event::WindowEvent { event, .. } => match event {
@@ -86,6 +83,10 @@ fn main() {
             },
             _ => return,
         }
+
+        let next_frame_time = std::time::Instant::now() +
+            std::time::Duration::from_nanos(16_666_667);
+        *control_flow = glutin::event_loop::ControlFlow::WaitUntil(next_frame_time);
 
         // we update `t`
         t += 0.0002;


### PR DESCRIPTION
You have to update the timers after the pattern match. Then a new time is set only after you have passed the previous one (and that signal is activated).
Then some events (such as moving the mouse) won't override it (as this way it doesn't just keep reseting the time).

2nd pull request because I didn't realise multiple files have this bug