### PR TITLE
Fix mdbook hiding `#version..` in rust codeblocks

### DIFF
--- a/book/tuto-02-triangle.md
+++ b/book/tuto-02-triangle.md
@@ -71,7 +71,7 @@ The tricky part is that *we* need to write the vertex and fragment shaders. To d
 
 ```rust
 let vertex_shader_src = r#"
-    #version 140
+    ##version 140
 
     in vec2 position;
 
@@ -91,7 +91,7 @@ The second shader is called the fragment shader (sometimes also named *pixel sha
 
 ```rust
 let fragment_shader_src = r#"
-    #version 140
+    ##version 140
 
     out vec4 color;
 

--- a/book/tuto-03-animated-triangle.md
+++ b/book/tuto-03-animated-triangle.md
@@ -113,7 +113,7 @@ And instead we are going to do a small change in our vertex shader:
 
 ```rust
 let vertex_shader_src = r#"
-    #version 140
+    ##version 140
 
     in vec2 position;
 

--- a/book/tuto-04-matrices.md
+++ b/book/tuto-04-matrices.md
@@ -17,7 +17,7 @@ Let's get back to our moving triangle. We are going to change the vertex shader 
 
 ```rust
 let vertex_shader_src = r#"
-    #version 140
+    ##version 140
 
     in vec2 position;
 


### PR DESCRIPTION
Fixes #2053. This does not touch the glsl code blocks as they seem to be left alone.

Please note there might be a more inclusive fix for this but, this will fix it for anyone viewing through the link on the repo. 

If viewing the raw markdown files it will show as `##version`.