### PR TITLE
Lowered version check for gl_PointSize from 3.0 to 2.0

### DIFF
--- a/src/program/program.rs
+++ b/src/program/program.rs
@@ -82,7 +82,7 @@ impl Program {
                     return Err(ProgramCreationError::TransformFeedbackNotSupported);
                 }
 
-                if uses_point_size && (facade.get_context().get_version().0 == Api::Gl) && !(facade.get_context().get_version() >= &Version(Api::Gl, 3, 0)) {
+                if uses_point_size && (facade.get_context().get_version().0 == Api::Gl) && !(facade.get_context().get_version() >= &Version(Api::Gl, 2, 0)) {
                     return Err(ProgramCreationError::PointSizeNotSupported);
                 }
 
@@ -103,7 +103,7 @@ impl Program {
             },
 
             ProgramCreationInput::Binary { data, outputs_srgb, uses_point_size } => {
-                if uses_point_size && (facade.get_context().get_version().0 == Api::Gl) && !(facade.get_context().get_version() >= &Version(Api::Gl, 3, 0)) {
+                if uses_point_size && (facade.get_context().get_version().0 == Api::Gl) && !(facade.get_context().get_version() >= &Version(Api::Gl, 2, 0)) {
                     return Err(ProgramCreationError::PointSizeNotSupported);
                 }
 
@@ -147,7 +147,7 @@ impl Program {
                     return Err(ProgramCreationError::TransformFeedbackNotSupported);
                 }
 
-                if uses_point_size && (facade.get_context().get_version().0 == Api::Gl) && !(facade.get_context().get_version() >= &Version(Api::Gl, 3, 0)) {
+                if uses_point_size && (facade.get_context().get_version().0 == Api::Gl) && !(facade.get_context().get_version() >= &Version(Api::Gl, 2, 0)) {
                     return Err(ProgramCreationError::PointSizeNotSupported);
                 }
 


### PR DESCRIPTION
Hello again,

this time I lowered the version requirement for using gl_PointSize from 3.0 to 2.0.
This should be sufficient since 3.2 / 4.0 is only required when used within a geometry / tesselation evaluation shader.
Since platform support is already checked when compiling those shaders we probably don't need to check so again afterwards.

Regarding the extensions that allow circumventing the version checks:
- gl_ext_geometry_shader4 : This seems to support it, and the new token PROGRAM_POINT_SIZE_EXT is just an alias for VERTEX_PROGRAM_POINT_SIZE

- gl_ext_geometry_shader : This seems to be ES specific, where gl_PointSize is always available

- gl_ext_tessellation_shader : This also seems to be ES specific, where gl_PointSize is always available

Apart from that if you prefer it I could change it and check for 2.0/3.2/4.0 depending on whether a geometry/tesselation shader is used in the program.