### PR TITLE
Add context trait for driver & devices UUID retrieval

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -36,10 +36,12 @@ use crate::vertex_array_object;
 pub use self::capabilities::{ReleaseBehavior, Capabilities, Profile};
 pub use self::extensions::ExtensionsList;
 pub use self::state::GlState;
+pub use self::uuid::UuidError;
 
 mod capabilities;
 mod extensions;
 mod state;
+mod uuid;
 
 /// Stores the state and information required for glium to execute commands. Most public glium
 /// functions require passing a `Rc<Context>`.

--- a/src/context/uuid.rs
+++ b/src/context/uuid.rs
@@ -3,7 +3,7 @@ use super::Context;
 /// Describes an error preventing the retrieval of the uuid.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UuidError {
-     /// EXT_external_objects is not supported by the driver
+    /// EXT_external_objects is not supported by the driver
     ExtensionNotPresent,
 }
 
@@ -13,45 +13,55 @@ impl std::fmt::Display for UuidError {
             UuidError::ExtensionNotPresent => "EXT_external_objects is not supported by the driver",
         };
 
-	f.write_str(desc)
+        f.write_str(desc)
     }
 }
 
 impl std::error::Error for UuidError {}
 
 impl Context {
-    /// Returns the UUID of the driver currently being used by this context. Useful to
-    /// ensure compatibility when sharing resources with an external API.
+    /// Returns the UUID of the driver currently being used by this context.
+    ///
+    /// Useful to ensure compatibility when sharing resources with an external API.
     pub fn driver_uuid(&self) -> Result<[u8; 16], UuidError> {
         if !self.extensions.gl_ext_semaphore && !self.extensions.gl_ext_memory_object {
-	    return Err(UuidError::ExtensionNotPresent)
-	}
-	let mut data = [0u8;16];
-	unsafe {self.gl.GetUnsignedBytevEXT(crate::gl::DRIVER_UUID_EXT, data.as_mut_ptr())};
-	Ok(data)
+            return Err(UuidError::ExtensionNotPresent);
+        }
+        let mut data = [0u8; 16];
+        unsafe {
+            self.gl
+                .GetUnsignedBytevEXT(crate::gl::DRIVER_UUID_EXT, data.as_mut_ptr())
+        };
+        Ok(data)
     }
 
-    /// Returns the UUIDs of the devices being used by this context. Useful to ensure
-    /// compatibility when sharing resources with an external API.
+    /// Returns the UUIDs of the devices being used by this context.
+    ///
+    /// Useful to ensure compatibility when sharing resources with an external API.
     pub fn device_uuids(&self) -> Result<Vec<[u8; 16]>, UuidError> {
-	if !self.extensions.gl_ext_semaphore && !self.extensions.gl_ext_memory_object {
-	    return Err(UuidError::ExtensionNotPresent)
-	}
-	let mut n = std::mem::MaybeUninit::<i32>::uninit();
-	let n = unsafe {
-	    self.gl.GetIntegerv(crate::gl::NUM_DEVICE_UUIDS_EXT, n.as_mut_ptr());
-	    n.assume_init()
-	};
+        if !self.extensions.gl_ext_semaphore && !self.extensions.gl_ext_memory_object {
+            return Err(UuidError::ExtensionNotPresent);
+        }
+        let mut n = std::mem::MaybeUninit::<i32>::uninit();
+        let n = unsafe {
+            self.gl
+                .GetIntegerv(crate::gl::NUM_DEVICE_UUIDS_EXT, n.as_mut_ptr());
+            n.assume_init()
+        };
 
-	let mut res = Vec::with_capacity(n as usize);
-	for i in 0..n {
-	    let mut data = [0u8;16];
-	    unsafe {self.gl.GetUnsignedBytei_vEXT(crate::gl::DEVICE_UUID_EXT, i as u32, data.as_mut_ptr())};
-	    res.push(data);
-	}
+        let mut res = Vec::with_capacity(n as usize);
+        for i in 0..n {
+            let mut data = [0u8; 16];
+            unsafe {
+                self.gl.GetUnsignedBytei_vEXT(
+                    crate::gl::DEVICE_UUID_EXT,
+                    i as u32,
+                    data.as_mut_ptr(),
+                )
+            };
+            res.push(data);
+        }
 
-	Ok(res)
+        Ok(res)
     }
 }
