### PR TITLE
replace deprecated `to_rgba` in examples and book

### DIFF
--- a/book/tuto-06-texture.md
+++ b/book/tuto-06-texture.md
@@ -21,7 +21,7 @@ In order to load the image, we just need to use `image::load`:
 ```rust
 use std::io::Cursor;
 let image = image::load(Cursor::new(&include_bytes!("/path/to/image.png")[..]),
-                        image::ImageFormat::Png).unwrap().to_rgba();
+                        image::ImageFormat::Png).unwrap().to_rgba8();
 let image_dimensions = image.dimensions();
 let image = glium::texture::RawImage2d::from_raw_rgba_reversed(&image.into_raw(), image_dimensions);
 ```

--- a/book/tuto-14-wall.md
+++ b/book/tuto-14-wall.md
@@ -51,7 +51,7 @@ Loading the texture is done like we have already done before:
 
 ```rust
 let image = image::load(Cursor::new(&include_bytes!("../book/tuto-14-diffuse.jpg")[..]),
-                        image::JPEG).unwrap().to_rgba();
+                        image::JPEG).unwrap().to_rgba8();
 let image_dimensions = image.dimensions();
 let image = glium::texture::RawImage2d::from_raw_rgba_reversed(&image.into_raw(), image_dimensions);
 let diffuse_texture = glium::texture::SrgbTexture2d::new(&display, image).unwrap();
@@ -135,7 +135,7 @@ Let's start with the beginning. We load the normal map into a texture:
 
 ```rust
 let image = image::load(Cursor::new(&include_bytes!("../book/tuto-14-normal.png")[..]),
-                        image::PNG).unwrap().to_rgba();
+                        image::PNG).unwrap().to_rgba8();
 let image_dimensions = image.dimensions();
 let image = glium::texture::RawImage2d::from_raw_rgba_reversed(&image.into_raw(), image_dimensions);
 let normal_map = glium::texture::Texture2d::new(&display, image).unwrap();

--- a/examples/blitting.rs
+++ b/examples/blitting.rs
@@ -16,7 +16,7 @@ fn main() {
 
     // building a texture with "OpenGL" drawn on it
     let image = image::load(Cursor::new(&include_bytes!("../tests/fixture/opengl.png")[..]),
-                            image::ImageFormat::Png).unwrap().to_rgba();
+                            image::ImageFormat::Png).unwrap().to_rgba8();
     let image_dimensions = image.dimensions();
     let image = glium::texture::RawImage2d::from_raw_rgba_reversed(&image.into_raw(), image_dimensions);
     let opengl_texture = glium::Texture2d::new(&display, image).unwrap();

--- a/examples/deferred.rs
+++ b/examples/deferred.rs
@@ -39,7 +39,7 @@ fn main() {
     let display = glium::Display::new(wb, cb, &event_loop).unwrap();
 
     let image = image::load(Cursor::new(&include_bytes!("../tests/fixture/opengl.png")[..]),
-        image::ImageFormat::Png).unwrap().to_rgba();
+        image::ImageFormat::Png).unwrap().to_rgba8();
     let image_dimensions = image.dimensions();
     let image = glium::texture::RawImage2d::from_raw_rgba_reversed(&image.into_raw(), image_dimensions);
     let opengl_texture = glium::texture::Texture2d::new(&display, image).unwrap();

--- a/examples/displacement_mapping.rs
+++ b/examples/displacement_mapping.rs
@@ -15,7 +15,7 @@ fn main() {
     let display = glium::Display::new(wb, cb, &event_loop).unwrap();
 
     let image = image::load(Cursor::new(&include_bytes!("../tests/fixture/opengl.png")[..]),
-                            image::ImageFormat::Png).unwrap().to_rgba();
+                            image::ImageFormat::Png).unwrap().to_rgba8();
     let image_dimensions = image.dimensions();
     let image = glium::texture::RawImage2d::from_raw_rgba_reversed(&image.into_raw(), image_dimensions);
     let opengl_texture = glium::texture::CompressedSrgbTexture2d::new(&display, image).unwrap();

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -20,7 +20,7 @@ fn main() {
 
     // building a texture with "OpenGL" drawn on it
     let image = image::load(Cursor::new(&include_bytes!("../tests/fixture/opengl.png")[..]),
-                            image::ImageFormat::Png).unwrap().to_rgba();
+                            image::ImageFormat::Png).unwrap().to_rgba8();
     let image_dimensions = image.dimensions();
     let image = glium::texture::RawImage2d::from_raw_rgba_reversed(&image.into_raw(), image_dimensions);
     let opengl_texture = glium::texture::CompressedTexture2d::new(&display, image).unwrap();

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -18,7 +18,7 @@ fn main() {
 
     // building a texture with "OpenGL" drawn on it
     let image = image::load(Cursor::new(&include_bytes!("../tests/fixture/opengl.png")[..]),
-                            image::ImageFormat::Png).unwrap().to_rgba();
+                            image::ImageFormat::Png).unwrap().to_rgba8();
     let image_dimensions = image.dimensions();
     let image = glium::texture::RawImage2d::from_raw_rgba_reversed(&image.into_raw(), image_dimensions);
     let opengl_texture = glium::texture::CompressedSrgbTexture2d::new(&display, image).unwrap();

--- a/examples/tutorial-06.rs
+++ b/examples/tutorial-06.rs
@@ -13,7 +13,7 @@ fn main() {
     let display = glium::Display::new(wb, cb, &event_loop).unwrap();
 
     let image = image::load(Cursor::new(&include_bytes!("../tests/fixture/opengl.png")[..]),
-                            image::ImageFormat::Png).unwrap().to_rgba();
+                            image::ImageFormat::Png).unwrap().to_rgba8();
     let image_dimensions = image.dimensions();
     let image = glium::texture::RawImage2d::from_raw_rgba_reversed(&image.into_raw(), image_dimensions);
     let texture = glium::texture::Texture2d::new(&display, image).unwrap();

--- a/examples/tutorial-14.rs
+++ b/examples/tutorial-14.rs
@@ -30,13 +30,13 @@ fn main() {
 
 
     let image = image::load(Cursor::new(&include_bytes!("../book/tuto-14-diffuse.jpg")[..]),
-                            image::ImageFormat::Jpeg).unwrap().to_rgba();
+                            image::ImageFormat::Jpeg).unwrap().to_rgba8();
     let image_dimensions = image.dimensions();
     let image = glium::texture::RawImage2d::from_raw_rgba_reversed(&image.into_raw(), image_dimensions);
     let diffuse_texture = glium::texture::SrgbTexture2d::new(&display, image).unwrap();
 
     let image = image::load(Cursor::new(&include_bytes!("../book/tuto-14-normal.png")[..]),
-                            image::ImageFormat::Png).unwrap().to_rgba();
+                            image::ImageFormat::Png).unwrap().to_rgba8();
     let image_dimensions = image.dimensions();
     let image = glium::texture::RawImage2d::from_raw_rgba_reversed(&image.into_raw(), image_dimensions);
     let normal_map = glium::texture::Texture2d::new(&display, image).unwrap();


### PR DESCRIPTION
Building the `blitting` example came up with a deprecation warning:
```rust
warning: use of deprecated associated function `image::DynamicImage::to_rgba`: replaced by `to_rgba8`
  --> examples/blitting.rs:19:63
   |
19 | ...                   image::ImageFormat::Png).unwrap().to_rgba();
   |                                                         ^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: 1 warning emitted
```
I replaced the call with `to_rgba8(…)` as indicated by the API docs.