### PR TITLE
Fix UniformBlockLayoutMismatch error in gpgpu example

### DIFF
--- a/examples/gpgpu.rs
+++ b/examples/gpgpu.rs
@@ -43,7 +43,7 @@ fn main() {
     struct Data {
         power: f32,
         _padding: [f32; 3],
-        values: [[f32;4]; NUM_VALUES],
+        values: [[f32; 4]; NUM_VALUES / 4],
     }
 
     implement_uniform_block!(Data, power, values);
@@ -59,7 +59,7 @@ fn main() {
         }
     }
 
-    program.execute(uniform! { MyBlock: &*buffer }, 4096, 1, 1);
+    program.execute(uniform! { MyBlock: &*buffer }, NUM_VALUES as u32 / 4, 1, 1);
 
     {
         let mapping = buffer.map();


### PR DESCRIPTION
Running the gpgpu example on the master branch resulted in a `UniformBlockLayoutMismatch` error and needed a minor fix.

The intention seems to be to raise 4096 floating point numbers, which are packed in 1024 `vec4`s, to the power of a random floating point number, so I adjusted the length of the input array and the number of work groups so that they match up to 1024.

Error:
```
> cargo run --example gpgpu                  
   Compiling glium v0.29.0 (C:\Users\***\dev\glium)
    Finished dev [unoptimized + debuginfo] target(s) in 2.05s
     Running `target\debug\examples\gpgpu.exe`
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: UniformBlockLayoutMismatch { name: "MyBlock", err: MemberMismatch { member: "values", err: LayoutMismatch { expected: Array { content: BasicType { ty: FloatVec4, offset_in_buffer: 16 }, length: 1024 }, obtained: Array { content: BasicType { ty: FloatVec4, offset_in_buffer: 16 }, length: 4096 } } } }', C:\Users\***\dev\glium\src\program\compute.rs:89:65
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
error: process didn't exit successfully: `target\debug\examples\gpgpu.exe` (exit code: 101)
```