### PR TITLE
Update tuto-03-animated-triangle.md

### DIFF
--- a/book/tuto-03-animated-triangle.md
+++ b/book/tuto-03-animated-triangle.md
@@ -30,11 +30,11 @@ while !closed {
                 &Default::default()).unwrap();
     target.finish().unwrap();
 
-    events_loop.poll_events(|event| {
-        match event {
-            glutin::Event::WindowEvent { event, .. } => match event {
-                glutin::WindowEvent::CloseRequested => closed = true,
-                _ => ()
+    event_loop.run(move |ev, _, _| {
+        match ev {
+            glutin::event::Event::WindowEvent { event, .. } => match event {
+                glutin::event::WindowEvent::CloseRequested => closed = true,
+                _ => (),
             },
             _ => (),
         }
@@ -80,11 +80,11 @@ while !closed {
                 &Default::default()).unwrap();
     target.finish().unwrap();
 
-    events_loop.poll_events(|event| {
-        match event {
-            glutin::Event::WindowEvent { event, .. } => match event {
-                glutin::WindowEvent::CloseRequested => closed = true,
-                _ => ()
+    event_loop.run(move |ev, _, _| {
+        match ev {
+            glutin::event::Event::WindowEvent { event, .. } => match event {
+                glutin::event::WindowEvent::CloseRequested => closed = true,
+                _ => (),
             },
             _ => (),
         }


### PR DESCRIPTION
Previously in tutorial 1 and 2 it was called `event_loop`, not `events_loop`.

I have no idea whats going on with line 33. in tutorial 1 it was called `event_loop.run`. changed them to be more like the version found in tutorial 1 but this lead to unreachable code. The triangle loads in the centre of the screen but does not move.

I tried this version and got the same result

```

        event_loop.run(move |ev, _, control_flow| {
            match ev {
                glutin::event::Event::WindowEvent { event, .. } => match event {
                    glutin::event::WindowEvent::CloseRequested => {
                        *control_flow = glutin::event_loop::ControlFlow::Exit;
                        closed = true;
                        return;
                    },
                    _ => return,
                },
                _ => return,
            }
        });
```

I also tried 

```

        event_loop.poll_events(|event| {
            match event {
                glutin::event::WindowEvent { event, .. } => match event {
                    glutin::event::WindowEvent::CloseRequested => closed = true,
                    _ => ()
                },
                _ => (),
            }
        });
```

which gets the following error

```
error[E0574]: expected struct, variant or union type, found enum `glutin::event::WindowEvent`
  --> src\main.rs:72:17
   |
72 |                 glutin::event::WindowEvent { event, .. } => match event {
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ not a struct, variant or union type
   |
help: consider importing this variant instead
   |
4  | use glutin::event::Event::WindowEvent;
   |
```