### PR TITLE
Add support for importing and using Vulkan semaphores

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ edition = "2018"
 default = ["glutin"]
 unstable = [] # used for benchmarks
 test_headless = []  # used for testing headless display
+vk_interop = [] # used for texture import from Vulkan
 
 [dependencies.glutin]
 version = "0.26"

--- a/build/main.rs
+++ b/build/main.rs
@@ -1,4 +1,4 @@
-use gl_generator::{Registry, Api, Profile, Fallbacks};
+use gl_generator::{Api, Fallbacks, Profile, Registry};
 use std::env;
 use std::fs::File;
 use std::io::Write;
@@ -17,7 +17,10 @@ fn main() {
     generate_gl_bindings(&mut file_output);
 }
 
-fn generate_gl_bindings<W>(dest: &mut W) where W: Write {
+fn generate_gl_bindings<W>(dest: &mut W)
+where
+    W: Write,
+{
     let gl_registry = Registry::new(
         Api::Gl,
         (4, 6),
@@ -56,6 +59,7 @@ fn generate_gl_bindings<W>(dest: &mut W) where W: Write {
             "GL_ARB_texture_multisample",
             "GL_ARB_texture_rg",
             "GL_ARB_texture_rgb10_a2ui",
+            "GL_ARB_texture_storage",
             "GL_ARB_transform_feedback3",
             "GL_ARB_vertex_buffer_object",
             "GL_ARB_vertex_shader",
@@ -63,6 +67,8 @@ fn generate_gl_bindings<W>(dest: &mut W) where W: Write {
             "GL_ATI_meminfo",
             "GL_EXT_debug_marker",
             "GL_EXT_direct_state_access",
+            "GL_EXT_memory_object",
+            "GL_EXT_memory_object_fd",
             "GL_EXT_framebuffer_blit",
             "GL_EXT_framebuffer_multisample",
             "GL_EXT_framebuffer_object",
@@ -70,6 +76,8 @@ fn generate_gl_bindings<W>(dest: &mut W) where W: Write {
             "GL_EXT_gpu_shader4",
             "GL_EXT_packed_depth_stencil",
             "GL_EXT_provoking_vertex",
+            "GL_EXT_semaphore",
+            "GL_EXT_semaphore_fd",
             "GL_EXT_texture_array",
             "GL_EXT_texture_buffer_object",
             "GL_EXT_texture_compression_s3tc",

--- a/src/context/extensions.rs
+++ b/src/context/extensions.rs
@@ -1,7 +1,7 @@
-use std::ffi::CStr;
-use crate::version::Version;
-use crate::version::Api;
 use crate::gl;
+use crate::version::Api;
+use crate::version::Version;
+use std::ffi::CStr;
 
 macro_rules! extensions {
     ($($string:expr => $field:ident,)+) => {
@@ -129,6 +129,8 @@ extensions! {
     "GL_EXT_buffer_storage" => gl_ext_buffer_storage,
     "GL_EXT_debug_marker" => gl_ext_debug_marker,
     "GL_EXT_direct_state_access" => gl_ext_direct_state_access,
+    "GL_EXT_memory_object" => gl_ext_memory_object,
+    "GL_EXT_memory_object_fd" => gl_ext_memory_object_fd,
     "GL_EXT_disjoint_timer_query" => gl_ext_disjoint_timer_query,
     "GL_EXT_framebuffer_blit" => gl_ext_framebuffer_blit,
     "GL_EXT_framebuffer_object" => gl_ext_framebuffer_object,
@@ -147,6 +149,8 @@ extensions! {
     "GL_EXT_robustness" => gl_ext_robustness,
     "GL_EXT_sRGB_write_control" => gl_ext_srgb_write_control,
     "GL_EXT_texture3D" => gl_ext_texture3d,
+    "GL_EXT_semaphore" => gl_ext_semaphore,
+    "GL_EXT_semaphore_fd" => gl_ext_semaphore_fd,
     "GL_EXT_texture_array" => gl_ext_texture_array,
     "GL_EXT_texture_buffer" => gl_ext_texture_buffer,
     "GL_EXT_texture_buffer_object" => gl_ext_texture_buffer_object,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,7 @@ pub mod pixel_buffer;
 pub mod program;
 pub mod uniforms;
 pub mod vertex;
+pub mod semaphore;
 pub mod texture;
 pub mod field;
 

--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -1,0 +1,110 @@
+#![cfg(feature = "vk_interop")]
+
+use std::{fs::File, mem, rc::Rc};
+
+use crate::{Context, ContextExt};
+
+use crate::{backend::Facade, context::CommandContext, gl};
+
+/// Describes an error encountered during semaphore creation
+#[derive(Debug, Clone, Copy)]
+pub enum SemaphoreCreationError {
+    /// Driver does not support EXT_semaphore
+    SemaphoreObjectNotSupported,
+    /// Driver does not support EXT_semaphore_fd
+    SemaphoreObjectFdNotSupported,
+    /// OpenGL returned a null pointer when creating semaphore
+    NullResult,
+}
+
+/// Describes a semaphore which can be used for OpenGL-Vulkan command queue synchronization
+pub struct Semaphore {
+    context: Rc<Context>,
+    id: gl::types::GLuint,
+    backing_fd: Option<File>,
+}
+
+impl Semaphore {
+    /// Creates a semaphore imported from a opaque file descriptor.
+    #[cfg(target_os = "linux")]
+    pub unsafe fn new_from_fd<F: Facade + ?Sized>(
+        facade: &F,
+        fd: File,
+    ) -> Result<Self, SemaphoreCreationError> {
+        use std::os::unix::io::AsRawFd;
+
+        let ctxt = facade.get_context().make_current();
+        let sem = Self::new(facade, &ctxt)?;
+
+        if ctxt.extensions.gl_ext_semaphore_fd {
+            ctxt.gl
+                .ImportSemaphoreFdEXT(sem.id, gl::HANDLE_TYPE_OPAQUE_FD_EXT, fd.as_raw_fd());
+
+            if ctxt.gl.IsSemaphoreEXT(sem.id) == gl::FALSE {
+                Err(SemaphoreCreationError::NullResult)
+            } else {
+                Ok(sem)
+            }
+        } else {
+            Err(SemaphoreCreationError::SemaphoreObjectFdNotSupported)
+        }
+    }
+
+    fn new<F: Facade + ?Sized>(
+        facade: &F,
+        ctxt: &CommandContext<'_>,
+    ) -> Result<Self, SemaphoreCreationError> {
+        if ctxt.extensions.gl_ext_semaphore {
+            let id = unsafe {
+                let mut id: gl::types::GLuint = 0;
+                ctxt.gl.GenSemaphoresEXT(1, mem::transmute(&mut id));
+                id
+            };
+
+            Ok(Self {
+                context: facade.get_context().clone(),
+                id,
+                backing_fd: None,
+            })
+        } else {
+            Err(SemaphoreCreationError::SemaphoreObjectNotSupported)
+        }
+    }
+
+    /// The semaphore blocks the GPU's command queue until the semaphore is signalled. This does not block the CPU.
+    pub fn wait(&self) {
+        let ctxt = self.context.get_context().make_current();
+        unsafe {
+            ctxt.gl.WaitSemaphoreEXT(
+                self.id,
+                0,
+                std::ptr::null(),
+                0,
+                std::ptr::null(),
+                std::ptr::null(),
+            )
+        }
+    }
+
+    /// Sends signal through semaphore.
+    pub fn signal(&self) {
+        let ctxt = self.context.get_context().make_current();
+        unsafe {
+            ctxt.gl.SignalSemaphoreEXT(
+                self.id,
+                0,
+                std::ptr::null(),
+                0,
+                std::ptr::null(),
+                std::ptr::null(),
+            )
+        }
+    }
+}
+
+impl Drop for Semaphore {
+    fn drop(&mut self) {
+        let ctxt = self.context.get_context().make_current();
+        unsafe { ctxt.gl.DeleteSemaphoresEXT(1, mem::transmute(&self.id)) };
+    }
+}

--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -2,7 +2,11 @@
 
 use std::{fs::File, rc::Rc};
 
-use crate::{Context, ContextExt, GlObject};
+use crate::{
+    buffer::{Buffer, Content},
+    texture::TextureAny,
+    Context, ContextExt, GlObject,
+};
 
 use crate::{backend::Facade, context::CommandContext, gl};
 
@@ -17,7 +21,51 @@ pub enum SemaphoreCreationError {
     NullResult,
 }
 
-/// Describes a semaphore which can be used for OpenGL-Vulkan command queue synchronization
+/// Describes a Vulkan image layout that a texture can be in. See https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageLayout.html
+#[derive(Debug, Clone, Copy)]
+pub enum TextureLayout {
+    /// Corresponds to VK_IMAGE_LAYOUT_UNDEFINED
+    None,
+    /// Corresponds to VK_IMAGE_LAYOUT_GENERAL
+    General,
+    /// Corresponds to VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
+    ColorAttachment,
+    /// Corresponds to VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT
+    DepthStencilAttachment,
+    /// Corresponds to VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL
+    DepthStencilReadOnly,
+    /// Corresponds to VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
+    ShaderReadOnly,
+    /// Corresponds to VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL
+    TransferSrc,
+    /// Corresponds to VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL
+    TransferDst,
+    /// Corresponds to VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL_KHR
+    DepthReadOnlyStencilAttachment,
+    /// Corresponds to VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL_KHR
+    DepthAttachmentStencilReadOnly,
+}
+
+impl Into<crate::gl::types::GLenum> for TextureLayout {
+    fn into(self) -> crate::gl::types::GLenum {
+        match self {
+            TextureLayout::None => gl::NONE,
+            TextureLayout::General => gl::LAYOUT_GENERAL_EXT,
+            TextureLayout::ColorAttachment => gl::LAYOUT_COLOR_ATTACHMENT_EXT,
+            TextureLayout::DepthStencilAttachment => gl::LAYOUT_DEPTH_STENCIL_ATTACHMENT_EXT,
+            TextureLayout::DepthStencilReadOnly => gl::LAYOUT_DEPTH_STENCIL_READ_ONLY_EXT,
+            TextureLayout::ShaderReadOnly => gl::LAYOUT_SHADER_READ_ONLY_EXT,
+            TextureLayout::TransferSrc => gl::LAYOUT_TRANSFER_SRC_EXT,
+            TextureLayout::TransferDst => gl::LAYOUT_TRANSFER_DST_EXT,
+            TextureLayout::DepthReadOnlyStencilAttachment => gl::LAYOUT_DEPTH_STENCIL_READ_ONLY_EXT,
+            TextureLayout::DepthAttachmentStencilReadOnly => {
+                gl::LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_EXT
+            }
+        }
+    }
+}
+
+/// Similar to a GL sync object, this describes a semaphore which can be used for OpenGL-Vulkan command queue synchronization.
 pub struct Semaphore {
     context: Rc<Context>,
     id: gl::types::GLuint,
@@ -70,33 +118,114 @@ impl Semaphore {
             Err(SemaphoreCreationError::SemaphoreObjectNotSupported)
         }
     }
+    /// Same as `wait` but without `buffers` parameter
+    pub fn wait_textures(&self, textures: Option<&[(TextureAny, TextureLayout)]>) {
+        // Don't care about type parameter
+        self.wait::<u32>(textures, None)
+    }
 
     /// The semaphore blocks the GPU's command queue until the semaphore is signalled. This does not block the CPU.
-    pub fn wait(&self) {
+    /// After this completes, the semaphore is returned to the unsignalled state.
+    /// Once the operation is complete, the memory corresponding to the passed `textures` and `buffers` is made available to OpenGL.
+    /// The layouts given with each texture must match the image layout used in Vulkan directly before the semaphore is signalled by it.
+    pub fn wait<T: ?Sized>(
+        &self,
+        textures: Option<&[(TextureAny, TextureLayout)]>,
+        buffers: Option<&[Buffer<T>]>,
+    ) where
+        T: Content,
+    {
         let ctxt = self.context.get_context().make_current();
+
+        let (buffer_ids, buffer_num, _) = match buffers {
+            Some(buffs) => {
+                let ids = buffs.iter().map(|b| b.get_id()).collect::<Vec<_>>();
+                (ids.as_ptr(), buffs.len(), Some(ids))
+            }
+            None => (std::ptr::null(), 0, None),
+        };
+
+        let (texture_ids, texture_layouts, textures_num, _, _) = match textures {
+            Some(textures) => {
+                let ids = textures.iter().map(|t| t.0.get_id()).collect::<Vec<_>>();
+                let layouts = textures
+                    .iter()
+                    .map(|t| t.1.into())
+                    .collect::<Vec<gl::types::GLenum>>();
+                (
+                    ids.as_ptr(),
+                    layouts.as_ptr(),
+                    textures.len(),
+                    Some(ids),
+                    Some(layouts),
+                )
+            }
+            None => (std::ptr::null(), std::ptr::null(), 0, None, None),
+        };
+
         unsafe {
             ctxt.gl.WaitSemaphoreEXT(
                 self.id,
-                0,
-                std::ptr::null(),
-                0,
-                std::ptr::null(),
-                std::ptr::null(),
+                buffer_num as u32,
+                buffer_ids,
+                textures_num as u32,
+                texture_ids,
+                texture_layouts,
             )
         }
     }
 
+    /// Same as `signal`, but without buffers parameter
+    pub fn signal_textures(&self, textures: Option<&[(TextureAny, TextureLayout)]>) {
+        // Don't care about type parameter.
+        self.signal::<u32>(textures, None)
+    }
+
     /// Sends signal through semaphore.
-    pub fn signal(&self) {
+    /// The memory of the `textures` and `buffers` is made available to the external API.
+    /// Before signalling the semaphore, the `textures` are transitioned into the layout specified.
+    pub fn signal<T: ?Sized>(
+        &self,
+        textures: Option<&[(TextureAny, TextureLayout)]>,
+        buffers: Option<&[Buffer<T>]>,
+    ) where
+        T: Content,
+    {
+        let (buffer_ids, buffer_num, _) = match buffers {
+            Some(buffs) => {
+                let ids = buffs.iter().map(|b| b.get_id()).collect::<Vec<_>>();
+                (ids.as_ptr(), buffs.len(), Some(ids))
+            }
+            None => (std::ptr::null(), 0, None),
+        };
+
+        let (texture_ids, texture_layouts, textures_num, _, _) = match textures {
+            Some(textures) => {
+                let ids = textures.iter().map(|t| t.0.get_id()).collect::<Vec<_>>();
+                let layouts = textures
+                    .iter()
+                    .map(|t| t.1.into())
+                    .collect::<Vec<gl::types::GLenum>>();
+                (
+                    ids.as_ptr(),
+                    layouts.as_ptr(),
+                    textures.len(),
+                    Some(ids),
+                    Some(layouts),
+                )
+            }
+            None => (std::ptr::null(), std::ptr::null(), 0, None, None),
+        };
+
         let ctxt = self.context.get_context().make_current();
         unsafe {
             ctxt.gl.SignalSemaphoreEXT(
                 self.id,
-                0,
-                std::ptr::null(),
-                0,
-                std::ptr::null(),
-                std::ptr::null(),
+                buffer_num as u32,
+                buffer_ids,
+                textures_num as u32,
+                texture_ids,
+                texture_layouts,
             )
         }
     }

--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -1,3 +1,6 @@
+/*!
+Contains everything related to external API semaphores.
+*/
 #![cfg(feature = "vk_interop")]
 
 use std::{fs::File, rc::Rc};

--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -141,30 +141,28 @@ impl Semaphore {
     {
         let ctxt = self.context.get_context().make_current();
 
-        let (buffer_ids, buffer_num, _) = match buffers {
-            Some(buffs) => {
-                let ids = buffs.iter().map(|b| b.get_id()).collect::<Vec<_>>();
-                (ids.as_ptr(), buffs.len(), Some(ids))
-            }
-            None => (std::ptr::null(), 0, None),
+        let (buffer_ids, buffer_num, _) = if let Some(buffs) = buffers {
+            let ids = buffs.iter().map(|b| b.get_id()).collect::<Vec<_>>();
+            (ids.as_ptr(), buffs.len(), Some(ids))
+        } else {
+            (std::ptr::null(), 0, None)
         };
 
-        let (texture_ids, texture_layouts, textures_num, _, _) = match textures {
-            Some(textures) => {
-                let ids = textures.iter().map(|t| t.0.get_id()).collect::<Vec<_>>();
-                let layouts = textures
-                    .iter()
-                    .map(|t| t.1.into())
-                    .collect::<Vec<gl::types::GLenum>>();
-                (
-                    ids.as_ptr(),
-                    layouts.as_ptr(),
-                    textures.len(),
-                    Some(ids),
-                    Some(layouts),
-                )
-            }
-            None => (std::ptr::null(), std::ptr::null(), 0, None, None),
+        let (texture_ids, texture_layouts, textures_num, _, _) = if let Some(textures) = textures {
+            let ids = textures.iter().map(|t| t.0.get_id()).collect::<Vec<_>>();
+            let layouts = textures
+                .iter()
+                .map(|t| t.1.into())
+                .collect::<Vec<gl::types::GLenum>>();
+            (
+                ids.as_ptr(),
+                layouts.as_ptr(),
+                textures.len(),
+                Some(ids),
+                Some(layouts),
+            )
+        } else {
+            (std::ptr::null(), std::ptr::null(), 0, None, None)
         };
 
         unsafe {
@@ -195,33 +193,32 @@ impl Semaphore {
     ) where
         T: Content,
     {
-        let (buffer_ids, buffer_num, _) = match buffers {
-            Some(buffs) => {
-                let ids = buffs.iter().map(|b| b.get_id()).collect::<Vec<_>>();
-                (ids.as_ptr(), buffs.len(), Some(ids))
-            }
-            None => (std::ptr::null(), 0, None),
-        };
-
-        let (texture_ids, texture_layouts, textures_num, _, _) = match textures {
-            Some(textures) => {
-                let ids = textures.iter().map(|t| t.0.get_id()).collect::<Vec<_>>();
-                let layouts = textures
-                    .iter()
-                    .map(|t| t.1.into())
-                    .collect::<Vec<gl::types::GLenum>>();
-                (
-                    ids.as_ptr(),
-                    layouts.as_ptr(),
-                    textures.len(),
-                    Some(ids),
-                    Some(layouts),
-                )
-            }
-            None => (std::ptr::null(), std::ptr::null(), 0, None, None),
-        };
-
         let ctxt = self.context.get_context().make_current();
+
+        let (buffer_ids, buffer_num, _) = if let Some(buffs) = buffers {
+            let ids = buffs.iter().map(|b| b.get_id()).collect::<Vec<_>>();
+            (ids.as_ptr(), buffs.len(), Some(ids))
+        } else {
+            (std::ptr::null(), 0, None)
+        };
+
+        let (texture_ids, texture_layouts, textures_num, _, _) = if let Some(textures) = textures {
+            let ids = textures.iter().map(|t| t.0.get_id()).collect::<Vec<_>>();
+            let layouts = textures
+                .iter()
+                .map(|t| t.1.into())
+                .collect::<Vec<gl::types::GLenum>>();
+            (
+                ids.as_ptr(),
+                layouts.as_ptr(),
+                textures.len(),
+                Some(ids),
+                Some(layouts),
+            )
+        } else {
+            (std::ptr::null(), std::ptr::null(), 0, None, None)
+        };
+
         unsafe {
             ctxt.gl.SignalSemaphoreEXT(
                 self.id,

--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -2,6 +2,7 @@
 Contains everything related to external API semaphores.
 */
 #![cfg(feature = "vk_interop")]
+// TODO: Add Windows support via EXT_external_objects_win32
 
 use std::{fs::File, rc::Rc};
 

--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -1,8 +1,8 @@
 #![cfg(feature = "vk_interop")]
 
-use std::{fs::File, mem, rc::Rc};
+use std::{fs::File, rc::Rc};
 
-use crate::{Context, ContextExt};
+use crate::{Context, ContextExt, GlObject};
 
 use crate::{backend::Facade, context::CommandContext, gl};
 
@@ -57,7 +57,7 @@ impl Semaphore {
         if ctxt.extensions.gl_ext_semaphore {
             let id = unsafe {
                 let mut id: gl::types::GLuint = 0;
-                ctxt.gl.GenSemaphoresEXT(1, mem::transmute(&mut id));
+                ctxt.gl.GenSemaphoresEXT(1, &mut id as *mut u32);
                 id
             };
 
@@ -102,9 +102,18 @@ impl Semaphore {
     }
 }
 
+impl GlObject for Semaphore {
+    type Id = gl::types::GLuint;
+
+    #[inline]
+    fn get_id(&self) -> gl::types::GLuint {
+        self.id
+    }
+}
+
 impl Drop for Semaphore {
     fn drop(&mut self) {
         let ctxt = self.context.get_context().make_current();
-        unsafe { ctxt.gl.DeleteSemaphoresEXT(1, mem::transmute(&self.id)) };
+        unsafe { ctxt.gl.DeleteSemaphoresEXT(1, &mut self.id as *mut u32) };
     }
 }

--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -25,7 +25,7 @@ pub struct Semaphore {
 }
 
 impl Semaphore {
-    /// Creates a semaphore imported from a opaque file descriptor.
+    /// Creates a semaphore imported from an opaque file descriptor.
     #[cfg(target_os = "linux")]
     pub unsafe fn new_from_fd<F: Facade + ?Sized>(
         facade: &F,


### PR DESCRIPTION
Thanks to the `EXT_external_objects` OpenGL extension, there now exists a possibility to interoperate between OpenGL and Vulkan. Specifically, this extension allows OpenGL to use Vulkan textures and semaphores.

This PR allows Glium to use Vulkan semaphores imported from linux file descriptors. Next, I will be working on allowing OpenGL to import textures created in Vulkan.

An example showing this working with Vulkano can be found here: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=119006cc560b90947054cfb72e80d0ef

The related Vulkano pull request can be found here: https://github.com/vulkano-rs/vulkano/pull/1606