### PR TITLE
Fix a bug in duplicate location checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## Version 0.32 (2022-07-30)
+## Version 0.32.1 (2022-07-31)
+
+- Bugfix release to not panic when given multiple vertex attributes with unspecified location numbers.
+
+## Version 0.32.0 (2022-07-30)
 
 - Updated glutin to version 0.29.0. See the glutin release notes [here](https://github.com/rust-windowing/glutin/blob/master/CHANGELOG.md#version-0290-2022-07-30).
+- Support for location binding for Vertex attributes.
 
 ## Version 0.31 (2021-12-11)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glium"
-version = "0.32.0"
+version = "0.32.1"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = """
 Elegant and safe OpenGL wrapper.

--- a/src/vertex_array_object.rs
+++ b/src/vertex_array_object.rs
@@ -290,7 +290,7 @@ impl VertexArrayObject {
         for &(_, ref bindings, _, _, _) in vertex_buffers {
             for (i, bi) in bindings.iter().enumerate() {
                 for (o, bo) in bindings.iter().enumerate() {
-                    if i != o && bi.2 == bo.2 {
+                    if i != o && bi.2 == bo.2 && bi.2 != -1 {
                         panic!("The program attribute `{}` has the same binding location as program attribute `{}` (binding location {})",
                                bi.0, bo.0, bi.2)
                     }


### PR DESCRIPTION
The code that checked for duplicate locations in #2013 didn't take into account when you don't specify the location. This broke a lot of glium code, but at run time so the test suite didn't detect it (we don't run tests, only compile them). We push out a bugfix release to remedy this.