### PR TITLE
sRGB clear_color if statement logic fix

### DIFF
--- a/src/ops/clear.rs
+++ b/src/ops/clear.rs
@@ -35,11 +35,11 @@ pub fn clear(context: &Context, framebuffer: Option<&ValidatedAttachments<'_>>,
         if ctxt.version >= &Version(Api::Gl, 3, 0) || ctxt.extensions.gl_arb_framebuffer_srgb ||
            ctxt.extensions.gl_ext_framebuffer_srgb || ctxt.extensions.gl_ext_srgb_write_control
         {
-            if !color_srgb && !ctxt.state.enabled_framebuffer_srgb {
+            if color_srgb && !ctxt.state.enabled_framebuffer_srgb {
                 ctxt.gl.Enable(gl::FRAMEBUFFER_SRGB);
                 ctxt.state.enabled_framebuffer_srgb = true;
 
-            } else if color_srgb && ctxt.state.enabled_framebuffer_srgb {
+            } else if !color_srgb && ctxt.state.enabled_framebuffer_srgb {
                 ctxt.gl.Disable(gl::FRAMEBUFFER_SRGB);
                 ctxt.state.enabled_framebuffer_srgb = false;
             }


### PR DESCRIPTION
Pretty simple change, now if `color_srgb` is false it will properly disable the `gl:FRAMEBUFFER_SRGB` option. There was a mistake in the if statement logic.