### PR TITLE
Fix texture tutorial color space

### DIFF
--- a/book/tuto-06-texture.md
+++ b/book/tuto-06-texture.md
@@ -29,7 +29,7 @@ let image = glium::texture::RawImage2d::from_raw_rgba_reversed(&image.into_raw()
 And in order to upload the image as a texture, it's as simple as:
 
 ```rust
-let texture = glium::texture::Texture2d::new(&display, image).unwrap();
+let texture = glium::texture::SrgbTexture2d::new(&display, image).unwrap();
 ```
 
 # Using the texture

--- a/examples/tutorial-06.rs
+++ b/examples/tutorial-06.rs
@@ -16,7 +16,7 @@ fn main() {
                             image::ImageFormat::Png).unwrap().to_rgba8();
     let image_dimensions = image.dimensions();
     let image = glium::texture::RawImage2d::from_raw_rgba_reversed(&image.into_raw(), image_dimensions);
-    let texture = glium::texture::Texture2d::new(&display, image).unwrap();
+    let texture = glium::texture::SrgbTexture2d::new(&display, image).unwrap();
 
     #[derive(Copy, Clone)]
     struct Vertex {


### PR DESCRIPTION
The texure was originally loaded in linear space. Substituting the original image for a photo makes it clear that the colors are off, so using SRGB.