### PR TITLE
Update the token for travis publication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
 env: 
   global:
     - secure: "Ts/4pe5X+GCq2tr88UyXvIciibED0vHaJhQE9gC4OIyJRIM4ZBiNmyVATZi16zWzLPVCkURWBIjMt5G7r7rJ0fwvGvsFUfCMg9if1xYEVgXBw/0FFvgO5CkUR+vK3lD1A9Gew1exCwz/bKz0Vf2NvHcpBdvZ3pUbageLRGKcVH4="
-    - secure: "AfE+PLANOT0mgUKpgGUu4yIrSNKxoNST5zFBeajONEEE0wl/bZVE6iGqucNPR0EaIgMfk+NGgCLLM7VFfy+HF5alBiqUUOapef+fc91iHVzoBgtlLXOO7E1UntrieBQCodURTaBtotCMe7jtlkNajkvUD6atKTYh1AYJ3JY2bHA="
+    - secure: "Cw+ZqVYKz/mv8yN2dUCJi4DBJImZglaw1GAaddpYBUtdJXgXVVLmQ5i2kWATIyHEQDmMxo9090jrozAkpDKjR2g0BWbywQ1v0G+6HsXkHmxlBkwoqviQK+a6OAEptMg/PeMspu9v+b6StwDX6G/RCv8i782h7xo32b1HpSr8qfE="
     - GLIUM_HEADLESS_TESTS=1
   matrix:
     - FEATURES='' TEST=0 COVERAGE=0 CHECK=0


### PR DESCRIPTION
I've run `travis encrypt CRATESIO_TOKEN=<mytoken>` and it gave me `Cw+Zq...`.
I'm unfortunately not sure whether the previous `CRATESIO_TOKEN` was `Ts/4pe...` or `Afe+PL...`, so I'm guessing the latter, but it might be the former.

cc https://github.com/glium/glium/issues/1876