### PR TITLE
Validate that a framebuffer isn't 0 on any dimension

### DIFF
--- a/examples/fxaa.rs
+++ b/examples/fxaa.rs
@@ -157,7 +157,15 @@ mod fxaa {
     pub fn draw<T, F, R>(system: &FxaaSystem, target: &mut T, enabled: bool, mut draw: F)
                          -> R where T: Surface, F: FnMut(&mut SimpleFrameBuffer<'_>) -> R
     {
-        let target_dimensions = target.get_dimensions();
+        let mut target_dimensions = target.get_dimensions();
+        // We need to ensure that our framebuffer is at least 1x1. Otherwise, we would get an error.
+        // This could happen when minimizing or resizing the window on Windows, for example.
+        if target_dimensions.0 == 0 {
+            target_dimensions.0 = 1;
+        }
+        if target_dimensions.1 == 0 {
+            target_dimensions.1 = 1;
+        }
 
         let mut target_color = system.target_color.borrow_mut();
         let mut target_depth = system.target_depth.borrow_mut();

--- a/examples/picking.rs
+++ b/examples/picking.rs
@@ -167,12 +167,22 @@ fn main() {
         let mut target = display.draw();
         target.clear_color_and_depth((0.0, 0.0, 0.0, 0.0), 1.0);
 
+        let mut target_dimensions = target.get_dimensions();
+        // We need to ensure that our framebuffer is at least 1x1. Otherwise, we would get an error.
+        // This could happen when minimizing or resizing the window on Windows, for example.
+        if target_dimensions.0 == 0 {
+            target_dimensions.0 = 1;
+        }
+        if target_dimensions.1 == 0 {
+            target_dimensions.1 = 1;
+        }
+
         //update picking texture
         if picking_attachments.is_none() || (
             picking_attachments.as_ref().unwrap().0.get_width(),
             picking_attachments.as_ref().unwrap().0.get_height().unwrap()
-        ) != target.get_dimensions() {
-            let (width, height) = target.get_dimensions();
+        ) != target_dimensions {
+            let (width, height) = target_dimensions;
             picking_attachments = Some((
                 glium::texture::UnsignedTexture2d::empty_with_format(
                     &display,

--- a/src/fbo.rs
+++ b/src/fbo.rs
@@ -331,6 +331,9 @@ impl<'a> FramebufferAttachments<'a> {
         }
 
         let dimensions = if let Some(dimensions) = dimensions {
+            if dimensions.0 * dimensions.1 == 0 {
+                return Err(ValidationError::EmptyFramebufferUnsupportedDimensions);
+            }
             dimensions
         } else {
             // TODO: handle this
@@ -517,6 +520,9 @@ impl<'a> FramebufferAttachments<'a> {
         }
 
         let dimensions = if let Some(dimensions) = dimensions {
+            if dimensions.0 * dimensions.1 == 0 {
+                return Err(ValidationError::EmptyFramebufferUnsupportedDimensions);
+            }
             dimensions
         } else {
             // TODO: handle this


### PR DESCRIPTION
I've added a check during framebuffer creation that makes sure that it's not 0 on any dimension, since this would lead to other errors later, now we return a ValidationError::EmptyFramebufferUnsupportedDimensions in that case.

Since on Windows one can resize a window to have 0 width/height which also happens when minimizing I've changed the fxaa example so that it doesn't crash on Windows (Mac and Linux with various WMs seem to ensure that a window is alwasy at least 1x1)

This fixes https://github.com/glium/glium/issues/2044

