### PR TITLE
Add support for Dual Source Blending

### DIFF
--- a/build/main.rs
+++ b/build/main.rs
@@ -30,6 +30,7 @@ where
             "GL_AMD_depth_clamp_separate",
             "GL_APPLE_vertex_array_object",
             "GL_ARB_bindless_texture",
+            "GL_ARB_blend_func_extended",
             "GL_ARB_buffer_storage",
             "GL_ARB_compute_shader",
             "GL_ARB_copy_buffer",

--- a/src/draw_parameters/blend.rs
+++ b/src/draw_parameters/blend.rs
@@ -178,6 +178,22 @@ pub enum LinearBlendingFactor {
     /// Multiply the source or destination component by `1.0` minus the alpha value of
     /// `Blend::const_value`.
     OneMinusConstantAlpha,
+
+    /// Multiply the source or destination component by its corresponding value
+    /// in source index one (you need to explicitly specify `layout(location=0, index=1)`
+    /// to bind it in your shader.
+    /// This is useful in Dual Source Blending
+    /// <https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_blend_func_extended.txt>
+    SourceOneColor,
+
+    /// Equivalent to `1 - SourceOneColor`.
+    OneMinusSourceOneColor,
+
+    /// Multiply the source or destination component by the alpha value of source index 1.
+    SourceOneAlpha,
+
+    /// Multiply the source or destination component by `1.0` minus the alpha value of source index 1.
+    OneMinusSourceOneAlpha,
 }
 
 impl LinearBlendingFactor {
@@ -198,6 +214,11 @@ impl LinearBlendingFactor {
             LinearBlendingFactor::OneMinusConstantColor => gl::ONE_MINUS_CONSTANT_COLOR,
             LinearBlendingFactor::ConstantAlpha => gl::CONSTANT_ALPHA,
             LinearBlendingFactor::OneMinusConstantAlpha => gl::ONE_MINUS_CONSTANT_ALPHA,
+            LinearBlendingFactor::SourceOneColor => gl::SRC1_COLOR,
+            LinearBlendingFactor::OneMinusSourceOneColor => gl::ONE_MINUS_SRC1_COLOR,
+            LinearBlendingFactor::SourceOneAlpha => gl::SRC1_ALPHA,
+            LinearBlendingFactor::OneMinusSourceOneAlpha => gl::ONE_MINUS_SRC1_ALPHA,
+
         }
     }
 }


### PR DESCRIPTION
I'm no expert, but this seems to allow using dual source blending ala:

```
let alpha_blending = glium::DrawParameters {
    blend: glium::Blend {
        color: BlendingFunction::Addition {
            source: LinearBlendingFactor::SourceOneColor,
            destination: LinearBlendingFactor::OneMinusSourceOneColor,
        },
        alpha: BlendingFunction::Addition {
            source: LinearBlendingFactor::SourceOneColor,
            destination: LinearBlendingFactor::OneMinusSourceOneColor,
        },
        constant_value: (0.0, 0.0, 0.0, 0.0),
    },

    ..Default::default()
};
```

and this in the shader:

```
// The color + alpha
layout(location=0, index=0) out vec4 color;
// Individual alpha channels for RGBA in color, used for subpixel
// antialiasing blending
layout(location=0, index=1) out vec4 colorMask;
```

based on my reading of:
https://stackoverflow.com/questions/48491340/use-rgb-texture-as-alpha-values-subpixel-font-rendering-in-opengl
https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_blend_func_extended.txt

refs: https://github.com/wez/wezterm/issues/932