-
-

--- a/src/context/uuid.rs
+++ b/src/context/uuid.rs
@@ -1,0 +1,57 @@
+use crate::ContextUuidExt;
+
+use super::Context;
+
+/// Describes an error preventing the retrieval of the uuid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UuidError {
+    /// EXT_external_objects is not supported by the driver
+    ExtensionNotPresent,
+}
+
+impl std::fmt::Display for UuidError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let desc = match self {
+            UuidError::ExtensionNotPresent => "EXT_external_objects is not supported by the driver",
+        };
+
+	f.write_str(desc)
+    }
+}
+
+impl std::error::Error for UuidError {}
+
+
+
+impl ContextUuidExt for Context {
+    type Error = UuidError;
+
+    fn driver_uuid(&self) -> Result<[u8; 16], Self::Error> {
+        if !self.extensions.gl_ext_semaphore && !self.extensions.gl_ext_memory_object {
+	    return Err(UuidError::ExtensionNotPresent)
+	}
+	let mut data = [0u8;16];
+	unsafe {self.gl.GetUnsignedBytevEXT(crate::gl::DRIVER_UUID_EXT, data.as_mut_ptr())};
+	Ok(data)
+    }
+
+    fn device_uuids(&self) -> Result<Vec<[u8; 16]>, Self::Error> {
+	if !self.extensions.gl_ext_semaphore && !self.extensions.gl_ext_memory_object {
+	    return Err(UuidError::ExtensionNotPresent)
+	}
+	let mut n = std::mem::MaybeUninit::<i32>::uninit();
+	let n = unsafe {
+	    self.gl.GetIntegerv(crate::gl::NUM_DEVICE_UUIDS_EXT, n.as_mut_ptr());
+	    n.assume_init()
+	};
+
+	let mut res = Vec::with_capacity(n as usize);
+	for i in 0..n {
+	    let mut data = [0u8;16];
+	    unsafe {self.gl.GetUnsignedBytei_vEXT(crate::gl::DEVICE_UUID_EXT, i as u32, data.as_mut_ptr())};
+	    res.push(data);
+	}
+
+	Ok(res)
+    }
+}

--- a/src/context/uuid.rs
+++ b/src/context/uuid.rs
@@ -29,8 +29,7 @@ impl Context {
         }
         let mut data = [0u8; 16];
         unsafe {
-            self.gl
-                .GetUnsignedBytevEXT(crate::gl::DRIVER_UUID_EXT, data.as_mut_ptr())
+            self.gl.GetUnsignedBytevEXT(crate::gl::DRIVER_UUID_EXT, data.as_mut_ptr())
         };
         Ok(data)
     }
@@ -44,8 +43,7 @@ impl Context {
         }
         let mut n = std::mem::MaybeUninit::<i32>::uninit();
         let n = unsafe {
-            self.gl
-                .GetIntegerv(crate::gl::NUM_DEVICE_UUIDS_EXT, n.as_mut_ptr());
+            self.gl.GetIntegerv(crate::gl::NUM_DEVICE_UUIDS_EXT, n.as_mut_ptr());
             n.assume_init()
         };
 

--- a/src/context/uuid.rs
+++ b/src/context/uuid.rs
@@ -1,11 +1,9 @@
-use crate::ContextUuidExt;
-
 use super::Context;
 
 /// Describes an error preventing the retrieval of the uuid.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UuidError {
-    /// EXT_external_objects is not supported by the driver
+     /// EXT_external_objects is not supported by the driver
     ExtensionNotPresent,
 }
 
