### PR TITLE
Fixed subroutine uniforms not being updated on program change

### DIFF
--- a/src/program/raw.rs
+++ b/src/program/raw.rs
@@ -650,6 +650,7 @@ impl ProgramExt for RawProgram {
                     Handle::Handle(id) => ctxt.gl.UseProgramObjectARB(id),
                 }
                 ctxt.state.program = program_id;
+                self.uniform_values.flush_subroutine_uniforms();
             }
         }
     }
@@ -729,6 +730,7 @@ impl Drop for RawProgram {
                     if ctxt.state.program == Handle::Id(id) {
                         ctxt.gl.UseProgram(0);
                         ctxt.state.program = Handle::Id(0);
+                        self.uniform_values.flush_subroutine_uniforms();
                     }
 
                     ctxt.gl.DeleteProgram(id);
@@ -739,6 +741,7 @@ impl Drop for RawProgram {
                     if ctxt.state.program == Handle::Handle(id) {
                         ctxt.gl.UseProgramObjectARB(0 as gl::types::GLhandleARB);
                         ctxt.state.program = Handle::Handle(0 as gl::types::GLhandleARB);
+                        self.uniform_values.flush_subroutine_uniforms();
                     }
 
                     ctxt.gl.DeleteObjectARB(id);

--- a/src/program/uniforms_storage.rs
+++ b/src/program/uniforms_storage.rs
@@ -374,6 +374,17 @@ impl UniformsStorage {
         }
     }
 
+    /// Clears all subroutine uniform values stored in this object.
+    /// This needs to be called when changing programs without `use_program`,
+    /// since all subroutine uniform state is lost when changing programs.
+    #[inline]
+    pub(crate) fn flush_subroutine_uniforms(&self) {
+        let mut subroutine_uniforms = self.subroutine_uniforms.borrow_mut();
+        if !subroutine_uniforms.is_empty() {
+            subroutine_uniforms.clear();
+        }
+    }
+
     /// Compares `indices` to the value stored in this object. If the values differ,
     /// updates the programs subroutine uniform bindings.
     pub fn set_subroutine_uniforms_for_stage(&self, ctxt: &mut CommandContext<'_>,


### PR DESCRIPTION
This should fix #2046, I'm not sure whether the call to `is_empty()` is necessary, but I thought it might make sense since  clearing an empty HashMap might be slower than this little check, since I suppose most of the time this will be skipped.