### PR TITLE
Fixed using of gl_PointSize on GLES contexts

### DIFF
--- a/src/program/program.rs
+++ b/src/program/program.rs
@@ -82,7 +82,7 @@ impl Program {
                     return Err(ProgramCreationError::TransformFeedbackNotSupported);
                 }
 
-                if uses_point_size && !(facade.get_context().get_version() >= &Version(Api::Gl, 3, 0)) {
+                if uses_point_size && (facade.get_context().get_version().0 == Api::Gl) && !(facade.get_context().get_version() >= &Version(Api::Gl, 3, 0)) {
                     return Err(ProgramCreationError::PointSizeNotSupported);
                 }
 
@@ -103,7 +103,7 @@ impl Program {
             },
 
             ProgramCreationInput::Binary { data, outputs_srgb, uses_point_size } => {
-                if uses_point_size && !(facade.get_context().get_version() >= &Version(Api::Gl, 3, 0)) {
+                if uses_point_size && (facade.get_context().get_version().0 == Api::Gl) && !(facade.get_context().get_version() >= &Version(Api::Gl, 3, 0)) {
                     return Err(ProgramCreationError::PointSizeNotSupported);
                 }
 
@@ -147,7 +147,7 @@ impl Program {
                     return Err(ProgramCreationError::TransformFeedbackNotSupported);
                 }
 
-                if uses_point_size && !(facade.get_context().get_version() >= &Version(Api::Gl, 3, 0)) {
+                if uses_point_size && (facade.get_context().get_version().0 == Api::Gl) && !(facade.get_context().get_version() >= &Version(Api::Gl, 3, 0)) {
                     return Err(ProgramCreationError::PointSizeNotSupported);
                 }
 
@@ -434,10 +434,12 @@ impl GlObject for Program {
 impl ProgramExt for Program {
     fn use_program(&self, ctxt: &mut CommandContext<'_>) {
         // compatibility was checked at program creation
-        if self.uses_point_size && !ctxt.state.enabled_program_point_size {
-            unsafe { ctxt.gl.Enable(gl::PROGRAM_POINT_SIZE); }
-        } else if !self.uses_point_size && ctxt.state.enabled_program_point_size {
-            unsafe { ctxt.gl.Disable(gl::PROGRAM_POINT_SIZE); }
+        if ctxt.version.0 == Api::Gl {
+            if self.uses_point_size && !ctxt.state.enabled_program_point_size {
+                unsafe { ctxt.gl.Enable(gl::PROGRAM_POINT_SIZE); }
+            } else if !self.uses_point_size && ctxt.state.enabled_program_point_size {
+                unsafe { ctxt.gl.Disable(gl::PROGRAM_POINT_SIZE); }
+            }
         }
 
         if (ctxt.version >= &Version(Api::Gl, 3, 0) || ctxt.extensions.gl_arb_framebuffer_srgb ||


### PR DESCRIPTION
Good evening, first off, thank you for maintaining this brilliant library! It's been a pleasure to use.

Apart from that I've stumbled upon a problem with the handling of `GL_PROGRAM_POINT_SIZE` in ES contexts, there is a check which throws an error if the context is not GL 3.0 or higher, however `GL_PROGRAM_POINT_SIZE` support seems to be available from 2.0 onwards. On ES that enum is not available and gl_PointSize seems to be available by default.

Because of this I've removed the version check and also added changes so that the glEnable/Disable calls for GL_PROGRAM_POINT_SIZE will only occur on GL contexts where they are necessary, and not in ES contexts since they result in a panic there.

With this patch applied my program at least runs great on both GL and ES contexts.

1. https://registry.khronos.org/OpenGL-Refpages/gl4/html/gl_PointSize.xhtml - gl_PointSize is available since GLSL 1.1
2. https://registry.khronos.org/OpenGL-Refpages/es3/html/glEnable.xhtml - `GL_PROGRAM_POINT_SIZE` not in the list
