### PR TITLE
Doctests: replace the calls using assume_init with function params

### DIFF
--- a/build/textures.rs
+++ b/build/textures.rs
@@ -440,9 +440,7 @@ fn build_texture<W: Write>(dest: &mut W, ty: TextureType, dimensions: TextureDim
                                 ///
                                 /// ```no_run
                                 /// # #[macro_use] extern crate glium;
-                                /// # fn main() {{
-                                /// # let texture: glium::texture::Texture2d = unsafe {{
-                                /// # ::std::mem::MaybeUninit::uninit().assume_init() }};
+                                /// # fn example(texture: glium::texture::Texture2d) {{
                                 /// let uniforms = uniform! {{
                                 ///     color_texture: texture.sampled().magnify_filter(glium::uniforms::MagnifySamplerFilter::Nearest)
                                 /// }};

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -25,10 +25,10 @@
 //! `implement_buffer_content!` macro on them. You must then use the `empty_unsized` constructor.
 //!
 //! ```no_run
-//! # #[macro_use] extern crate glium; fn main() {
+//! # #[macro_use] extern crate glium;
+//! # fn example(display: glium::Display) {
 //! # use std::mem;
 //! # use glium::buffer::{BufferType, BufferMode};
-//! # let display: glium::Display = unsafe { mem::MaybeUninit::uninit().assume_init() };
 //! struct Data {
 //!     data: [f32],        // `[f32]` is unsized, therefore `Data` is unsized too
 //! }

--- a/src/buffer/view.rs
+++ b/src/buffer/view.rs
@@ -244,8 +244,9 @@ impl<T: ?Sized> Buffer<T> where T: Content {
     ///     value2: u16,
     /// }
     ///
-    /// # let buffer: glium::buffer::Buffer<BufferContent> = unsafe { ::std::mem::MaybeUninit::uninit().assume_init() };
+    /// # fn example(buffer: glium::buffer::Buffer<BufferContent>) {
     /// let slice = unsafe { buffer.slice_custom(glium::field!(BufferContent, value2)) };
+    /// # }
     /// ```
     #[inline]
     pub unsafe fn slice_custom<R>(&self, f: Field<R>) -> BufferSlice<'_, R>
@@ -599,8 +600,9 @@ impl<'a, T: ?Sized> BufferSlice<'a, T> where T: Content + 'a {
     ///     value2: u16,
     /// }
     ///
-    /// # let buffer: glium::buffer::Buffer<BufferContent> = unsafe { ::std::mem::MaybeUninit::uninit().assume_init() };
+    /// # fn example(buffer: glium::buffer::Buffer<BufferContent>) {
     /// let slice = unsafe { buffer.slice_custom(glium::field!(BufferContent, value2)) };
+    /// # }
     /// ```
     #[inline]
     pub unsafe fn slice_custom<R>(&self, f: Field<R>) -> BufferSlice<'a, R>

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -508,10 +508,7 @@ impl Context {
     /// ## Example
     ///
     /// ```no_run
-    /// # extern crate glium;
-    /// # extern crate glutin;
-    /// # fn main() {
-    /// # let display: glium::Display = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+    /// # fn example(display: glium::Display) {
     /// let pixels: Result<Vec<Vec<(u8, u8, u8, u8)>>, _> = display.read_front_buffer();
     /// # }
     /// ```

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -101,7 +101,7 @@ pub enum MessageType {
 /// ## Example
 ///
 /// ```no_run
-/// # let display: glium::Display = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+/// # fn example(display: glium::Display) {
 /// let before = glium::debug::TimestampQuery::new(&display);
 /// // do some stuff here
 /// let after = glium::debug::TimestampQuery::new(&display);
@@ -113,6 +113,7 @@ pub enum MessageType {
 ///     },
 ///     _ => ()
 /// }
+/// # }
 /// ```
 ///
 pub struct TimestampQuery {

--- a/src/draw_parameters/mod.rs
+++ b/src/draw_parameters/mod.rs
@@ -20,26 +20,28 @@
 //! `SamplesPassedQuery` allows you to know the number of samples that have been drawn.
 //!
 //! ```no_run
-//! # let display: glium::Display = unsafe { ::std::mem::MaybeUninit::uninit().assume_init() };
+//! # fn example(display: glium::Display) {
 //! let query = glium::draw_parameters::SamplesPassedQuery::new(&display).unwrap();
 //! let params = glium::DrawParameters {
 //!     samples_passed_query: Some((&query).into()),
 //!     .. Default::default()
 //! };
+//! # }
 //! ```
 //!
 //! After drawing with these parameters, you can retrieve the value inside the query:
 //!
 //! ```no_run
-//! # let query: glium::draw_parameters::SamplesPassedQuery = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+//! # fn example(query: glium::draw_parameters::SamplesPassedQuery) {
 //! let value = query.get();
+//! # }
 //! ```
 //!
 //! This operation will consume the query and block until the GPU has finished drawing. Instead,
 //! you can also use the query as a condition for drawing:
 //!
 //! ```no_run
-//! # let query: glium::draw_parameters::SamplesPassedQuery = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+//! # fn example(query: glium::draw_parameters::SamplesPassedQuery) {
 //! let params = glium::DrawParameters {
 //!     condition: Some(glium::draw_parameters::ConditionalRendering {
 //!         query: (&query).into(),
@@ -48,6 +50,7 @@
 //!     }),
 //!     .. Default::default()
 //! };
+//! # }
 //! ```
 //!
 //! If you use conditional rendering, glium will submit the draw command but the GPU will execute

--- a/src/framebuffer/mod.rs
+++ b/src/framebuffer/mod.rs
@@ -5,19 +5,18 @@ In order to draw on a texture, use a `SimpleFrameBuffer`. This framebuffer is co
 shaders that write to `gl_FragColor`.
 
 ```no_run
-# let display: glium::Display = unsafe { ::std::mem::MaybeUninit::uninit().assume_init() };
-# let texture: glium::texture::Texture2d = unsafe { ::std::mem::MaybeUninit::uninit().assume_init() };
+# fn example(display: glium::Display, texture: glium::texture::Texture2d) {
 let framebuffer = glium::framebuffer::SimpleFrameBuffer::new(&display, &texture);
 // framebuffer.draw(...);    // draws over `texture`
+# }
 ```
 
 If, however, your shader wants to write to multiple color buffers at once, you must use
 a `MultiOutputFrameBuffer`.
 
 ```no_run
-# let display: glium::Display = unsafe { ::std::mem::MaybeUninit::uninit().assume_init() };
-# let texture1: glium::texture::Texture2d = unsafe { ::std::mem::MaybeUninit::uninit().assume_init() };
-# let texture2: glium::texture::Texture2d = unsafe { ::std::mem::MaybeUninit::uninit().assume_init() };
+# use glium::texture::Texture2d;
+# fn example(display: glium::Display, texture1: Texture2d, texture2: Texture2d) {
 let output = [ ("output1", &texture1), ("output2", &texture2) ];
 let framebuffer = glium::framebuffer::MultiOutputFrameBuffer::new(&display, output.iter().cloned());
 // framebuffer.draw(...);
@@ -31,6 +30,7 @@ let framebuffer = glium::framebuffer::MultiOutputFrameBuffer::new(&display, outp
 //         output1 = vec4(0.0, 0.0, 0.5, 1.0);
 //         output2 = vec4(1.0, 0.7, 1.0, 1.0);
 //     }
+# }
 ```
 
 **Note**: depth-stencil attachments are not yet implemented.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -427,11 +427,9 @@ macro_rules! implement_uniform_block {
 ///
 /// ## Example
 ///
-/// ```ignore       // TODO: no_run instead
-/// # #[macro_use]
-/// # extern crate glium;
-/// # fn main() {
-/// # let display: glium::Display = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+/// ```no_run
+/// use glium::program;
+/// # fn example(display: glium::Display) {
 /// let program = program!(&display,
 ///     300 => {
 ///         vertex: r#"

--- a/src/program/compute.rs
+++ b/src/program/compute.rs
@@ -105,10 +105,11 @@ impl ComputeShader {
     /// ## Example
     ///
     /// ```no_run
-    /// # let program: glium::Program = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+    /// # fn example(program: glium::Program) {
     /// for (name, uniform) in program.uniforms() {
     ///     println!("Name: {} - Type: {:?}", name, uniform.ty);
     /// }
+    /// # }
     /// ```
     #[inline]
     pub fn uniforms(&self) -> hash_map::Iter<'_, String, Uniform> {
@@ -120,10 +121,11 @@ impl ComputeShader {
     /// ## Example
     ///
     /// ```no_run
-    /// # let program: glium::Program = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+    /// # fn example(program: glium::Program) {
     /// for (name, uniform) in program.get_uniform_blocks() {
     ///     println!("Name: {}", name);
     /// }
+    /// # }
     /// ```
     #[inline]
     pub fn get_uniform_blocks(&self)
@@ -136,10 +138,11 @@ impl ComputeShader {
     /// ## Example
     ///
     /// ```no_run
-    /// # let program: glium::Program = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+    /// fn example(program: glium::Program) {
     /// for (name, uniform) in program.get_shader_storage_blocks() {
     ///     println!("Name: {}", name);
     /// }
+    /// # }
     /// ```
     #[inline]
     pub fn get_shader_storage_blocks(&self)

--- a/src/program/program.rs
+++ b/src/program/program.rs
@@ -130,10 +130,11 @@ impl Program {
     /// # Example
     ///
     /// ```no_run
-    /// # let display: glium::Display = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+    /// # fn example(display: glium::Display) {
     /// # let vertex_source = ""; let fragment_source = ""; let geometry_source = "";
     /// let program = glium::Program::from_source(&display, vertex_source, fragment_source,
     ///     Some(geometry_source));
+    /// # }
     /// ```
     ///
     #[inline]
@@ -189,10 +190,11 @@ impl Program {
     /// ## Example
     ///
     /// ```no_run
-    /// # let program: glium::Program = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+    /// # fn example(program: glium::Program) {
     /// for (name, uniform) in program.uniforms() {
     ///     println!("Name: {} - Type: {:?}", name, uniform.ty);
     /// }
+    /// # }
     /// ```
     #[inline]
     pub fn uniforms(&self) -> hash_map::Iter<'_, String, Uniform> {
@@ -204,10 +206,11 @@ impl Program {
     /// ## Example
     ///
     /// ```no_run
-    /// # let program: glium::Program = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+    /// # fn example(program: glium::Program) {
     /// for (name, uniform) in program.get_uniform_blocks() {
     ///     println!("Name: {}", name);
     /// }
+    /// # }
     /// ```
     #[inline]
     pub fn get_uniform_blocks(&self)
@@ -275,10 +278,11 @@ impl Program {
     /// ## Example
     ///
     /// ```no_run
-    /// # let program: glium::Program = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+    /// # fn example(program: glium::Program) {
     /// for (name, attribute) in program.attributes() {
     ///     println!("Name: {} - Type: {:?}", name, attribute.ty);
     /// }
+    /// # }
     /// ```
     #[inline]
     pub fn attributes(&self) -> hash_map::Iter<'_, String, Attribute> {
@@ -296,10 +300,11 @@ impl Program {
     /// ## Example
     ///
     /// ```no_run
-    /// # let program: glium::Program = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+    /// # fn example(program: glium::Program) {
     /// for (name, uniform) in program.get_shader_storage_blocks() {
     ///     println!("Name: {}", name);
     /// }
+    /// # }
     /// ```
     #[inline]
     pub fn get_shader_storage_blocks(&self)
@@ -312,10 +317,11 @@ impl Program {
     /// ## Example
     ///
     /// ```no_run
-    /// # let program: glium::Program = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+    /// # fn example(program: glium::Program) {
     /// for (name, uniform) in program.get_atomic_counters() {
     ///     println!("Name: {}", name);
     /// }
+    /// # }
     /// ```
     #[inline]
     pub fn get_atomic_counters(&self)
@@ -330,10 +336,11 @@ impl Program {
     /// ## Example
     ///
     /// ```no_run
-    /// # let program: glium::Program = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+    /// # fn example(program: glium::Program) {
     /// for (&(ref name, shader), uniform) in program.get_subroutine_uniforms() {
     ///     println!("Name: {}", name);
     /// }
+    /// # }
     /// ```
     #[inline]
     pub fn get_subroutine_uniforms(&self)

--- a/src/program/raw.rs
+++ b/src/program/raw.rs
@@ -372,10 +372,11 @@ impl RawProgram {
     /// ## Example
     ///
     /// ```no_run
-    /// # let program: glium::Program = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+    /// # fn example(program: glium::Program) {
     /// for (name, uniform) in program.uniforms() {
     ///     println!("Name: {} - Type: {:?}", name, uniform.ty);
     /// }
+    /// # }
     /// ```
     #[inline]
     pub fn uniforms(&self) -> hash_map::Iter<'_, String, Uniform> {
@@ -387,10 +388,11 @@ impl RawProgram {
     /// ## Example
     ///
     /// ```no_run
-    /// # let program: glium::Program = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+    /// # fn example(program: glium::Program) {
     /// for (name, uniform) in program.get_uniform_blocks() {
     ///     println!("Name: {}", name);
     /// }
+    /// # }
     /// ```
     #[inline]
     pub fn get_uniform_blocks(&self)
@@ -486,10 +488,11 @@ impl RawProgram {
     /// ## Example
     ///
     /// ```no_run
-    /// # let program: glium::Program = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+    /// # fn example(program: glium::Program) {
     /// for (name, attribute) in program.attributes() {
     ///     println!("Name: {} - Type: {:?}", name, attribute.ty);
     /// }
+    /// # }
     /// ```
     #[inline]
     pub fn attributes(&self) -> hash_map::Iter<'_, String, Attribute> {
@@ -501,10 +504,11 @@ impl RawProgram {
     /// ## Example
     ///
     /// ```no_run
-    /// # let program: glium::Program = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+    /// # fn example(program: glium::Program) {
     /// for (name, uniform) in program.get_shader_storage_blocks() {
     ///     println!("Name: {}", name);
     /// }
+    /// # }
     /// ```
     #[inline]
     pub fn get_shader_storage_blocks(&self)
@@ -517,10 +521,11 @@ impl RawProgram {
     /// ## Example
     ///
     /// ```no_run
-    /// # let program: glium::Program = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+    /// # fn example(program: glium::Program) {
     /// for (name, uniform) in program.get_atomic_counters() {
     ///     println!("Name: {}", name);
     /// }
+    /// # }
     /// ```
     #[inline]
     pub fn get_atomic_counters(&self)

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -22,11 +22,12 @@ pub struct SyncNotSupportedError;
 /// ## Example
 ///
 /// ```no_run
-/// # let display: glium::Display = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+/// # fn example(display: glium::Display) {
 /// # fn do_something<T>(_: &T) {}
 /// let fence = glium::SyncFence::new(&display).unwrap();
 /// do_something(&display);
 /// fence.wait();   // blocks until the previous operations have finished
+/// # }
 /// ```
 pub struct SyncFence {
     context: Rc<Context>,

--- a/src/texture/bindless.rs
+++ b/src/texture/bindless.rs
@@ -17,9 +17,9 @@ Bindless textures are a very recent feature that is supported only by recent har
 drivers. `resident` will return an `Err` if this feature is not supported.
 
 ```no_run
-# let display: glium::Display = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
-# let texture: glium::texture::Texture2d = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+# fn example(display: glium::Display, texture: glium::texture::Texture2d) {
 let texture = texture.resident().unwrap();
+# }
 ```
 
 In a real application, you will likely manage a `Vec<ResidentTexture>`.
@@ -42,12 +42,12 @@ struct UniformBuffer<'a> {
 
 implement_uniform_block!(UniformBuffer<'a>, texture, some_value);
 
-# let display: glium::Display = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
-# let texture: glium::texture::bindless::ResidentTexture = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+# fn example(display: glium::Display, texture: glium::texture::bindless::ResidentTexture) {
 let uniform_buffer = glium::uniforms::UniformBuffer::new(&display, UniformBuffer {
     texture: glium::texture::TextureHandle::new(&texture, &Default::default()),
     some_value: 5.0,
 });
+# }
 # }
 ```
 

--- a/src/uniforms/mod.rs
+++ b/src/uniforms/mod.rs
@@ -9,13 +9,10 @@ the `#[uniforms]` attribute on it. See the `glium_macros` crate for more infos.
 The second way is to use the `uniform!` macro provided by glium:
 
 ```no_run
-#[macro_use]
-extern crate glium;
-
-# fn main() {
-# let display: glium::Display = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
-# let tex: f32 = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
-# let matrix: f32 = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+# use glium::uniform;
+# fn example(display: glium::Display) {
+# let tex: f32 = 0.0;
+# let matrix: f32 = 0.0;
 let uniforms = uniform! {
     texture: tex,
     matrix: matrix
@@ -30,12 +27,8 @@ In both situations, each field must implement the `UniformValue` trait.
 In order to customize the way a texture is being sampled, you must use a `Sampler`.
 
 ```no_run
-#[macro_use]
-extern crate glium;
-
-# fn main() {
-# let display: glium::Display = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
-# let texture: glium::texture::Texture2d = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+# use glium::uniform;
+# fn example(display: glium::Display, texture: glium::texture::Texture2d) {
 let uniforms = uniform! {
     texture: glium::uniforms::Sampler::new(&texture)
                         .magnify_filter(glium::uniforms::MagnifySamplerFilter::Nearest)
@@ -50,12 +43,8 @@ upload the content of this block in the video memory thanks to a `UniformBuffer`
 can link the buffer to the name of the block, just like any other uniform.
 
 ```no_run
-#[macro_use]
-extern crate glium;
-# fn main() {
-# let display: glium::Display = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
-# let texture: glium::texture::Texture2d = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
-
+# use glium::uniform;
+# fn example(display: glium::Display, texture: glium::texture::Texture2d) {
 let program = glium::Program::from_source(&display,
     "
         #version 110
@@ -96,12 +85,8 @@ than using multiple programs that are switched during execution.
 A subroutine uniform is unique per shader stage, and not per program.
 
 ```no_run
-#[macro_use]
-extern crate glium;
-# fn main() {
-# let display: glium::Display = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
-# let texture: glium::texture::Texture2d = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
-
+# use glium::uniform;
+# fn example(display: glium::Display, texture: glium::texture::Texture2d) {
 let program = glium::Program::from_source(&display,
     "
         #version 150

--- a/src/vertex/buffer.rs
+++ b/src/vertex/buffer.rs
@@ -108,7 +108,6 @@ impl<T> VertexBuffer<T> where T: Vertex {
     /// ```no_run
     /// # #[macro_use]
     /// # extern crate glium;
-    /// # extern crate glutin;
     /// # fn main() {
     /// #[derive(Copy, Clone)]
     /// struct Vertex {
@@ -118,11 +117,12 @@ impl<T> VertexBuffer<T> where T: Vertex {
     ///
     /// implement_vertex!(Vertex, position, texcoords);
     ///
-    /// # let display: glium::Display = unsafe { ::std::mem::MaybeUninit::uninit().assume_init() };
+    /// # fn example(display: glium::Display) {
     /// let vertex_buffer = glium::VertexBuffer::new(&display, &[
     ///     Vertex { position: [0.0,  0.0, 0.0], texcoords: [0.0, 1.0] },
     ///     Vertex { position: [5.0, -3.0, 2.0], texcoords: [1.0, 0.0] },
     /// ]);
+    /// # }
     /// # }
     /// ```
     ///
@@ -233,9 +233,7 @@ impl<T> VertexBuffer<T> where T: Copy {
     /// # Example
     ///
     /// ```no_run
-    /// # extern crate glium;
-    /// # extern crate glutin;
-    /// # fn main() {
+    /// # fn example(display: glium::Display) {
     /// use std::borrow::Cow;
     ///
     /// let bindings = Cow::Owned(vec![(
@@ -249,7 +247,6 @@ impl<T> VertexBuffer<T> where T: Copy {
     ///     ),
     /// ]);
     ///
-    /// # let display: glium::Display = unsafe { ::std::mem::MaybeUninit::uninit().assume_init() };
     /// let data = vec![
     ///     1.0, -0.3, 409.0,
     ///     -0.4, 2.8, 715.0f32

--- a/src/vertex/mod.rs
+++ b/src/vertex/mod.rs
@@ -32,7 +32,7 @@ Once you have a struct that implements the `Vertex` trait, you can build an arra
 upload it to the video memory by creating a `VertexBuffer`.
 
 ```no_run
-# let display: glium::Display = unsafe { ::std::mem::MaybeUninit::uninit().assume_init() };
+# fn example(display: glium::Display) {
 # #[derive(Copy, Clone)]
 # struct MyVertex {
 #     position: [f32; 3],
@@ -57,6 +57,7 @@ let data = &[
 ];
 
 let vertex_buffer = glium::vertex::VertexBuffer::new(&display, data);
+# }
 ```
 
 ## Drawing
@@ -74,17 +75,10 @@ Each source can be:
 
 ```no_run
 # use glium::Surface;
-# let display: glium::Display = unsafe { ::std::mem::MaybeUninit::uninit().assume_init() };
-# #[derive(Copy, Clone)]
-# struct MyVertex { position: [f32; 3], texcoords: [f32; 2], }
-# impl glium::vertex::Vertex for MyVertex {
-#     fn build_bindings() -> glium::vertex::VertexFormat { unimplemented!() }
-# }
-# let program: glium::program::Program = unsafe { ::std::mem::MaybeUninit::uninit().assume_init() };
+# fn example<V: glium::vertex::Vertex>(display: glium::Display, program: glium::program::Program,
+#            vertex_buffer: glium::vertex::VertexBuffer<V>, vertex_buffer2: glium::vertex::VertexBuffer<V>) {
 # let indices = glium::index::NoIndices(glium::index::PrimitiveType::TrianglesList);
 # let uniforms = glium::uniforms::EmptyUniforms;
-# let vertex_buffer: glium::vertex::VertexBuffer<MyVertex> = unsafe { ::std::mem::MaybeUninit::uninit().assume_init() };
-# let vertex_buffer2: glium::vertex::VertexBuffer<MyVertex> = unsafe { ::std::mem::MaybeUninit::uninit().assume_init() };
 # let mut frame = display.draw();
 // drawing with a single vertex buffer
 frame.draw(&vertex_buffer, &indices, &program, &uniforms, &Default::default()).unwrap();
@@ -112,6 +106,7 @@ frame.draw((&vertex_buffer, vertex_buffer2.per_instance().unwrap()), &indices,
 // instancing without any per-instance attribute
 frame.draw((&vertex_buffer, glium::vertex::EmptyInstanceAttributes { len: 36 }), &indices,
            &program, &uniforms, &Default::default()).unwrap();
+# }
 ```
 
 Note that if you use `index::EmptyIndices` as indices the length of all vertex sources must

--- a/src/vertex/transform_feedback.rs
+++ b/src/vertex/transform_feedback.rs
@@ -57,14 +57,10 @@ use crate::gl;
 /// # Example
 ///
 /// ```no_run
-/// # #[macro_use]
-/// # extern crate glium;
+/// # use glium::{implement_vertex, uniform};
 /// # use glium::Surface;
-/// # fn main() {
-/// # let display: glium::Display = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
-/// # let program: glium::Program = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
-/// # let vb: glium::vertex::VertexBufferAny = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
-/// # let ib: glium::index::IndexBuffer<u16> = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+/// # fn example(display: glium::Display, program: glium::Program,
+/// #            vb: glium::vertex::VertexBufferAny, ib: glium::index::IndexBuffer<u16>) {
 /// #[derive(Copy, Clone, Debug, PartialEq)]
 /// struct Vertex {
 ///     output_val: (f32, f32),


### PR DESCRIPTION
We shouldn't have UB, not even in doctests.

Implements what originally the author of #1853 promised to do, but then didn't follow up on.

Function params also don't require any unsafe.

This PR also changes one test from ignore to no_run, implementing a TODO.