### PR TITLE
Future proof the API a little

### DIFF
--- a/src/backend/glutin/headless.rs
+++ b/src/backend/glutin/headless.rs
@@ -30,7 +30,7 @@ impl Deref for Headless {
 
 impl Deref for GlutinBackend {
     type Target = Rc<RefCell<Takeable<glutin::Context<Pc>>>>;
-    fn deref(&self) -> &Rc<RefCell<Takeable<glutin::Context<Pc>>>> {
+    fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
@@ -121,7 +121,7 @@ impl Headless {
     }
 
     /// Borrow the inner glutin context
-    pub fn gl_context(&self) -> Ref<'_, Takeable<glutin::Context<Pc>>> {
+    pub fn gl_context(&self) -> Ref<'_, impl Deref<Target = glutin::Context<Pc>>> {
         self.glutin.borrow()
     }
 

--- a/src/backend/glutin/mod.rs
+++ b/src/backend/glutin/mod.rs
@@ -162,7 +162,7 @@ impl Display {
 
     /// Borrow the inner glutin WindowedContext.
     #[inline]
-    pub fn gl_window(&self) -> Ref<'_, Takeable<glutin::WindowedContext<Pc>>> {
+    pub fn gl_window(&self) -> Ref<'_, impl Deref<Target = glutin::WindowedContext<Pc>>> {
         self.gl_window.borrow()
     }
 
@@ -240,7 +240,7 @@ impl backend::Facade for Display {
 impl Deref for GlutinBackend {
     type Target = Rc<RefCell<Takeable<glutin::WindowedContext<Pc>>>>;
     #[inline]
-    fn deref(&self) -> &Rc<RefCell<Takeable<glutin::WindowedContext<Pc>>>> {
+    fn deref(&self) -> &Self::Target {
         &self.0
     }
 }


### PR DESCRIPTION
Don't expose Takeable in these two instances. The type is still exposed
by the Deref impls, for which we need TAIT.