### PR TITLE
Added support for location binding in 'implement_vertex'

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -116,6 +116,7 @@ macro_rules! implement_vertex {
                         (
                             Cow::Borrowed(stringify!($field_name)),
                             $crate::__glium_offset_of!($struct_name, $field_name),
+                            -1,
                             {
                                 // Obtain the type of the $field_name field of $struct_name and
                                 // call get_type on it.
@@ -148,6 +149,7 @@ macro_rules! implement_vertex {
                         (
                             Cow::Borrowed(stringify!($field_name)),
                             $crate::__glium_offset_of!($struct_name, $field_name),
+                            -1,
                             {
                                 // Obtain the type of the $field_name field of $struct_name and
                                 // call get_type on it.
@@ -162,6 +164,41 @@ macro_rules! implement_vertex {
                             {
                                 $should_normalize
                             }
+                        )
+                    ),+
+                ])
+            }
+        }
+    };
+
+    ($struct_name:ident, $($field_name:ident location($location:expr)),+) => {
+        impl $crate::vertex::Vertex for $struct_name {
+            #[inline]
+            fn build_bindings() -> $crate::vertex::VertexFormat {
+                use std::borrow::Cow;
+
+                // TODO: use a &'static [] if possible
+
+                Cow::Owned(vec![
+                    $(
+                        (
+                            Cow::Borrowed(stringify!($field_name)),
+                            $crate::__glium_offset_of!($struct_name, $field_name),
+                            {
+                                $location
+                            },
+                            {
+                                // Obtain the type of the $field_name field of $struct_name and
+                                // call get_type on it.
+                                fn attr_type_of_val<T: $crate::vertex::Attribute>(_: Option<&T>)
+                                    -> $crate::vertex::AttributeType
+                                {
+                                    <T as $crate::vertex::Attribute>::get_type()
+                                }
+                                let field_option = None::<&$struct_name>.map(|v| &v.$field_name);
+                                attr_type_of_val(field_option)
+                            },
+                            false
                         )
                     ),+
                 ])

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -97,10 +97,28 @@ macro_rules! uniform {
 ///
 /// ## Naming convention
 ///
-/// When it comes to using to using your vertex array in a shader you must make sure that all your attribute variables *match* the field names in the struct you are calling calling this macro for.
+/// If not using the location option, when it comes to using to using your vertex array in a shader you must make sure that all your attribute variables *match* the field names in the struct you are calling calling this macro for.
 ///
-/// So, if you have a `vertex_position` atribute/input in your shader, a field named `vertex_position` must be present in the struct. Ohterwise the drawing functions will panic.
+/// So, if you have a `vertex_position` attribute/input in your shader, a field named `vertex_position` must be present in the struct. Otherwise the drawing functions will panic.
 ///
+/// ## Normalize option
+///
+/// You can specify a normalize option for attributes.
+/// ```
+/// # use glium::implement_vertex;
+/// # fn main() {
+/// implement_vertex!(Vertex, position normalize(false), tex_coords normalize(false));
+/// # }
+/// ```
+/// ## Location option
+///
+/// You can specify a location option for attributes.
+/// ```
+/// # use glium::implement_vertex;
+/// # fn main() {
+/// implement_vertex!(Vertex, position location(0), tex_coords location(1));
+/// # }
+/// ```
 #[macro_export]
 macro_rules! implement_vertex {
     ($struct_name:ident, $($field_name:ident),+) => (

--- a/src/program/raw.rs
+++ b/src/program/raw.rs
@@ -428,7 +428,7 @@ impl RawProgram {
         }
 
         for elem in buf.elements.iter() {
-            if format.iter().find(|e| e.1 == elem.offset && e.2 == elem.ty)
+            if format.iter().find(|e| e.1 == elem.offset && e.3 == elem.ty)
                             .is_none()
             {
                 return false;

--- a/src/vertex/format.rs
+++ b/src/vertex/format.rs
@@ -410,7 +410,7 @@ impl AttributeType {
 /// third element is the type and the fourth element indicates whether
 /// or not the element should use fixed-point normalization when
 /// binding in a VAO.
-pub type VertexFormat = Cow<'static, [(Cow<'static, str>, usize, AttributeType, bool)]>;
+pub type VertexFormat = Cow<'static, [(Cow<'static, str>, usize, i32, AttributeType, bool)]>;
 
 unsafe impl Attribute for i8 {
     #[inline]

--- a/src/vertex/mod.rs
+++ b/src/vertex/mod.rs
@@ -290,7 +290,7 @@ pub trait Vertex: Copy + Sized {
     fn is_supported<C: ?Sized>(caps: &C) -> bool where C: CapabilitiesSource {
         let format = Self::build_bindings();
 
-        for &(_, _, ref ty, _) in format.iter() {
+        for &(_, _, _, ref ty, _) in format.iter() {
             if !ty.is_supported(caps) {
                 return false;
             }

--- a/src/vertex_array_object.rs
+++ b/src/vertex_array_object.rs
@@ -286,6 +286,18 @@ impl VertexArrayObject {
             }
         }
 
+        // checking for duplicate attribute locations
+        for &(_, ref bindings, _, _, _) in vertex_buffers {
+            for i in 0..bindings.len() {
+                for o in 0..bindings.len() {
+                    if i != o && bindings[i].2 == bindings[o].2 {
+                        panic!("The program attribute `{}` has the same binding location as program attribute `{}` (binding location {})",
+                               bindings[i].0, bindings[o].0, bindings[i].2)
+                    }
+                }
+            }
+        }
+
         // checking for missing attributes
         for (&ref name, attribute) in program.attributes() {
             let mut found = false;

--- a/src/vertex_array_object.rs
+++ b/src/vertex_array_object.rs
@@ -262,7 +262,7 @@ impl VertexArrayObject {
             for &(ref name, _, location, ty, _) in bindings.iter() {
                 let attribute = match location {
                     -1 => {
-                        // No location precised in Vertex Format. Check name instead
+                        // No location specified in Vertex Format. Check name instead
                         match program.get_attribute(Borrow::<str>::borrow(name)) {
                             Some(a) => a,
                             None => continue,
@@ -549,7 +549,7 @@ unsafe fn bind_attribute(ctxt: &mut CommandContext<'_>, program: &Program,
 
         let attribute = match location {
             -1 => {
-                // No location precised in Vertex Format. Check name instead
+                // No location specified in Vertex Format. Check name instead
                 match program.get_attribute(Borrow::<str>::borrow(name)) {
                     Some(a) => a,
                     None => continue,

--- a/src/vertex_array_object.rs
+++ b/src/vertex_array_object.rs
@@ -288,11 +288,11 @@ impl VertexArrayObject {
 
         // checking for duplicate attribute locations
         for &(_, ref bindings, _, _, _) in vertex_buffers {
-            for i in 0..bindings.len() {
-                for o in 0..bindings.len() {
-                    if i != o && bindings[i].2 == bindings[o].2 {
+            for (i, bi) in bindings.iter().enumerate() {
+                for (o, bo) in bindings.iter().enumerate() {
+                    if i != o && bi.2 == bo.2 {
                         panic!("The program attribute `{}` has the same binding location as program attribute `{}` (binding location {})",
-                               bindings[i].0, bindings[o].0, bindings[i].2)
+                               bi.0, bo.0, bi.2)
                     }
                 }
             }


### PR DESCRIPTION
Firstly, let me tell you
- I don't know glium very much
- I never contributed to a project like that before
- My understanding of OpenGL is basic
- My understanding of rust is.. okay-ish
- My first language is not english. I'm good at it but I can struggle when it gets technical

The code I provided can't be merged right now because of.. reasons. But I can't really do anything more before discussing the topic with you first

I wanted to make GLSL exported from spirv-cross work with glium.  spirv-cross generates GLSL like this
```glsl
layout(location = 0) in vec2 input_position;
layout(location = 1) in vec3 input_color;
```

usually, in raw Opengl, that enough for me. I do some glAttribPointer magic and it's alright

But here comes the glium documentation for [glium::implement_vertex](https://docs.rs/glium/latest/glium/macro.implement_vertex.html#):

> When it comes to using to using your vertex array in a shader you must make sure that all your attribute variables match the field names in the struct you are calling calling this macro for.
> 
> So, if you have a vertex_position atribute/input in your shader, a field named vertex_position must be present in the struct. Ohterwise the drawing functions will panic.

oh no! if spirv-cross (or naga, or anything really) generates something inelegant, i'll have to adapt my struct to it, or modify the generated GLSL somehow. I didn't like this

There might be a solution for this problem that I didn't think of. If that's the case, tell me so I can open an issue and we can sort this out there. But I decided to dive into glium's source code to see if I could make something work

I came with this **VERY INCOMPLETE** implementation. The macro I made works, but is inelegant. The implement_vertex macro has a 'normalize' option thing so I used the same logic to make a 'location' option. But it's not possible to mix 'normalize' and 'location' together, which is a shame. This is a problem of implement_vertex in the first place, but I didn't want to change too much since I don't know the source code enough

I might be missing a couple of checks too. I will need the advice of someone who knows the stuff© to continue.

Here's how to use a location in my implementation

```rust
#[derive(Copy, Clone)]
pub struct Vertex {
    pub position: [f32; 2],
    pub color: [f32; 3],
}

glium::implement_vertex!(Vertex, position location(0), color location(1));

```

This works for me (on a simple triangle with attribute names that do not match). glium still panics if the vertex format is not right (if you made a mistake in the locations for example)