### PR TITLE
Remove trivial and unnecessary UB

### DIFF
--- a/src/texture/any.rs
+++ b/src/texture/any.rs
@@ -213,8 +213,8 @@ pub fn new_texture<'a, F: ?Sized, P>(facade: &F, format: TextureFormatRequest,
 
         BufferAny::unbind_pixel_unpack(&mut ctxt);
 
-        let id: gl::types::GLuint = 0;
-        ctxt.gl.GenTextures(1, mem::transmute(&id));
+        let mut id: gl::types::GLuint = 0;
+        ctxt.gl.GenTextures(1, &mut id);
 
         {
             ctxt.gl.BindTexture(bind_point, id);


### PR DESCRIPTION
I don't understand why it was written this way. [glGenTextures](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGenTextures.xhtml) is passed a mutable pointer which is set as an out parameter, but the existing code was transmuting a shared reference to the buffer to a mutable pointer, which is undefined behavior. The fix is trivial: just make the buffer mutable and pass a mutable reference instead.