### PR TITLE
Only check MAX_CLIP_DISTANCES in GL as this is not supported in GLES

### DIFF
--- a/src/draw_parameters/mod.rs
+++ b/src/draw_parameters/mod.rs
@@ -634,19 +634,21 @@ fn sync_clip_planes_bitmask(ctxt: &mut context::CommandContext<'_>, clip_planes_
                             -> Result<(), DrawError> {
     unsafe {
         let mut max_clip_planes: gl::types::GLint = 0;
-        ctxt.gl.GetIntegerv(gl::MAX_CLIP_DISTANCES, &mut max_clip_planes);
-        for i in 0..32 {
-            if clip_planes_bitmask & (1 << i) != ctxt.state.enabled_clip_planes & (1 << i) {
-                if clip_planes_bitmask & (1 << i) != 0 {
-                    if i < max_clip_planes {
-                        ctxt.gl.Enable(gl::CLIP_DISTANCE0 + i as u32);
-                        ctxt.state.enabled_clip_planes |= 1 << i;
-                    } else {
-                        return Err(DrawError::ClipPlaneIndexOutOfBounds);
+        if ctxt.version >= &Version(Api::Gl, 1, 0) {
+            ctxt.gl.GetIntegerv(gl::MAX_CLIP_DISTANCES, &mut max_clip_planes);
+            for i in 0..32 {
+                if clip_planes_bitmask & (1 << i) != ctxt.state.enabled_clip_planes & (1 << i) {
+                    if clip_planes_bitmask & (1 << i) != 0 {
+                        if i < max_clip_planes {
+                            ctxt.gl.Enable(gl::CLIP_DISTANCE0 + i as u32);
+                            ctxt.state.enabled_clip_planes |= 1 << i;
+                        } else {
+                            return Err(DrawError::ClipPlaneIndexOutOfBounds);
+                        }
+                    } else if i < max_clip_planes {
+                        ctxt.gl.Disable(gl::CLIP_DISTANCE0 + i as u32);
+                        ctxt.state.enabled_clip_planes &= !(1 << i);
                     }
-                } else if i < max_clip_planes {
-                    ctxt.gl.Disable(gl::CLIP_DISTANCE0 + i as u32);
-                    ctxt.state.enabled_clip_planes &= !(1 << i);
                 }
             }
         }


### PR DESCRIPTION
This change will limit query of MAX_CLIP_DISTANCES to desktop GL, as this parameter is not available in GLES. Fixes console error spam in Emscripten.