### PR TITLE
Include Windows jobs in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macOS-latest, ubuntu-latest]
+        os: [macOS-latest, windows-latest, ubuntu-latest]
         toolchain: [stable, beta, nightly]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Glium interacts with C interfaces and thus it's best to test a diverse set of origin operating systems.