### PR TITLE
Add support for importing Vulkan textures

### DIFF
--- a/build/textures.rs
+++ b/build/textures.rs
@@ -802,6 +802,24 @@ fn build_texture<W: Write>(dest: &mut W, ty: TextureType, dimensions: TextureDim
                 }}
         ", format = relevant_format, name = name)).unwrap();
 
+    // writing the 'new_from_fd' function
+    (writeln!(dest, r#"
+                /// Builds a new texture reference from an existing texture, externally created by a foreign
+                /// API like Vulkan. The texture is imported via an opaque file descriptor. You must make
+                /// sure all of the texture parameters match those used to create the texture in Vulkan.
+                #[cfg(target_os = "linux")]
+                pub unsafe fn new_from_fd<F: Facade + ?Sized>(facade: &F,
+                                                 format: {format},
+                                                 mipmaps: MipmapsOption,
+                                                 ty: Dimensions,
+                                                 params: crate::texture::ImportParameters,
+                                                 fd: std::fs::File)
+                                                 -> Result<{name}, crate::texture::TextureImportError> {{
+                    let format = format.to_texture_format();
+                    Ok({name}(any::new_from_fd(facade, format, mipmaps, ty, params, fd)?))
+                }}
+        "#, format = relevant_format, name = name)).unwrap();
+
     // dimensions getters
     write_dimensions_getters(dest, dimensions, "self.0", true);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,6 +151,7 @@ pub mod debug;
 pub mod draw_parameters;
 pub mod framebuffer;
 pub mod index;
+pub mod memory_object;
 pub mod pixel_buffer;
 pub mod program;
 pub mod uniforms;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1387,3 +1387,4 @@ fn get_gl_error(ctxt: &mut context::CommandContext<'_>) -> Option<&'static str> 
         _ => Some("Unknown glGetError return value")
     }
 }
+

--- a/src/memory_object.rs
+++ b/src/memory_object.rs
@@ -30,12 +30,12 @@ impl std::fmt::Display for MemoryObjectCreationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         use self::MemoryObjectCreationError::*;
 
-	let desc = match *self {
-	    MemoryObjectNotSupported => "Driver does not support EXT_memory_object",
-	    MemoryObjectFdNotSupported => "Driver does not support EXT_memory_object_fd",
-	    NullResult => "OpenGL returned a null pointer when creating memory object",
-	};
-	f.write_str(desc)
+        let desc = match *self {
+            MemoryObjectNotSupported => "Driver does not support EXT_memory_object",
+            MemoryObjectFdNotSupported => "Driver does not support EXT_memory_object_fd",
+            NullResult => "OpenGL returned a null pointer when creating memory object",
+        };
+        f.write_str(desc)
     }
 }
 
@@ -60,7 +60,7 @@ impl MemoryObject {
         fd: std::fs::File,
         size: u64,
     ) -> Result<Self, MemoryObjectCreationError> {
-	use std::os::unix::io::AsRawFd;
+        use std::os::unix::io::AsRawFd;
         let ctxt = facade.get_context().make_current();
         let mem_obj: Self = Self::new(facade, &ctxt)?;
 

--- a/src/memory_object.rs
+++ b/src/memory_object.rs
@@ -13,6 +13,7 @@ use crate::ContextExt;
 use std::{fs::File, mem, rc::Rc};
 
 /// Describes an error encountered during memory object creation
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MemoryObjectCreationError {
     /// Driver does not support EXT_memory_object
     MemoryObjectNotSupported,
@@ -21,6 +22,21 @@ pub enum MemoryObjectCreationError {
     /// OpenGL returned a null pointer when creating memory object
     NullResult,
 }
+
+impl std::fmt::Display for MemoryObjectCreationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use self::MemoryObjectCreationError::*;
+
+	let desc = match *self {
+	    MemoryObjectNotSupported => "Driver does not support EXT_memory_object",
+	    MemoryObjectFdNotSupported => "Driver does not support EXT_memory_object_fd",
+	    NullResult => "OpenGL returned a null pointer when creating memory object",
+	};
+	f.write_str(desc)
+    }
+}
+
+impl std::error::Error for MemoryObjectCreationError {}
 
 /// Describes a memory object created by an external API. In OpenGL there is no distinction
 /// between a texture or buffer and its underlying memory. However, in other API's like Vulkan

