### PR TITLE
Tests on Windows

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -77,14 +77,15 @@ macro_rules! uniform {
 /// ## Example
 ///
 /// ```rust
+/// # #[macro_use] extern crate glium;
 /// # use glium::uniform;
 /// # fn main(){
-///     let uniforms = dynamic_uniform!{
-///         color: [1.0, 1.0, 0.0, 1.0],
-///         some_value: 12i32,
+///     let mut uniforms = dynamic_uniform!{
+///         color: &[1.0, 1.0, 0.0, 1.0],
+///         some_value: &12i32,
 ///     };
 ///
-///     uniforms.add("another_value", 1.5f32);
+///     uniforms.add("another_value", &1.5f32);
 /// # }
 /// ```
 ///
@@ -141,6 +142,11 @@ macro_rules! dynamic_uniform{
 /// ```
 /// # use glium::implement_vertex;
 /// # fn main() {
+/// # #[derive(Copy, Clone)]
+/// # struct Vertex {
+/// #     position: [f32; 3],
+/// #     tex_coords: [f32; 2],
+/// # }
 /// implement_vertex!(Vertex, position normalize(false), tex_coords normalize(false));
 /// # }
 /// ```
@@ -150,6 +156,11 @@ macro_rules! dynamic_uniform{
 /// ```
 /// # use glium::implement_vertex;
 /// # fn main() {
+/// # #[derive(Copy, Clone)]
+/// # struct Vertex {
+/// #     position: [f32; 3],
+/// #     tex_coords: [f32; 2],
+/// # }
 /// implement_vertex!(Vertex, position location(0), tex_coords location(1));
 /// # }
 /// ```

--- a/src/vertex/buffer.rs
+++ b/src/vertex/buffer.rs
@@ -239,10 +239,12 @@ impl<T> VertexBuffer<T> where T: Copy {
     ///
     /// let bindings = Cow::Owned(vec![(
     ///         Cow::Borrowed("position"), 0,
+    /// #       0,
     ///         glium::vertex::AttributeType::F32F32,
     ///         false,
     ///     ), (
     ///         Cow::Borrowed("color"), 2 * ::std::mem::size_of::<f32>(),
+    /// #       0,
     ///         glium::vertex::AttributeType::F32,
     ///         false,
     ///     ),

--- a/tests/shaders.rs
+++ b/tests/shaders.rs
@@ -695,6 +695,7 @@ fn unsized_array() {
         "
             #version 430
 
+            layout(std140)
             struct Foo {
                 ivec3 a[3];
                 int b;
@@ -791,6 +792,7 @@ fn array_layout_offsets() {
         "
             #version 330
 
+            layout(std140)
             struct Foo {
                 vec2 pos;
                 vec2 dir;

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -8,7 +8,9 @@ Test supports module.
 use glium::{self, glutin};
 use glium::backend::Facade;
 use glium::index::PrimitiveType;
-use glutin::{event::Event, event_loop::{EventLoop, EventLoopBuilder, EventLoopProxy}, NotCurrent, WindowedContext};
+use glutin::event::Event;
+use glutin::event_loop::{EventLoop, EventLoopBuilder, EventLoopProxy};
+use glutin::{NotCurrent, WindowedContext};
 
 use std::env;
 use std::thread;
@@ -20,7 +22,8 @@ pub fn build_display() -> glium::Display {
     // TODO: assess sync usage and prove this approach is safe
 
     static mut EVENT_LOOP_PROXY: RwLock<Option<EventLoopProxy<()>>> = RwLock::new(None);
-    static mut CONTEXT_RECEIVER: RwLock<Option<Receiver<WindowedContext<NotCurrent>>>> = RwLock::new(None);
+    static mut CONTEXT_RECEIVER: RwLock<Option<Receiver<WindowedContext<NotCurrent>>>> =
+        RwLock::new(None);
     static mut INIT_EVENT_LOOP: Once = Once::new();
     static mut SEND_PROXY: Once = Once::new();
 
@@ -109,7 +112,7 @@ pub fn build_display() -> glium::HeadlessRenderer {
 ///
 /// In real applications this is used for things such as switching to fullscreen. Some things are
 /// invalidated during a rebuild, and this has to be handled by glium.
-pub fn rebuild_display(display: &glium::Display) {
+pub fn rebuild_display(_display: &glium::Display) {
     /*let version = parse_version();
     let event_loop = glutin::event_loop::EventLoop::new();
     let wb = glutin::window::WindowBuilder::new().with_visible(false);

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -39,6 +39,7 @@ pub fn build_display() -> glium::Display {
             let builder = thread::Builder::new().name("event_loop".into());
             builder.spawn(|| {
                 let event_loop = if cfg!(windows) {
+                    #[cfg(windows)]
                     use glutin::platform::windows::EventLoopBuilderExtWindows;
 
                     EventLoopBuilder::new().with_any_thread(true).build()

--- a/tests/uniforms.rs
+++ b/tests/uniforms.rs
@@ -5,6 +5,12 @@ use glium::Surface;
 
 mod support;
 
+const RED_HALF_ALPHA: (u8, u8, u8, u8) = if cfg!(windows) {
+    (255, 0, 0, 127)
+} else {
+    (255, 0, 0, 128)
+};
+
 #[derive(Copy, Clone)]
 struct Vertex {
     position: [f32; 2],
@@ -45,8 +51,8 @@ fn uniforms_storage_single_value() {
     texture.as_surface().draw(&vb, &ib, &program, &uniforms, &Default::default()).unwrap();
 
     let data: Vec<Vec<(u8, u8, u8, u8)>> = texture.read();
-    assert_eq!(data[0][0], (255, 0, 0, 128));
-    assert_eq!(data.last().unwrap().last().unwrap(), &(255, 0, 0, 128));
+    assert_eq!(data[0][0], RED_HALF_ALPHA);
+    assert_eq!(data.last().unwrap().last().unwrap(), &RED_HALF_ALPHA);
 
     display.assert_no_error(None);
 }
@@ -127,8 +133,8 @@ fn uniforms_storage_ignore_inactive_uniforms() {
     texture.as_surface().draw(&vb, &ib, &program, &uniforms, &Default::default()).unwrap();
 
     let data: Vec<Vec<(u8, u8, u8, u8)>> = texture.read();
-    assert_eq!(data[0][0], (255, 0, 0, 128));
-    assert_eq!(data.last().unwrap().last().unwrap(), &(255, 0, 0, 128));
+    assert_eq!(data[0][0], RED_HALF_ALPHA);
+    assert_eq!(data.last().unwrap().last().unwrap(), &RED_HALF_ALPHA);
 
     display.assert_no_error(None);
 }
@@ -206,8 +212,8 @@ fn uniforms_dynamic_single_value() {
     texture.as_surface().draw(&vb, &ib, &program, &uniforms, &Default::default()).unwrap();
 
     let data: Vec<Vec<(u8, u8, u8, u8)>> = texture.read();
-    assert_eq!(data[0][0], (255, 0, 0, 128));
-    assert_eq!(data.last().unwrap().last().unwrap(), &(255, 0, 0, 128));
+    assert_eq!(data[0][0], RED_HALF_ALPHA);
+    assert_eq!(data.last().unwrap().last().unwrap(), &RED_HALF_ALPHA);
 
     display.assert_no_error(None);
 }
@@ -290,8 +296,8 @@ fn uniforms_dynamic_ignore_inactive_uniforms() {
     texture.as_surface().draw(&vb, &ib, &program, &uniforms, &Default::default()).unwrap();
 
     let data: Vec<Vec<(u8, u8, u8, u8)>> = texture.read();
-    assert_eq!(data[0][0], (255, 0, 0, 128));
-    assert_eq!(data.last().unwrap().last().unwrap(), &(255, 0, 0, 128));
+    assert_eq!(data[0][0], RED_HALF_ALPHA);
+    assert_eq!(data.last().unwrap().last().unwrap(), &RED_HALF_ALPHA);
 
     display.assert_no_error(None);
 }

--- a/tests/vertex_buffer.rs
+++ b/tests/vertex_buffer.rs
@@ -70,7 +70,9 @@ fn transform_feedback() {
             .. Default::default()
         };
 
-        display.draw().draw(&vb, &ib, &program, &uniform!{}, &params).unwrap();
+        let mut frame = display.draw();
+        frame.draw(&vb, &ib, &program, &uniform!{}, &params).unwrap();
+        frame.finish().unwrap();
     }
 
     let result = match out_buffer.read() {


### PR DESCRIPTION
Hi,

I am aware that the tests not working on Windows has been a [known issue](https://github.com/glium/glium/issues/1780) for [several years](https://github.com/glium/glium/issues/1440) now. The advice to use `--test-threads 1` is no longer applicable as it appears to spin up new threads rather than forcing them all to run on the main thread. The panic message from `EventLoop` suggests using the extension method `with_any_thread` on `EventLoopBuilder`, which does allow running a single test per process via `cargo test --test <Target> <Name> -- --exact`.

The changes to the test modules fix the failures on my system. The change to support/mod.rs is of questionable value outside a Windows platform. There are only six remaining tests that are still failing:
- `multiple_displays` and `bindless_texture_residency_context_rebuild` can both be made to pass by using a singleton event_loop. I do not think this can be done in Safe Rust, and the singleton does not help with running multiple tests per process anyway
- I am not sure the four `empty_stenciltexture(1|2)d(array)*` tests are meant to be uncommented. I did not attempt to get them passing
- I am finding 322 active test names in the tests folder, but I may have missed something
