### PR TITLE
Also implement AsUniformValue for textures directly

### DIFF
--- a/build/textures.rs
+++ b/build/textures.rs
@@ -425,6 +425,13 @@ fn build_texture<W: Write>(dest: &mut W, ty: TextureType, dimensions: TextureDim
                                 }}
                             }}
 
+                            impl AsUniformValue for {myname} {{
+                                #[inline]
+                                fn as_uniform_value(&self) -> UniformValue {{
+                                    UniformValue::{myname}(self, None)
+                                }}
+                            }}
+
                             impl<'a> AsUniformValue for Sampler<'a, {myname}> {{
                                 #[inline]
                                 fn as_uniform_value(&self) -> UniformValue {{

--- a/tests/texture_creation.rs
+++ b/tests/texture_creation.rs
@@ -87,6 +87,29 @@ fn texture_2d_creation() {
 }
 
 #[test]
+fn texture_2d_as_uniform_value_lifetime() {
+    let display = support::build_display();
+
+    let texture = glium::texture::Texture2d::new(&display, vec![
+        vec![(0, 0, 0, 0), (0, 0, 0, 0)],
+        vec![(0, 0, 0, 0), (0, 0, 0, 0)],
+        vec![(0, 0, 0, 0), (0, 0, 0, 0u8)],
+    ]).unwrap();
+
+    // A function that takes texture reference should be able to return UniformValue (with lifetime
+    // inherited from the reference).
+    fn get_uniforms(texture: &glium::texture::Texture2d) -> glium::uniforms::UniformValue {
+        use glium::uniforms::AsUniformValue;
+        texture.as_uniform_value()
+    }
+
+    let uniforms = get_uniforms(&texture);
+    assert!(matches!(uniforms, glium::uniforms::UniformValue::Texture2d(..)));
+
+    display.assert_no_error(None);
+}
+
+#[test]
 fn empty_texture2d_u8u8u8u8() {
     let display = support::build_display();
 


### PR DESCRIPTION
In addition to implementing if for references, i.e.
`impl<'a> AsUniformValue for &'a {TextureType}`.

The method `as_uniform_value(&self)` takes self by reference, so there
should be no need to require the second-level reference.

This allows a longer lifetime to be automatically inferred. Fixes
compilation of the texture_2d_as_uniform_value_lifetime() test from the
previous commit.

This commit doesn't remove the original impl above in order not to introduce
breaking changes. Removing would mean every texture passing in `uniform! {}`
would have to change.

Should fix #1400. We should also be able to close #1054 (resolved in a slightly different manner).
Related closed issues/PRs: #1629, #1632.

Also related: #1850 - not fixed in this PR, but a similar change to impl for `Sampler` could fix it.
CC @slightknack.