### PR TITLE
Clamp max attribute name length to [63, 2047] and comment

### DIFF
--- a/src/program/reflection.rs
+++ b/src/program/reflection.rs
@@ -1,5 +1,6 @@
 use crate::gl;
 
+use std::cmp;
 use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
 use std::ffi;
@@ -345,7 +346,7 @@ pub unsafe fn reflect_attributes(ctxt: &mut CommandContext<'_>, program: Handle)
                                                 &mut attr_name_len_max);
             }
         };
-        (active_attributes, attr_name_len_max)
+        (active_attributes, cmp::min(cmp::max(attr_name_len_max, 63), 2047))
     };
 
     // the result of this function

--- a/src/program/reflection.rs
+++ b/src/program/reflection.rs
@@ -346,7 +346,10 @@ pub unsafe fn reflect_attributes(ctxt: &mut CommandContext<'_>, program: Handle)
                                                 &mut attr_name_len_max);
             }
         };
-        (active_attributes, cmp::min(cmp::max(attr_name_len_max, 63), 2047))
+        //let's not trust the driver too much, and clamp the max_len to [63, 2047]
+        attr_name_len_max = cmp::min(cmp::max(attr_name_len_max, 63), 2047);
+
+        (active_attributes, attr_name_len_max)
     };
 
     // the result of this function
@@ -392,7 +395,11 @@ pub unsafe fn reflect_attributes(ctxt: &mut CommandContext<'_>, program: Handle)
         }
 
         if attr_name.is_empty() {
-            continue;   //TODO what do we really want to do here, return an error?
+            //Some spirv compilers add an empty attribute to shaders. Most drivers
+            //don't expose this attribute, but some do.
+            //Since we can't do anything with empty attribute names, we simply skip
+            //them in this reflection code.
+            continue;
         }
 
         let location = match program {

--- a/src/program/reflection.rs
+++ b/src/program/reflection.rs
@@ -346,7 +346,7 @@ pub unsafe fn reflect_attributes(ctxt: &mut CommandContext<'_>, program: Handle)
                                                 &mut attr_name_len_max);
             }
         };
-        //let's not trust the driver too much, and clamp the max_len to [63, 2047]
+        // let's not trust the driver too much, and clamp the max_len to [63, 2047]
         attr_name_len_max = cmp::min(cmp::max(attr_name_len_max, 63), 2047);
 
         (active_attributes, attr_name_len_max)
@@ -395,10 +395,10 @@ pub unsafe fn reflect_attributes(ctxt: &mut CommandContext<'_>, program: Handle)
         }
 
         if attr_name.is_empty() {
-            //Some spirv compilers add an empty attribute to shaders. Most drivers
-            //don't expose this attribute, but some do.
-            //Since we can't do anything with empty attribute names, we simply skip
-            //them in this reflection code.
+            // Some spirv compilers add an empty attribute to shaders. Most drivers
+            // don't expose this attribute, but some do.
+            // Since we can't do anything with empty attribute names, we simply skip
+            // them in this reflection code.
             continue;
         }
 


### PR DESCRIPTION
Let's not trust the driver too much.