### PR TITLE
add cubemap support

### DIFF
--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -790,7 +790,7 @@ impl<P> Texture3dDataSink<P> for Vec<Vec<Vec<P>>> where P: Copy + Clone {
 }
 
 
-/// wrap RawCubemap in RawImage3d
+/// Wraps a RawImage3d into a cube map
 pub struct RawCubemap<'a, T: Clone> {
     data: RawImage3d<'a, T>,
     dimension: u32,


### PR DESCRIPTION
it implements Cubemap binding with texture3d fixed issue #644. it's the easiest way if don't refactor the texture. the project doesn't have an example showing how to test it correctly, so it may have some problems or bugs. 