### PR TITLE
Update ouroboros [fix potential UB]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ fnv = "1.0.5"
 gl_generator = "0.14"
 
 [dev-dependencies]
-ouroboros = "0.9"
+ouroboros = "0.10"
 cgmath = "0.18"
 genmesh = "0.6"
 image = "0.23"

--- a/examples/deferred.rs
+++ b/examples/deferred.rs
@@ -19,7 +19,7 @@ pub struct Dt {
 
 #[self_referencing]
 struct Data {
-    dt: Box<Dt>,
+    dt: Dt,
     #[borrows(dt)]
     #[covariant]
     buffs: (glium::framebuffer::MultiOutputFrameBuffer<'this>, glium::framebuffer::SimpleFrameBuffer<'this>, &'this Dt),
@@ -284,11 +284,11 @@ fn main() {
     let light_texture = glium::texture::Texture2d::empty_with_format(&display, glium::texture::UncompressedFloatFormat::F32F32F32F32, glium::texture::MipmapsOption::NoMipmap, 800, 500).unwrap();
 
     let mut tenants = DataBuilder {
-        dt: Box::new(Dt {
+        dt: Dt {
             depthtexture,
             textures: [texture1, texture2, texture3, texture4],
             light_texture,
-        }),
+        },
         buffs_builder: |dt| {
             let output = [("output1", &dt.textures[0]), ("output2", &dt.textures[1]), ("output3", &dt.textures[2]), ("output4", &dt.textures[3])];
             let framebuffer = glium::framebuffer::MultiOutputFrameBuffer::with_depth_buffer(&display, output.iter().cloned(), &dt.depthtexture).unwrap();


### PR DESCRIPTION
A potential source of undefined behavior was discovered in `ouroboros`. This PR updates it to the latest version `0.10.0` which fixes the problem. The update also drops the requirement that referenced fields exist in a `Box` or another container, so this PR also unboxes those fields.