@@ -21,12 +19,10 @@ impl std::fmt::Display for UuidError {
 
 impl std::error::Error for UuidError {}
 
-
-
-impl ContextUuidExt for Context {
-    type Error = UuidError;
-
-    fn driver_uuid(&self) -> Result<[u8; 16], Self::Error> {
+impl Context {
+    /// Returns the UUID of the driver currently being used by this context. Useful to
+    /// ensure compatibility when sharing resources with an external API.
+    pub fn driver_uuid(&self) -> Result<[u8; 16], UuidError> {
         if !self.extensions.gl_ext_semaphore && !self.extensions.gl_ext_memory_object {
 	    return Err(UuidError::ExtensionNotPresent)
 	}
@@ -35,7 +31,9 @@ impl ContextUuidExt for Context {
 	Ok(data)
     }
 
-    fn device_uuids(&self) -> Result<Vec<[u8; 16]>, Self::Error> {
+    /// Returns the UUIDs of the devices being used by this context. Useful to ensure
+    /// compatibility when sharing resources with an external API.
+    pub fn device_uuids(&self) -> Result<Vec<[u8; 16]>, UuidError> {
 	if !self.extensions.gl_ext_semaphore && !self.extensions.gl_ext_memory_object {
 	    return Err(UuidError::ExtensionNotPresent)
 	}
@@ -55,3 +53,5 @@ impl ContextUuidExt for Context {
 	Ok(res)
     }
 }
+
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@ extern crate lazy_static;
 
 #[cfg(feature = "glutin")]
 pub use crate::backend::glutin::glutin;
-pub use crate::context::Profile;
+pub use crate::context::{Profile, UuidError};
 pub use crate::draw_parameters::{Blend, BlendingFunction, LinearBlendingFactor, BackfaceCullingMode};
 pub use crate::draw_parameters::{Depth, DepthTest, PolygonMode, DrawParameters, StencilTest, StencilOperation};
 pub use crate::draw_parameters::{Smooth};
@@ -306,6 +306,18 @@ trait ContextExt {
 
     /// Returns the capabilities of the backend.
     fn capabilities(&self) -> &context::Capabilities;
+}
+
+/// Trait to get driver and devices UUIDs from context.
+pub trait ContextUuidExt {
+    /// Error preventing the retrieval of the uuid.
+    type Error: std::error::Error + Sized;
+    /// Returns the UUID of the driver currently being used by this context. Useful to
+    /// ensure compatibility when sharing resources with an external API.
+    fn driver_uuid(&self) -> Result<[u8; 16], Self::Error>;
+    /// Returns the UUIDs of the devices being used by this context. Useful to ensure
+    /// compatibility when sharing resources with an external API.
+    fn device_uuids(&self) -> Result<Vec<[u8; 16]>, Self::Error>;
 }
 
 /// Internal trait for programs.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,18 +308,6 @@ trait ContextExt {
     fn capabilities(&self) -> &context::Capabilities;
 }
 
-/// Trait to get driver and devices UUIDs from context.
-pub trait ContextUuidExt {
-    /// Error preventing the retrieval of the uuid.
-    type Error: std::error::Error + Sized;
-    /// Returns the UUID of the driver currently being used by this context. Useful to
-    /// ensure compatibility when sharing resources with an external API.
-    fn driver_uuid(&self) -> Result<[u8; 16], Self::Error>;
-    /// Returns the UUIDs of the devices being used by this context. Useful to ensure
-    /// compatibility when sharing resources with an external API.
-    fn device_uuids(&self) -> Result<Vec<[u8; 16]>, Self::Error>;
-}
-
 /// Internal trait for programs.
 trait ProgramExt {
     /// Calls `glUseProgram` and enables/disables `GL_PROGRAM_POINT_SIZE` and


### PR DESCRIPTION
When sharing resources between OpenGL and another API steps must be taken to ensure that the driver and device being used is the same on both sides.  This is especially important on systems with more than one graphics card, or where drivers may be selected on a per-program basis (As is the case on Linux).

For this purpose `EXT_external_objects` adds the possibility to get the UUID's of the driver and devices being used by the OpenGL driver. This can used, for example, in a Vulkan application which intends to share resources with the GL context, to select a compatible physical device.