### PR TITLE
Only compile the tests, don't run them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,17 +23,12 @@ jobs:
       env:
         RUSTFLAGS: -D warnings
       run: |
-        cargo check --all
-    - name: Run the tests
+        cargo check --all --all-targets
+    - name: Compile the tests
       env:
         RUSTFLAGS: -D warnings
       run: |
-         cargo test --all
-    - name: Run the tests with x509-parser enabled
-      env:
-        RUSTFLAGS: -D warnings
-      run: |
-         cargo test --verbose --features x509-parser
+         cargo test --all --all-targets --no-run
     - name: Run cargo doc
       run: |
         cargo doc --all --all-features


### PR DESCRIPTION
Most of the tests create an event loop, which
can't be created outside of the main thread.

Thus these tests need a custom runner that
runs the tests only on the main thread.

Don't run the tests for now.

Part of #1892