--- a/src/memory_object.rs
+++ b/src/memory_object.rs
@@ -13,7 +13,7 @@ use crate::version::Version;
 use crate::backend::Facade;
 use crate::context::Context;
 use crate::ContextExt;
-use std::{fs::File, rc::Rc};
+use std::rc::Rc;
 
 /// Describes an error encountered during memory object creation
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -57,7 +57,7 @@ impl MemoryObject {
     pub unsafe fn new_from_fd<F: Facade + ?Sized>(
         facade: &F,
         dedicated: bool,
-        fd: File,
+        fd: std::fs::File,
         size: u64,
     ) -> Result<Self, MemoryObjectCreationError> {
 	use std::os::unix::io::AsRawFd;

--- a/src/memory_object.rs
+++ b/src/memory_object.rs
@@ -104,11 +104,11 @@ impl MemoryObject {
                 ctxt.gl.CreateMemoryObjectsEXT(1, &mut id as *mut u32);
 
                 if ctxt.gl.IsMemoryObjectEXT(id) == gl::FALSE {
-                    Err(MemoryObjectCreationError::NullResult)
+                    return Err(MemoryObjectCreationError::NullResult);
                 } else {
-                    Ok(id)
+                    id
                 }
-            }?;
+            };
 
             Ok(Self {
                 context: facade.get_context().clone(),

--- a/src/memory_object.rs
+++ b/src/memory_object.rs
@@ -1,0 +1,118 @@
+#![cfg(feature = "vk_interop")]
+// TODO: Add Windows support via EXT_external_objects_win32
+
+use crate::GlObject;
+use crate::context::CommandContext;
+use crate::gl;
+use crate::version::Api;
+use crate::version::Version;
+
+use crate::backend::Facade;
+use crate::context::Context;
+use crate::ContextExt;
+use std::{fs::File, mem, rc::Rc};
+
+/// Describes an error encountered during memory object creation
+pub enum MemoryObjectCreationError {
+    /// Driver does not support EXT_memory_object
+    MemoryObjectNotSupported,
+    /// Driver does not support EXT_memory_object_fd
+    MemoryObjectFdNotSupported,
+    /// OpenGL returned a null pointer when creating memory object
+    NullResult,
+}
+
+/// Describes a memory object created by an external API. In OpenGL there is no distinction
+/// between a texture or buffer and its underlying memory. However, in other API's like Vulkan
+/// the underlying memory and the image are separate. Thus this type is useful when interfacing
+/// with such APIs, as such a memory object can then be used to create a texture or buffer
+/// which OpenGL can then interact with.
+pub struct MemoryObject {
+    context: Rc<Context>,
+    id: gl::types::GLuint,
+}
+
+impl MemoryObject {
+    /// Creates a memory object form an opaque file descriptor.
+    #[cfg(target_os = "linux")]
+    pub unsafe fn new_from_fd<F: Facade + ?Sized>(
+        facade: &F,
+        dedicated: bool,
+        fd: File,
+        size: u64,
+    ) -> Result<Self, MemoryObjectCreationError> {
+	use std::os::unix::io::AsRawFd;
+        let ctxt = facade.get_context().make_current();
+        let mem_obj: Self = Self::new(facade, &ctxt)?;
+
+        if !ctxt.extensions.gl_ext_memory_object_fd {
+            Err(MemoryObjectCreationError::MemoryObjectFdNotSupported)
+        } else {
+            let dedicated: gl::types::GLint = if dedicated {
+                gl::TRUE as i32
+            } else {
+                gl::FALSE as i32
+            };
+
+            ctxt.gl.MemoryObjectParameterivEXT(
+                mem_obj.id,
+                gl::DEDICATED_MEMORY_OBJECT_EXT,
+                mem::transmute(&dedicated),
+            );
+
+            ctxt.gl.ImportMemoryFdEXT(
+                mem_obj.id,
+                size,
+                gl::HANDLE_TYPE_OPAQUE_FD_EXT,
+                fd.as_raw_fd(),
+            );
+
+            Ok(mem_obj)
+        }
+    }
+
+    fn new<F: Facade + ?Sized>(
+        facade: &F,
+        ctxt: &CommandContext<'_>,
+    ) -> Result<Self, MemoryObjectCreationError> {
+        if (ctxt.version >= &Version(Api::Gl, 4, 5)
+            || ctxt.version >= &Version(Api::GlEs, 3, 2)
+            || ctxt.extensions.gl_arb_texture_storage)
+            && ctxt.extensions.gl_ext_memory_object
+        {
+            let id = unsafe {
+                let id: gl::types::GLuint = 0;
+                ctxt.gl.CreateMemoryObjectsEXT(1, mem::transmute(&id));
+
+                if ctxt.gl.IsMemoryObjectEXT(id) == gl::FALSE {
+                    Err(MemoryObjectCreationError::NullResult)
+                } else {
+                    Ok(id)
+                }
+            }?;
+
+            Ok(Self {
+                context: facade.get_context().clone(),
+                id,
+            })
+        } else {
+            Err(MemoryObjectCreationError::MemoryObjectNotSupported)
+        }
+    }
+}
+
+impl GlObject for MemoryObject {
+    type Id = gl::types::GLuint;
+
+    #[inline]
+    fn get_id(&self) -> gl::types::GLuint {
+        self.id
+    }
+}
+
+impl Drop for MemoryObject {
+    fn drop(&mut self) {
+        let ctxt = self.context.get_context().make_current();
+        unsafe { ctxt.gl.DeleteMemoryObjectsEXT(1, &mut self.id as *mut u32) };
+    }
+}

--- a/src/memory_object.rs
+++ b/src/memory_object.rs
@@ -1,4 +1,7 @@
-#![cfg(feature = "vk_interop")]
+/*!
+Contains everything related to external API memory objects.
+*/
+
 // TODO: Add Windows support via EXT_external_objects_win32
 
 use crate::GlObject;
@@ -10,7 +13,7 @@ use crate::version::Version;
 use crate::backend::Facade;
 use crate::context::Context;
 use crate::ContextExt;
-use std::{fs::File, mem, rc::Rc};
+use std::{fs::File, rc::Rc};
 
 /// Describes an error encountered during memory object creation
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -73,7 +76,7 @@ impl MemoryObject {
             ctxt.gl.MemoryObjectParameterivEXT(
                 mem_obj.id,
                 gl::DEDICATED_MEMORY_OBJECT_EXT,
-                mem::transmute(&dedicated),
+                &dedicated as *const i32,
             );
 
             ctxt.gl.ImportMemoryFdEXT(
@@ -97,8 +100,8 @@ impl MemoryObject {
             && ctxt.extensions.gl_ext_memory_object
         {
             let id = unsafe {
-                let id: gl::types::GLuint = 0;
-                ctxt.gl.CreateMemoryObjectsEXT(1, mem::transmute(&id));
+                let mut id: gl::types::GLuint = 0;
+                ctxt.gl.CreateMemoryObjectsEXT(1, &mut id as *mut u32);
 
                 if ctxt.gl.IsMemoryObjectEXT(id) == gl::FALSE {
                     Err(MemoryObjectCreationError::NullResult)

--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -3,7 +3,7 @@ Contains everything related to external API semaphores.
 */
 // TODO: Add Windows support via EXT_external_objects_win32
 
-use std::{fs::File, rc::Rc};
+use std::rc::Rc;
 
 use crate::{
     buffer::{Buffer, Content},
@@ -94,7 +94,7 @@ impl Semaphore {
     #[cfg(target_os = "linux")]
     pub unsafe fn new_from_fd<F: Facade + ?Sized>(
         facade: &F,
-        fd: File,
+        fd: std::fs::File,
     ) -> Result<Self, SemaphoreCreationError> {
         use std::os::unix::io::AsRawFd;
 

--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -28,12 +28,12 @@ impl std::fmt::Display for SemaphoreCreationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         use self::SemaphoreCreationError::*;
 
-	let desc = match *self {
-	    SemaphoreObjectNotSupported => "Driver does not support EXT_semaphore",
-	    SemaphoreObjectFdNotSupported => "Driver does not support EXT_semaphore_fd",
-	    NullResult => "OpenGL returned a null pointer when creating semaphore",
-	};
-	f.write_str(desc)
+        let desc = match *self {
+            SemaphoreObjectNotSupported => "Driver does not support EXT_semaphore",
+            SemaphoreObjectFdNotSupported => "Driver does not support EXT_semaphore_fd",
+            NullResult => "OpenGL returned a null pointer when creating semaphore",
+        };
+        f.write_str(desc)
     }
 }
 
@@ -245,7 +245,7 @@ impl Semaphore {
                 texture_ids,
                 texture_layouts,
             );
-	    ctxt.gl.Flush(); // Must flush after signalling semaphore
+            ctxt.gl.Flush(); // Must flush after signalling semaphore
         }
     }
 }

--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -15,7 +15,7 @@ use crate::{
 use crate::{backend::Facade, context::CommandContext, gl};
 
 /// Describes an error encountered during semaphore creation
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SemaphoreCreationError {
     /// Driver does not support EXT_semaphore
     SemaphoreObjectNotSupported,
@@ -24,6 +24,21 @@ pub enum SemaphoreCreationError {
     /// OpenGL returned a null pointer when creating semaphore
     NullResult,
 }
+
+impl std::fmt::Display for SemaphoreCreationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use self::SemaphoreCreationError::*;
+
+	let desc = match *self {
+	    SemaphoreObjectNotSupported => "Driver does not support EXT_semaphore",
+	    SemaphoreObjectFdNotSupported => "Driver does not support EXT_semaphore_fd",
+	    NullResult => "OpenGL returned a null pointer when creating semaphore",
+	};
+	f.write_str(desc)
+    }
+}
+
+impl std::error::Error for SemaphoreCreationError {}
 
 /// Describes a Vulkan image layout that a texture can be in. See https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageLayout.html
 #[derive(Debug, Clone, Copy)]

--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -86,8 +86,7 @@ impl Into<crate::gl::types::GLenum> for TextureLayout {
 /// Similar to a GL sync object, this describes a semaphore which can be used for OpenGL-Vulkan command queue synchronization.
 pub struct Semaphore {
     context: Rc<Context>,
-    id: gl::types::GLuint,
-    backing_fd: Option<File>,
+    id: gl::types::GLuint,    
 }
 
 impl Semaphore {
@@ -130,7 +129,6 @@ impl Semaphore {
             Ok(Self {
                 context: facade.get_context().clone(),
                 id,
-                backing_fd: None,
             })
         } else {
             Err(SemaphoreCreationError::SemaphoreObjectNotSupported)

--- a/src/texture/any.rs
+++ b/src/texture/any.rs
@@ -457,7 +457,7 @@ pub fn new_texture<'a, F: ?Sized, P>(facade: &F, format: TextureFormatRequest,
         levels: texture_levels as u32,
         generate_mipmaps: should_generate_mipmaps,
         owned: true,
-	memory: None
+        memory: None
     })
 }
 
@@ -488,7 +488,7 @@ pub unsafe fn from_id<F: Facade + ?Sized>(facade: &F,
         levels: mipmap_levels,
         generate_mipmaps: should_generate_mipmaps,
         owned,
-	memory: None,
+        memory: None,
     }
 }
 
@@ -496,17 +496,17 @@ pub unsafe fn from_id<F: Facade + ?Sized>(facade: &F,
 /// API like Vulkan. The texture is imported via an opaque file descriptor.
 #[cfg(target_os = "linux")]
 pub unsafe fn new_from_fd<F: Facade + ?Sized>(facade: &F,
-					      format: TextureFormat,
-					      mipmaps: MipmapsOption,
-					      ty: Dimensions,
-					      params: super::ImportParameters,
-					      fd: std::fs::File) -> Result<TextureAny,super::TextureImportError> {
+                                              format: TextureFormat,
+                                              mipmaps: MipmapsOption,
+                                              ty: Dimensions,
+                                              params: super::ImportParameters,
+                                              fd: std::fs::File) -> Result<TextureAny,super::TextureImportError> {
     use crate::ToGlEnum;
     let memory = MemoryObject::new_from_fd(facade, params.dedicated_memory, fd, params.size)?;
     
     let (width, height, depth, array_size, samples) = extract_dimensions(ty);
     let mipmap_levels = mipmaps.num_levels(width, height, depth);
-						  
+                                                  
     let should_generate_mipmaps = mipmaps.should_generate();
     let texture_levels = mipmaps.num_levels(width, height, depth) as gl::types::GLsizei;
     
@@ -522,27 +522,27 @@ pub unsafe fn new_from_fd<F: Facade + ?Sized>(facade: &F,
      };
 
     let is_multisampled = matches!(ty, Dimensions::Texture2dMultisample {..}
-				   | Dimensions::Texture2dMultisampleArray {..});
+                                   | Dimensions::Texture2dMultisampleArray {..});
     
     let ctxt = facade.get_context().make_current();
 
     let id = {
-	let has_mipmaps = texture_levels > 1;
+        let has_mipmaps = texture_levels > 1;
 
-	let mut id: gl::types::GLuint = 0;
+        let mut id: gl::types::GLuint = 0;
         ctxt.gl.GenTextures(1, &mut id as *mut u32);
-	
-	ctxt.gl.BindTexture(bind_point, id);
-	let gl_tiling: crate::gl::types::GLenum = params.tiling.into();
+        
+        ctxt.gl.BindTexture(bind_point, id);
+        let gl_tiling: crate::gl::types::GLenum = params.tiling.into();
 
-	ctxt.gl.TexParameteri(bind_point, gl::TEXTURE_TILING_EXT, gl_tiling as i32);
+        ctxt.gl.TexParameteri(bind_point, gl::TEXTURE_TILING_EXT, gl_tiling as i32);
 
-	if !is_multisampled {
+        if !is_multisampled {
             ctxt.gl.TexParameteri(bind_point, gl::TEXTURE_WRAP_S, gl::REPEAT as i32);
             ctxt.gl.TexParameteri(bind_point, gl::TEXTURE_MAG_FILTER, filtering as i32);
         }
 
-	match ty {
+        match ty {
             Dimensions::Texture1d { .. } => (),
             Dimensions::Texture2dMultisample { .. } => (),
             Dimensions::Texture2dMultisampleArray { .. } => (),
@@ -575,45 +575,45 @@ pub unsafe fn new_from_fd<F: Facade + ?Sized>(facade: &F,
             ctxt.gl.TexParameteri(bind_point, gl::TEXTURE_MAX_LEVEL, 0);
         }
 
-	if bind_point == gl::TEXTURE_3D || bind_point == gl::TEXTURE_2D_ARRAY || bind_point == gl::TEXTURE_CUBE_MAP_ARRAY {
-	    ctxt.gl.TexStorageMem3DEXT(bind_point, texture_levels, storage_internal_format,
-				       width as gl::types::GLsizei, height.unwrap() as gl::types::GLsizei,
-				       depth.unwrap() as gl::types::GLsizei, memory.get_id(), params.offset);
-	} else if bind_point == gl::TEXTURE_2D || bind_point == gl::TEXTURE_1D_ARRAY || bind_point == gl::TEXTURE_CUBE_MAP {
-	    ctxt.gl.TexStorageMem2DEXT(bind_point, texture_levels, storage_internal_format as gl::types::GLenum,
-				       width as gl::types::GLsizei, height.unwrap() as gl::types::GLsizei, memory.get_id(),
-				       params.offset);		
-	} else if bind_point == gl::TEXTURE_2D_MULTISAMPLE {
-	    ctxt.gl.TexStorageMem2DMultisampleEXT(bind_point, samples.unwrap() as gl::types::GLsizei,
-						  storage_internal_format, width as gl::types::GLsizei,
-						  height.unwrap() as gl::types::GLsizei, gl::TRUE, memory.get_id(), params.offset);
-	} else if bind_point == gl::TEXTURE_2D_MULTISAMPLE_ARRAY {
-	    ctxt.gl.TexStorageMem3DMultisampleEXT(bind_point, samples.unwrap() as gl::types::GLsizei,
-						  storage_internal_format, width as gl::types::GLsizei,
-						  height.unwrap() as gl::types::GLsizei, array_size.unwrap() as gl::types::GLsizei,
-						  gl::TRUE, memory.get_id(), params.offset);
-	} else if bind_point == gl::TEXTURE_1D {
-	    ctxt.gl.TexStorageMem1DEXT(bind_point, texture_levels, storage_internal_format, width as gl::types::GLsizei,
-				       memory.get_id(), params.offset);
-	}
+        if bind_point == gl::TEXTURE_3D || bind_point == gl::TEXTURE_2D_ARRAY || bind_point == gl::TEXTURE_CUBE_MAP_ARRAY {
+            ctxt.gl.TexStorageMem3DEXT(bind_point, texture_levels, storage_internal_format,
+                                       width as gl::types::GLsizei, height.unwrap() as gl::types::GLsizei,
+                                       depth.unwrap() as gl::types::GLsizei, memory.get_id(), params.offset);
+        } else if bind_point == gl::TEXTURE_2D || bind_point == gl::TEXTURE_1D_ARRAY || bind_point == gl::TEXTURE_CUBE_MAP {
+            ctxt.gl.TexStorageMem2DEXT(bind_point, texture_levels, storage_internal_format as gl::types::GLenum,
+                                       width as gl::types::GLsizei, height.unwrap() as gl::types::GLsizei, memory.get_id(),
+                                       params.offset);          
+        } else if bind_point == gl::TEXTURE_2D_MULTISAMPLE {
+            ctxt.gl.TexStorageMem2DMultisampleEXT(bind_point, samples.unwrap() as gl::types::GLsizei,
+                                                  storage_internal_format, width as gl::types::GLsizei,
+                                                  height.unwrap() as gl::types::GLsizei, gl::TRUE, memory.get_id(), params.offset);
+        } else if bind_point == gl::TEXTURE_2D_MULTISAMPLE_ARRAY {
+            ctxt.gl.TexStorageMem3DMultisampleEXT(bind_point, samples.unwrap() as gl::types::GLsizei,
+                                                  storage_internal_format, width as gl::types::GLsizei,
+                                                  height.unwrap() as gl::types::GLsizei, array_size.unwrap() as gl::types::GLsizei,
+                                                  gl::TRUE, memory.get_id(), params.offset);
+        } else if bind_point == gl::TEXTURE_1D {
+            ctxt.gl.TexStorageMem1DEXT(bind_point, texture_levels, storage_internal_format, width as gl::types::GLsizei,
+                                       memory.get_id(), params.offset);
+        }
 
-	if should_generate_mipmaps {
+        if should_generate_mipmaps {
             generate_mipmaps(&ctxt, bind_point);
         }
 
-	id
+        id
     };
     
     Ok (TextureAny {
         context: facade.get_context().clone(),
         id,
         requested_format: TextureFormatRequest::Specific(format),
-	actual_format: Cell::new(None),
+        actual_format: Cell::new(None),
         ty,
         levels: mipmap_levels,
         generate_mipmaps: should_generate_mipmaps,
         owned: false,
-	memory: Some(memory)
+        memory: Some(memory)
     })
 }
 

--- a/src/texture/any.rs
+++ b/src/texture/any.rs
@@ -79,7 +79,7 @@ pub struct TextureAny {
     owned: bool,
 
     /// If this texture was created in Vulkan for example, it may be backed by external memory.
-    memory: Option<MemoryObject>
+    memory: Option<MemoryObject>,
 }
 
 fn extract_dimensions(ty: Dimensions)
@@ -604,7 +604,7 @@ pub unsafe fn new_from_fd<F: Facade + ?Sized>(facade: &F,
         id
     };
     
-    Ok (TextureAny {
+    Ok(TextureAny {
         context: facade.get_context().clone(),
         id,
         requested_format: TextureFormatRequest::Specific(format),

--- a/src/texture/any.rs
+++ b/src/texture/any.rs
@@ -1,4 +1,4 @@
-use crate::ToGlEnum;
+
 use crate::gl;
 use crate::GlObject;
 
@@ -41,8 +41,6 @@ use std::ffi::c_void;
 
 use crate::ops;
 use crate::fbo;
-
-use super::TextureImportError;
 
 /// Type of a texture.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -502,7 +500,8 @@ pub unsafe fn new_from_fd<F: Facade + ?Sized>(facade: &F,
 					      mipmaps: MipmapsOption,
 					      ty: Dimensions,
 					      params: super::ImportParameters,
-					      fd: std::fs::File) -> Result<TextureAny,TextureImportError> {
+					      fd: std::fs::File) -> Result<TextureAny,super::TextureImportError> {
+    use crate::ToGlEnum;
     let memory = MemoryObject::new_from_fd(facade, params.dedicated_memory, fd, params.size)?;
     
     let (width, height, depth, array_size, samples) = extract_dimensions(ty);

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -132,6 +132,9 @@ pub use self::ty_support::{is_texture_3d_supported, is_texture_1d_array_supporte
 pub use self::ty_support::{is_texture_2d_array_supported, is_texture_2d_multisample_supported};
 pub use self::ty_support::{is_texture_2d_multisample_array_supported, is_cubemaps_supported};
 pub use self::ty_support::is_cubemap_arrays_supported;
+pub use self::texture_import::ExternalTilingMode;
+pub use self::texture_import::ImportParameters;
+pub use self::texture_import::TextureImportError;
 
 pub mod bindless;
 pub mod buffer_texture;
@@ -140,7 +143,9 @@ pub mod pixel_buffer;
 mod any;
 mod get_format;
 mod pixel;
+mod texture_import;
 mod ty_support;
+
 
 mod textures {
     #![allow(clippy::all)]

--- a/src/texture/texture_import.rs
+++ b/src/texture/texture_import.rs
@@ -47,11 +47,11 @@ pub enum TextureImportError {
 impl fmt::Display for TextureImportError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         use self::TextureImportError::*;
-	match *self {
-	    FormatNotPresent => write!(fmt, "A specific format for the texture was not given."),
-	    MemoryObjectCreation(e) => e.fmt(fmt),
-	    FormatNotSupported(e) => e.fmt(fmt),
-	}
+        match *self {
+            FormatNotPresent => write!(fmt, "A specific format for the texture was not given."),
+            MemoryObjectCreation(e) => e.fmt(fmt),
+            FormatNotSupported(e) => e.fmt(fmt),
+        }
     }
 }
 

--- a/src/texture/texture_import.rs
+++ b/src/texture/texture_import.rs
@@ -1,0 +1,64 @@
+use std::{error::Error, fmt};
+
+use crate::{gl, image_format::FormatNotSupportedError, memory_object::MemoryObjectCreationError};
+
+/// Describes a tiling mode used in texture storage by an external API
+pub enum ExternalTilingMode {
+    /// Corresponds to VK_IMAGE_TILING_OPTIMAL
+    Optimal,
+    /// Corresponds to VK_IMAGE_TILING_LINEAR
+    Linear
+}
+
+impl Into<crate::gl::types::GLenum> for ExternalTilingMode {
+    fn into(self) -> crate::gl::types::GLenum {
+        match self {
+            ExternalTilingMode::Optimal => gl::OPTIMAL_TILING_EXT,
+            ExternalTilingMode::Linear => gl::LINEAR_TILING_EXT,
+        }
+    }
+}
+
+/// Contains parameters needed to import a texture created in an external
+/// API into OpenGL. Must match with parameters used by external memory.
+pub struct ImportParameters {
+    /// Describes whether this memory was created as "dedicated" by the external API.
+    pub dedicated_memory: bool,
+    /// Size of the memory object in bytes.
+    pub size: u64,
+    /// Offset of the memory object in bytes.
+    pub offset: u64,
+    /// Tiling mode used in the memory object.
+    pub tiling: ExternalTilingMode,
+}
+
+
+/// Error that can happen when importing a texture.
+#[derive(Debug, Clone, Copy)]
+pub enum TextureImportError {
+    /// A specific format for the texture was not given.
+    FormatNotPresent,
+    /// An error ocurred during memory object creation
+    MemoryObjectCreation(MemoryObjectCreationError),
+    /// Texture format not supported by this OpenGL context
+    FormatNotSupported(FormatNotSupportedError),
+}
+
+impl fmt::Display for TextureImportError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use self::TextureImportError::*;
+	match *self {
+	    FormatNotPresent => write!(fmt, "A specific format for the texture was not given."),
+	    MemoryObjectCreation(e) => e.fmt(fmt),
+	    FormatNotSupported(e) => e.fmt(fmt),
+	}
+    }
+}
+
+impl From<MemoryObjectCreationError> for TextureImportError {
+    fn from(e: MemoryObjectCreationError) -> Self {
+        Self::MemoryObjectCreation(e)
+    }
+}
+
+impl Error for TextureImportError {}


### PR DESCRIPTION
As a continuation of my previous work, where I added semaphore import  in #1939, I've been working on adding the possibility to import Vulkan textures into Glium.

This MR adds the functionality of the [EXT_external_objects](https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_external_objects.txt) into Glium.

In Vulkan, textures and memory are separate concepts. Thus, in order to conform to this, the aforementioned extension introduces the concept of memory objects in OpenGL. These external memory objects can be used to create OpenGL textures. Thus, I've added the `new_from_fd` function to textures, which imports a memory object from an opaque file descriptor and uses that to create GL texture.

With this functionality, it is now possible to import Vulkan textures, and with the existing Vulkan semaphore support, it is possible to synchronize access to these textures.

The only remaining issue at the moment is a crash happening with the Intel Iris driver, when flushing the signal semaphore command from the OpenGL side. Running a debug version of the driver, it prints out `Failed to submit batchbuffer: Invalid argument`. Given that the driver does not pass the piglit `vk-semaphores-2` test, this is probably a problem within the Iris driver. I will submit a bug report to the Mesa repository.

I have created some [sample code](https://gist.github.com/fayalalebrun/8845ba4464af687895cf49ba96b105d6). This program draws to a shared texture with Glium from another thread, which is the drawn to the window by Vulkano. This texture oscillates between a black and green color. I'm interested to hear how well it works on Nvidia or with other Intel/AMD drivers.

[Related Vulkano MR](https://github.com/vulkano-rs/vulkano/pull/1734)