### PR TITLE
Support GL_ARB_clip_control

### DIFF
--- a/src/context/extensions.rs
+++ b/src/context/extensions.rs
@@ -56,6 +56,7 @@ extensions! {
     "GL_APPLE_vertex_array_object" => gl_apple_vertex_array_object,
     "GL_ARB_bindless_texture" => gl_arb_bindless_texture,
     "GL_ARB_buffer_storage" => gl_arb_buffer_storage,
+    "GL_ARB_clip_control" => gl_arb_clip_control,
     "GL_ARB_compute_shader" => gl_arb_compute_shader,
     "GL_ARB_copy_buffer" => gl_arb_copy_buffer,
     "GL_ARB_debug_output" => gl_arb_debug_output,

--- a/src/context/state.rs
+++ b/src/context/state.rs
@@ -229,6 +229,9 @@ pub struct GlState {
     /// The latest value passed to `glProvokingVertex`.
     pub provoking_vertex: gl::types::GLenum,
 
+    /// The latest value passed to `glClipControl`.
+    pub clip_control: (gl::types::GLenum, gl::types::GLenum),
+
     /// The latest value passed to `glPixelStore` with `GL_UNPACK_ALIGNMENT`.
     pub pixel_store_unpack_alignment: gl::types::GLint,
 
@@ -464,6 +467,7 @@ impl Default for GlState {
             transform_feedback_paused: false,
             primitive_bounding_box: (-1.0, -1.0, -1.0, -1.0, 1.0, 1.0, 1.0, 1.0),
             polygon_offset: (0.0, 0.0),
+            clip_control: (gl::LOWER_LEFT, gl::NEGATIVE_ONE_TO_ONE),
 
             next_draw_call_id: 1,
             latest_memory_barrier_vertex_attrib_array: 1,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1085,6 +1085,9 @@ pub enum DrawError {
     /// Restarting indices (multiple objects per draw call) is not supported by the backend.
     FixedIndexRestartingNotSupported,
 
+    /// Changing the clip volume definition (origin and depth mode) is not supported by the backend.
+    ClipControlNotSupported,
+
     /// Tried to enable a clip plane that does not exist.
     ClipPlaneIndexOutOfBounds,
 
@@ -1159,6 +1162,8 @@ impl fmt::Display for DrawError {
                 "One the blending parameters is not supported by the backend",
             FixedIndexRestartingNotSupported =>
                 "Restarting indices (multiple objects per draw call) is not supported by the backend",
+            ClipControlNotSupported =>
+                "Changing the clip volume definition (origin and depth mode) is not supported by the backend",
             ClipPlaneIndexOutOfBounds =>
                 "Tried to enable a clip plane that does not exist.",
             InsufficientImageUnits =>


### PR DESCRIPTION
>  [This extension provides additional clip control modes to configure how clip space is mapped to window space.  This extension's goal is to 1) allow OpenGL to effectively match Direct3D's coordinate system conventions, and 2) potentially improve the numerical precision of the Z coordinate mapping.](https://registry.khronos.org/OpenGL/extensions/ARB/ARB_clip_control.txt)