### PR TITLE
Add missing use to full example

### DIFF
--- a/book/tuto-01-getting-started.md
+++ b/book/tuto-01-getting-started.md
@@ -116,6 +116,7 @@ Here is our full `main` function after this step:
 
 ```rust
 extern crate glium;
+use glium::Surface;
 
 fn main() {
     use glium::{glutin, Surface};


### PR DESCRIPTION
This is in an above step but is missing from the full example.