### PR TITLE
Update implement_buffer_content to handle unsafe

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -259,7 +259,7 @@ macro_rules! implement_buffer_content {
                 type Owned = Box<$struct_name<$($gs)*>>;
 
                 #[inline]
-                fn read<F, E>(size: usize, f: F) -> ::std::result::Result<Box<$struct_name<$($gs)*>>, E>
+                unsafe fn read<F, E>(size: usize, f: F) -> ::std::result::Result<Box<$struct_name<$($gs)*>>, E>
                               where F: FnOnce(&mut $struct_name<$($gs)*>) -> ::std::result::Result<(), E>
                 {
                     use std::mem;


### PR DESCRIPTION
#1909 qualified `read` as unsafe. This causes the `implement_buffer_content` macro to no longer work using the example given in the docs:

```rust
struct Data {
    data: [u32]
}

implement_buffer_content!(Data);
```