### PR TITLE
Adopt intra-doc-links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,7 @@ jobs:
       run: |
          cargo test --all --all-targets --no-run
     - name: Run cargo doc
+      env:
+        RUSTFLAGS: -D warnings
       run: |
         cargo doc --all --all-features

--- a/examples/deferred.rs
+++ b/examples/deferred.rs
@@ -1,4 +1,4 @@
-#![allow(proc_macro_back_compat)]
+#![allow(unknown_lints, proc_macro_back_compat)]
 
 #[macro_use]
 extern crate glium;

--- a/examples/deferred.rs
+++ b/examples/deferred.rs
@@ -1,3 +1,5 @@
+#![allow(proc_macro_back_compat)]
+
 #[macro_use]
 extern crate glium;
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,18 +43,18 @@ OpenGL is similar to a drawing software: you draw something, then draw over it, 
 again, etc. until you are satisfied of the result.
 
 Once you have a `display`, you can call `let mut frame = display.draw();` to start drawing. This
-`frame` object implements [the `Surface` trait](trait.Surface.html) and provides some functions
+`frame` object implements [the `Surface` trait](`Surface`) and provides some functions
 such as `clear_color`, but also allows you to draw with the rendering pipeline.
 
 In order to draw something, you will need to pass:
 
- - A source of vertices (see the [`vertex`](vertex/index.html) module)
- - A source of indices (see the [`index`](index/index.html) module)
+ - A source of vertices (see the [`vertex`](`vertex`) module)
+ - A source of indices (see the [`index`](`index`) module)
  - A program that contains the shader that the GPU will execute (see the
-   [`program`](program/index.html) module)
- - A list of uniforms for the program (see the [`uniforms`](uniforms/index.html) module)
+   [`program`](`mod@program`) module)
+ - A list of uniforms for the program (see the [`uniforms`](`uniforms`) module)
  - Draw parameters to customize the drawing process (see the
-   [`draw_parameters`](draw_parameters/index.html) module)
+   [`draw_parameters`](`draw_parameters`) module)
 
 Once you have finished drawing, you can call `frame.finish()` to swap buffers and present the
 result to the user.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ Easy-to-use, high-level, OpenGL3+ wrapper.
 Glium is based on glutin - a cross-platform crate for building an OpenGL window and handling
 application events.
 
-Glium provides a **Display** which extends the **glutin::WindowedContext** with a high-level, safe API.
+Glium provides a [**Display**](`Display`) which extends the [**glutin::WindowedContext**](`glutin::WindowedContext`) with a high-level, safe API.
 
 # Initialization
 


### PR DESCRIPTION
There were a couple of manual links to documentation. Replace them with intra-doc-links.