### PR TITLE
Add gl_context method to Headless

### DIFF
--- a/src/backend/glutin/headless.rs
+++ b/src/backend/glutin/headless.rs
@@ -5,7 +5,7 @@ use crate::debug;
 use crate::context;
 use crate::backend::{self, Backend};
 use std::rc::Rc;
-use std::cell::RefCell;
+use std::cell::{Ref, RefCell};
 use std::ops::Deref;
 use std::os::raw::c_void;
 use super::glutin;
@@ -118,6 +118,11 @@ impl Headless {
         let glutin_backend = GlutinBackend(glutin_context.clone());
         let context = unsafe { context::Context::new(glutin_backend, checked, debug) }?;
         Ok(Headless { context, glutin: glutin_context })
+    }
+
+    /// Borrow the inner glutin context
+    pub fn gl_context(&self) -> Ref<'_, Takeable<glutin::Context<Pc>>> {
+        self.glutin.borrow()
     }
 
     /// Start drawing on the backbuffer.


### PR DESCRIPTION
At the moment there is an inconsistency between the `Display` and `Headless` glutin backends. While `Display` has a `gl_window` method allowing you to get a reference to the inner glutin context, `Headless` has no such equivalent.

This adds the `gl_context` method to `Headless`, which serves the same function as the `gl_window` method in `Display`.

Such functionality can be very useful if for example you are interfacing with a third party library which requires detailed information about the OpenGL context.