### PR TITLE
Reduce memory allocations in draw

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ features = []
 optional = true
 
 [dependencies]
-memoffset = "0.6"
+memoffset = "0.8"
 takeable-option = "0.5"
 backtrace = "0.3.2"
 lazy_static = "1.0"

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -156,104 +156,106 @@ macro_rules! dynamic_uniform{
 #[macro_export]
 macro_rules! implement_vertex {
     ($struct_name:ident, $($field_name:ident),+) => (
+        impl $struct_name {
+            const BINDINGS: $crate::vertex::VertexFormat = &[
+                $(
+                    (
+                        std::borrow::Cow::Borrowed(stringify!($field_name)),
+                        $crate::__glium_offset_of!($struct_name, $field_name),
+                        -1,
+                        {
+                            const fn attr_type_of_val<T: $crate::vertex::Attribute>(_: Option<&T>)
+                                -> $crate::vertex::AttributeType
+                            {
+                                <T as $crate::vertex::Attribute>::TYPE
+                            }
+                            let field_option = match None::<&$struct_name> {
+                                Some(v) => Some(&v.$field_name),
+                                None => None
+                            };
+                            attr_type_of_val(field_option)
+                        },
+                        false
+                    )
+                ),+
+            ];
+        }
+
         impl $crate::vertex::Vertex for $struct_name {
             #[inline]
             fn build_bindings() -> $crate::vertex::VertexFormat {
-                use std::borrow::Cow;
-
-                // TODO: use a &'static [] if possible
-
-                Cow::Owned(vec![
-                    $(
-                        (
-                            Cow::Borrowed(stringify!($field_name)),
-                            $crate::__glium_offset_of!($struct_name, $field_name),
-                            -1,
-                            {
-                                // Obtain the type of the $field_name field of $struct_name and
-                                // call get_type on it.
-                                fn attr_type_of_val<T: $crate::vertex::Attribute>(_: Option<&T>)
-                                    -> $crate::vertex::AttributeType
-                                {
-                                    <T as $crate::vertex::Attribute>::get_type()
-                                }
-                                let field_option = None::<&$struct_name>.map(|v| &v.$field_name);
-                                attr_type_of_val(field_option)
-                            },
-                            false
-                        )
-                    ),+
-                ])
+                Self::BINDINGS
             }
         }
     );
 
     ($struct_name:ident, $($field_name:ident normalize($should_normalize:expr)),+) => {
+        impl $struct_name {
+            const BINDINGS: $crate::vertex::VertexFormat = &[
+                $(
+                    (
+                        std::borrow::Cow::Borrowed(stringify!($field_name)),
+                        $crate::__glium_offset_of!($struct_name, $field_name),
+                        -1,
+                        {
+                            const fn attr_type_of_val<T: $crate::vertex::Attribute>(_: Option<&T>)
+                                -> $crate::vertex::AttributeType
+                            {
+                                <T as $crate::vertex::Attribute>::TYPE
+                            }
+                            let field_option = match None::<&$struct_name> {
+                                Some(v) => Some(&v.$field_name),
+                                None => None
+                            };
+                            attr_type_of_val(field_option)
+                        },
+                        {
+                            $should_normalize
+                        }
+                    )
+                ),+
+            ];
+        }
         impl $crate::vertex::Vertex for $struct_name {
             #[inline]
             fn build_bindings() -> $crate::vertex::VertexFormat {
-                use std::borrow::Cow;
-
-                // TODO: use a &'static [] if possible
-
-                Cow::Owned(vec![
-                    $(
-                        (
-                            Cow::Borrowed(stringify!($field_name)),
-                            $crate::__glium_offset_of!($struct_name, $field_name),
-                            -1,
-                            {
-                                // Obtain the type of the $field_name field of $struct_name and
-                                // call get_type on it.
-                                fn attr_type_of_val<T: $crate::vertex::Attribute>(_: Option<&T>)
-                                    -> $crate::vertex::AttributeType
-                                {
-                                    <T as $crate::vertex::Attribute>::get_type()
-                                }
-                                let field_option = None::<&$struct_name>.map(|v| &v.$field_name);
-                                attr_type_of_val(field_option)
-                            },
-                            {
-                                $should_normalize
-                            }
-                        )
-                    ),+
-                ])
+                Self::BINDINGS
             }
         }
     };
 
     ($struct_name:ident, $($field_name:ident location($location:expr)),+) => {
+        impl $struct_name {
+            const BINDINGS: $crate::vertex::VertexFormat = &[
+                $(
+                    (
+                        std::borrow::Cow::Borrowed(stringify!($field_name)),
+                        $crate::__glium_offset_of!($struct_name, $field_name),
+                        {
+                            $location
+                        },
+                        {
+                            const fn attr_type_of_val<T: $crate::vertex::Attribute>(_: Option<&T>)
+                                -> $crate::vertex::AttributeType
+                            {
+                                <T as $crate::vertex::Attribute>::TYPE
+                            }
+                            let field_option = match None::<&$struct_name> {
+                                Some(v) => Some(&v.$field_name),
+                                None => None
+                            };
+                            attr_type_of_val(field_option)
+                        },
+                        false
+                    )
+                ),+
+            ];
+        }
+
         impl $crate::vertex::Vertex for $struct_name {
             #[inline]
             fn build_bindings() -> $crate::vertex::VertexFormat {
-                use std::borrow::Cow;
-
-                // TODO: use a &'static [] if possible
-
-                Cow::Owned(vec![
-                    $(
-                        (
-                            Cow::Borrowed(stringify!($field_name)),
-                            $crate::__glium_offset_of!($struct_name, $field_name),
-                            {
-                                $location
-                            },
-                            {
-                                // Obtain the type of the $field_name field of $struct_name and
-                                // call get_type on it.
-                                fn attr_type_of_val<T: $crate::vertex::Attribute>(_: Option<&T>)
-                                    -> $crate::vertex::AttributeType
-                                {
-                                    <T as $crate::vertex::Attribute>::get_type()
-                                }
-                                let field_option = None::<&$struct_name>.map(|v| &v.$field_name);
-                                attr_type_of_val(field_option)
-                            },
-                            false
-                        )
-                    ),+
-                ])
+                Self::BINDINGS
             }
         }
     };

--- a/src/vertex/buffer.rs
+++ b/src/vertex/buffer.rs
@@ -73,7 +73,7 @@ pub struct VertexBuffer<T> where T: Copy {
 /// Represents a slice of a `VertexBuffer`.
 pub struct VertexBufferSlice<'b, T> where T: Copy {
     buffer: BufferSlice<'b, [T]>,
-    bindings: &'b VertexFormat,
+    bindings: VertexFormat,
 }
 
 impl<'b, T: 'b> VertexBufferSlice<'b, T> where T: Copy + Content {
@@ -94,7 +94,7 @@ impl<'b, T: 'b> VertexBufferSlice<'b, T> where T: Copy + Content {
             return Err(InstancingNotSupported);
         }
 
-        Ok(PerInstance(self.buffer.as_slice_any(), &self.bindings))
+        Ok(PerInstance(self.buffer.as_slice_any(), self.bindings))
     }
 }
 
@@ -302,7 +302,7 @@ impl<T> VertexBuffer<T> where T: Copy {
 
         Some(VertexBufferSlice {
             buffer: slice,
-            bindings: &self.bindings,
+            bindings: self.bindings,
         })
     }
 
@@ -328,7 +328,7 @@ impl<T> VertexBuffer<T> where T: Copy {
             return Err(InstancingNotSupported);
         }
 
-        Ok(PerInstance(self.buffer.as_slice_any(), &self.bindings))
+        Ok(PerInstance(self.buffer.as_slice_any(), self.bindings))
     }
 }
 
@@ -397,7 +397,7 @@ impl<'a, T> From<&'a mut VertexBuffer<T>> for BufferMutSlice<'a, [T]> where T: C
 impl<'a, T> From<&'a VertexBuffer<T>> for VerticesSource<'a> where T: Copy {
     #[inline]
     fn from(this: &VertexBuffer<T>) -> VerticesSource<'_> {
-        VerticesSource::VertexBuffer(this.buffer.as_slice_any(), &this.bindings, false)
+        VerticesSource::VertexBuffer(this.buffer.as_slice_any(), this.bindings, false)
     }
 }
 
@@ -427,7 +427,7 @@ impl<'a, T> From<VertexBufferSlice<'a, T>> for BufferSlice<'a, [T]> where T: Cop
 impl<'a, T> From<VertexBufferSlice<'a, T>> for VerticesSource<'a> where T: Copy {
     #[inline]
     fn from(this: VertexBufferSlice<'a, T>) -> VerticesSource<'a> {
-        VerticesSource::VertexBuffer(this.buffer.as_slice_any(), &this.bindings, false)
+        VerticesSource::VertexBuffer(this.buffer.as_slice_any(), this.bindings, false)
     }
 }
 
@@ -485,7 +485,7 @@ impl VertexBufferAny {
             return Err(InstancingNotSupported);
         }
 
-        Ok(PerInstance(self.buffer.as_slice_any(), &self.bindings))
+        Ok(PerInstance(self.buffer.as_slice_any(), self.bindings))
     }
 }
 
@@ -523,7 +523,7 @@ impl DerefMut for VertexBufferAny {
 impl<'a> From<&'a VertexBufferAny> for VerticesSource<'a> {
     #[inline]
     fn from(this :&VertexBufferAny) -> VerticesSource<'_> {
-        VerticesSource::VertexBuffer(this.buffer.as_slice_any(), &this.bindings, false)
+        VerticesSource::VertexBuffer(this.buffer.as_slice_any(), this.bindings, false)
     }
 }
 

--- a/src/vertex/format.rs
+++ b/src/vertex/format.rs
@@ -1,9 +1,9 @@
 use std::borrow::Cow;
 use std::mem;
 
-use crate::vertex::Attribute;
 use crate::version::Api;
 use crate::version::Version;
+use crate::vertex::Attribute;
 use crate::CapabilitiesSource;
 
 #[cfg(feature = "cgmath")]
@@ -410,1691 +410,1029 @@ impl AttributeType {
 /// third element is the type and the fourth element indicates whether
 /// or not the element should use fixed-point normalization when
 /// binding in a VAO.
-pub type VertexFormat = Cow<'static, [(Cow<'static, str>, usize, i32, AttributeType, bool)]>;
+pub type VertexFormat = &'static [(Cow<'static, str>, usize, i32, AttributeType, bool)];
 
 unsafe impl Attribute for i8 {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I8
-    }
+    const TYPE: AttributeType = AttributeType::I8;
 }
 
 unsafe impl Attribute for (i8, i8) {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I8I8
-    }
+    const TYPE: AttributeType = AttributeType::I8I8;
 }
 
 unsafe impl Attribute for [i8; 2] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I8I8
-    }
+    const TYPE: AttributeType = AttributeType::I8I8;
 }
 
 unsafe impl Attribute for (i8, i8, i8) {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I8I8I8
-    }
+    const TYPE: AttributeType = AttributeType::I8I8I8;
 }
 
 unsafe impl Attribute for [i8; 3] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I8I8I8
-    }
+    const TYPE: AttributeType = AttributeType::I8I8I8;
 }
 
 unsafe impl Attribute for (i8, i8, i8, i8) {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I8I8I8I8
-    }
+    const TYPE: AttributeType = AttributeType::I8I8I8I8;
 }
 
 unsafe impl Attribute for [i8; 4] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I8I8I8I8
-    }
+    const TYPE: AttributeType = AttributeType::I8I8I8I8;
 }
 
 unsafe impl Attribute for u8 {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U8
-    }
+    const TYPE: AttributeType = AttributeType::U8;
 }
 
 unsafe impl Attribute for (u8, u8) {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U8U8
-    }
+    const TYPE: AttributeType = AttributeType::U8U8;
 }
 
 unsafe impl Attribute for [u8; 2] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U8U8
-    }
+    const TYPE: AttributeType = AttributeType::U8U8;
 }
 
 unsafe impl Attribute for (u8, u8, u8) {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U8U8U8
-    }
+    const TYPE: AttributeType = AttributeType::U8U8U8;
 }
 
 unsafe impl Attribute for [u8; 3] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U8U8U8
-    }
+    const TYPE: AttributeType = AttributeType::U8U8U8;
 }
 
 unsafe impl Attribute for (u8, u8, u8, u8) {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U8U8U8U8
-    }
+    const TYPE: AttributeType = AttributeType::U8U8U8U8;
 }
 
 unsafe impl Attribute for [u8; 4] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U8U8U8U8
-    }
+    const TYPE: AttributeType = AttributeType::U8U8U8U8;
 }
 
 unsafe impl Attribute for i16 {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I16
-    }
+    const TYPE: AttributeType = AttributeType::I16;
 }
 
 unsafe impl Attribute for (i16, i16) {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I16I16
-    }
+    const TYPE: AttributeType = AttributeType::I16I16;
 }
 
 unsafe impl Attribute for [i16; 2] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I16I16
-    }
+    const TYPE: AttributeType = AttributeType::I16I16;
 }
 
 unsafe impl Attribute for (i16, i16, i16) {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I16I16I16
-    }
+    const TYPE: AttributeType = AttributeType::I16I16I16;
 }
 
 unsafe impl Attribute for [i16; 3] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I16I16I16
-    }
+    const TYPE: AttributeType = AttributeType::I16I16I16;
 }
 
 unsafe impl Attribute for (i16, i16, i16, i16) {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I16I16I16I16
-    }
+    const TYPE: AttributeType = AttributeType::I16I16I16I16;
 }
 
 unsafe impl Attribute for [i16; 4] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I16I16I16I16
-    }
+    const TYPE: AttributeType = AttributeType::I16I16I16I16;
 }
 
 unsafe impl Attribute for u16 {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U16
-    }
+    const TYPE: AttributeType = AttributeType::U16;
 }
 
 unsafe impl Attribute for (u16, u16) {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U16U16
-    }
+    const TYPE: AttributeType = AttributeType::U16U16;
 }
 
 unsafe impl Attribute for [u16; 2] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U16U16
-    }
+    const TYPE: AttributeType = AttributeType::U16U16;
 }
 
 unsafe impl Attribute for (u16, u16, u16) {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U16U16U16
-    }
+    const TYPE: AttributeType = AttributeType::U16U16U16;
 }
 
 unsafe impl Attribute for [u16; 3] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U16U16U16
-    }
+    const TYPE: AttributeType = AttributeType::U16U16U16;
 }
 
 unsafe impl Attribute for (u16, u16, u16, u16) {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U16U16U16U16
-    }
+    const TYPE: AttributeType = AttributeType::U16U16U16U16;
 }
 
 unsafe impl Attribute for [u16; 4] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U16U16U16U16
-    }
+    const TYPE: AttributeType = AttributeType::U16U16U16U16;
 }
 
 unsafe impl Attribute for i32 {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I32
-    }
+    const TYPE: AttributeType = AttributeType::I32;
 }
 
 unsafe impl Attribute for (i32, i32) {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I32I32
-    }
+    const TYPE: AttributeType = AttributeType::I32I32;
 }
 
 unsafe impl Attribute for [i32; 2] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I32I32
-    }
+    const TYPE: AttributeType = AttributeType::I32I32;
 }
 
 unsafe impl Attribute for (i32, i32, i32) {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I32I32I32
-    }
+    const TYPE: AttributeType = AttributeType::I32I32I32;
 }
 
 unsafe impl Attribute for [i32; 3] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I32I32I32
-    }
+    const TYPE: AttributeType = AttributeType::I32I32I32;
 }
 
 unsafe impl Attribute for (i32, i32, i32, i32) {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I32I32I32I32
-    }
+    const TYPE: AttributeType = AttributeType::I32I32I32I32;
 }
 
 unsafe impl Attribute for [i32; 4] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I32I32I32I32
-    }
+    const TYPE: AttributeType = AttributeType::I32I32I32I32;
 }
 
 unsafe impl Attribute for u32 {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U32
-    }
+    const TYPE: AttributeType = AttributeType::U32;
 }
 
 unsafe impl Attribute for (u32, u32) {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U32U32
-    }
+    const TYPE: AttributeType = AttributeType::U32U32;
 }
 
 unsafe impl Attribute for [u32; 2] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U32U32
-    }
+    const TYPE: AttributeType = AttributeType::U32U32;
 }
 
 unsafe impl Attribute for (u32, u32, u32) {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U32U32U32
-    }
+    const TYPE: AttributeType = AttributeType::U32U32U32;
 }
 
 unsafe impl Attribute for [u32; 3] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U32U32U32
-    }
+    const TYPE: AttributeType = AttributeType::U32U32U32;
 }
 
 unsafe impl Attribute for (u32, u32, u32, u32) {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U32U32U32U32
-    }
+    const TYPE: AttributeType = AttributeType::U32U32U32U32;
 }
 
 unsafe impl Attribute for [u32; 4] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U32U32U32U32
-    }
+    const TYPE: AttributeType = AttributeType::U32U32U32U32;
 }
 
 unsafe impl Attribute for i64 {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I64
-    }
+    const TYPE: AttributeType = AttributeType::I64;
 }
 
 unsafe impl Attribute for (i64, i64) {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I64I64
-    }
+    const TYPE: AttributeType = AttributeType::I64I64;
 }
 
 unsafe impl Attribute for [i64; 2] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I64I64
-    }
+    const TYPE: AttributeType = AttributeType::I64I64;
 }
 
 unsafe impl Attribute for (i64, i64, i64) {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I64I64I64
-    }
+    const TYPE: AttributeType = AttributeType::I64I64I64;
 }
 
 unsafe impl Attribute for [i64; 3] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I64I64I64
-    }
+    const TYPE: AttributeType = AttributeType::I64I64I64;
 }
 
 unsafe impl Attribute for (i64, i64, i64, i64) {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I64I64I64I64
-    }
+    const TYPE: AttributeType = AttributeType::I64I64I64I64;
 }
 
 unsafe impl Attribute for [i64; 4] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I64I64I64I64
-    }
+    const TYPE: AttributeType = AttributeType::I64I64I64I64;
 }
 
 unsafe impl Attribute for u64 {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U64
-    }
+    const TYPE: AttributeType = AttributeType::U64;
 }
 
 unsafe impl Attribute for (u64, u64) {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U64U64
-    }
+    const TYPE: AttributeType = AttributeType::U64U64;
 }
 
 unsafe impl Attribute for [u64; 2] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U64U64
-    }
+    const TYPE: AttributeType = AttributeType::U64U64;
 }
 
 unsafe impl Attribute for (u64, u64, u64) {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U64U64U64
-    }
+    const TYPE: AttributeType = AttributeType::U64U64U64;
 }
 
 unsafe impl Attribute for [u64; 3] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U64U64U64
-    }
+    const TYPE: AttributeType = AttributeType::U64U64U64;
 }
 
 unsafe impl Attribute for (u64, u64, u64, u64) {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U64U64U64U64
-    }
+    const TYPE: AttributeType = AttributeType::U64U64U64U64;
 }
 
 unsafe impl Attribute for [u64; 4] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U64U64U64U64
-    }
+    const TYPE: AttributeType = AttributeType::U64U64U64U64;
 }
 
 unsafe impl Attribute for f32 {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F32
-    }
+    const TYPE: AttributeType = AttributeType::F32;
 }
 
 unsafe impl Attribute for (f32, f32) {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F32F32
-    }
+    const TYPE: AttributeType = AttributeType::F32F32;
 }
 
 unsafe impl Attribute for [f32; 2] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F32F32
-    }
+    const TYPE: AttributeType = AttributeType::F32F32;
 }
 
 unsafe impl Attribute for (f32, f32, f32) {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F32F32F32
-    }
+    const TYPE: AttributeType = AttributeType::F32F32F32;
 }
 
 unsafe impl Attribute for [f32; 3] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F32F32F32
-    }
+    const TYPE: AttributeType = AttributeType::F32F32F32;
 }
 
 unsafe impl Attribute for (f32, f32, f32, f32) {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F32F32F32F32
-    }
+    const TYPE: AttributeType = AttributeType::F32F32F32F32;
 }
 
 unsafe impl Attribute for [f32; 4] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F32F32F32F32
-    }
+    const TYPE: AttributeType = AttributeType::F32F32F32F32;
 }
 
 unsafe impl Attribute for [[f32; 2]; 2] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F32x2x2
-    }
+    const TYPE: AttributeType = AttributeType::F32x2x2;
 }
 
 unsafe impl Attribute for [[f32; 3]; 3] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F32x3x3
-    }
+    const TYPE: AttributeType = AttributeType::F32x3x3;
 }
 
 unsafe impl Attribute for [[f32; 4]; 4] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F32x4x4
-    }
+    const TYPE: AttributeType = AttributeType::F32x4x4;
 }
 
 unsafe impl Attribute for f64 {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F64
-    }
+    const TYPE: AttributeType = AttributeType::F64;
 }
 
 unsafe impl Attribute for (f64, f64) {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F64F64
-    }
+    const TYPE: AttributeType = AttributeType::F64F64;
 }
 
 unsafe impl Attribute for [f64; 2] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F64F64
-    }
+    const TYPE: AttributeType = AttributeType::F64F64;
 }
 
 unsafe impl Attribute for (f64, f64, f64) {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F64F64F64
-    }
+    const TYPE: AttributeType = AttributeType::F64F64F64;
 }
 
 unsafe impl Attribute for [f64; 3] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F64F64F64
-    }
+    const TYPE: AttributeType = AttributeType::F64F64F64;
 }
 
 unsafe impl Attribute for (f64, f64, f64, f64) {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F64F64F64F64
-    }
+    const TYPE: AttributeType = AttributeType::F64F64F64F64;
 }
 
 unsafe impl Attribute for [f64; 4] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F64F64F64F64
-    }
+    const TYPE: AttributeType = AttributeType::F64F64F64F64;
 }
 
 unsafe impl Attribute for [[f64; 2]; 2] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F64x2x2
-    }
+    const TYPE: AttributeType = AttributeType::F64x2x2;
 }
 
 unsafe impl Attribute for [[f64; 3]; 3] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F64x3x3
-    }
+    const TYPE: AttributeType = AttributeType::F64x3x3;
 }
 
 unsafe impl Attribute for [[f64; 4]; 4] {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F64x4x4
-    }
+    const TYPE: AttributeType = AttributeType::F64x4x4;
 }
-
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Point2<i8> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I8I8
-    }
+    const TYPE: AttributeType = AttributeType::I8I8;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Point3<i8> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I8I8I8
-    }
+    const TYPE: AttributeType = AttributeType::I8I8I8;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Vector2<i8> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I8I8
-    }
+    const TYPE: AttributeType = AttributeType::I8I8;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Vector3<i8> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I8I8I8
-    }
+    const TYPE: AttributeType = AttributeType::I8I8I8;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Vector4<i8> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I8I8I8I8
-    }
+    const TYPE: AttributeType = AttributeType::I8I8I8I8;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Point2<u8> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U8U8
-    }
+    const TYPE: AttributeType = AttributeType::U8U8;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Point3<u8> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U8U8U8
-    }
+    const TYPE: AttributeType = AttributeType::U8U8U8;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Vector2<u8> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U8U8
-    }
+    const TYPE: AttributeType = AttributeType::U8U8;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Vector3<u8> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U8U8U8
-    }
+    const TYPE: AttributeType = AttributeType::U8U8U8;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Vector4<u8> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U8U8U8U8
-    }
+    const TYPE: AttributeType = AttributeType::U8U8U8U8;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Point2<i16> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I16I16
-    }
+    const TYPE: AttributeType = AttributeType::I16I16;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Point3<i16> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I16I16I16
-    }
+    const TYPE: AttributeType = AttributeType::I16I16I16;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Vector2<i16> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I16I16
-    }
+    const TYPE: AttributeType = AttributeType::I16I16;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Vector3<i16> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I16I16I16
-    }
+    const TYPE: AttributeType = AttributeType::I16I16I16;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Vector4<i16> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I16I16I16I16
-    }
+    const TYPE: AttributeType = AttributeType::I16I16I16I16;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Point2<u16> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U16U16
-    }
+    const TYPE: AttributeType = AttributeType::U16U16;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Point3<u16> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U16U16U16
-    }
+    const TYPE: AttributeType = AttributeType::U16U16U16;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Vector2<u16> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U16U16
-    }
+    const TYPE: AttributeType = AttributeType::U16U16;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Vector3<u16> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U16U16U16
-    }
+    const TYPE: AttributeType = AttributeType::U16U16U16;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Vector4<u16> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U16U16U16U16
-    }
+    const TYPE: AttributeType = AttributeType::U16U16U16U16;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Point2<i32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I32I32
-    }
+    const TYPE: AttributeType = AttributeType::I32I32;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Point3<i32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I32I32I32
-    }
+    const TYPE: AttributeType = AttributeType::I32I32I32;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Vector2<i32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I32I32
-    }
+    const TYPE: AttributeType = AttributeType::I32I32;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Vector3<i32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I32I32I32
-    }
+    const TYPE: AttributeType = AttributeType::I32I32I32;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Vector4<i32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I32I32I32I32
-    }
+    const TYPE: AttributeType = AttributeType::I32I32I32I32;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Point2<u32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U32U32
-    }
+    const TYPE: AttributeType = AttributeType::U32U32;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Point3<u32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U32U32U32
-    }
+    const TYPE: AttributeType = AttributeType::U32U32U32;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Vector2<u32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U32U32
-    }
+    const TYPE: AttributeType = AttributeType::U32U32;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Vector3<u32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U32U32U32
-    }
+    const TYPE: AttributeType = AttributeType::U32U32U32;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Vector4<u32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U32U32U32U32
-    }
+    const TYPE: AttributeType = AttributeType::U32U32U32U32;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Point2<i64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I64I64
-    }
+    const TYPE: AttributeType = AttributeType::I64I64;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Point3<i64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I64I64I64
-    }
+    const TYPE: AttributeType = AttributeType::I64I64I64;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Vector2<i64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I64I64
-    }
+    const TYPE: AttributeType = AttributeType::I64I64;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Vector3<i64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I64I64I64
-    }
+    const TYPE: AttributeType = AttributeType::I64I64I64;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Vector4<i64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I64I64I64I64
-    }
+    const TYPE: AttributeType = AttributeType::I64I64I64I64;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Point2<u64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U64U64
-    }
+    const TYPE: AttributeType = AttributeType::U64U64;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Point3<u64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U64U64U64
-    }
+    const TYPE: AttributeType = AttributeType::U64U64U64;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Vector2<u64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U64U64
-    }
+    const TYPE: AttributeType = AttributeType::U64U64;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Vector3<u64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U64U64U64
-    }
+    const TYPE: AttributeType = AttributeType::U64U64U64;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Vector4<u64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U64U64U64U64
-    }
+    const TYPE: AttributeType = AttributeType::U64U64U64U64;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Point2<f32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F32F32
-    }
+    const TYPE: AttributeType = AttributeType::F32F32;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Point3<f32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F32F32F32
-    }
+    const TYPE: AttributeType = AttributeType::F32F32F32;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Vector2<f32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F32F32
-    }
+    const TYPE: AttributeType = AttributeType::F32F32;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Vector3<f32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F32F32F32
-    }
+    const TYPE: AttributeType = AttributeType::F32F32F32;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Vector4<f32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F32F32F32F32
-    }
+    const TYPE: AttributeType = AttributeType::F32F32F32F32;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Matrix2<f32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F32x2x2
-    }
+    const TYPE: AttributeType = AttributeType::F32x2x2;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Matrix3<f32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F32x3x3
-    }
+    const TYPE: AttributeType = AttributeType::F32x3x3;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Matrix4<f32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F32x4x4
-    }
+    const TYPE: AttributeType = AttributeType::F32x4x4;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Point2<f64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F64F64
-    }
+    const TYPE: AttributeType = AttributeType::F64F64;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Point3<f64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F64F64F64
-    }
+    const TYPE: AttributeType = AttributeType::F64F64F64;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Vector2<f64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F64F64
-    }
+    const TYPE: AttributeType = AttributeType::F64F64;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Vector3<f64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F64F64F64
-    }
+    const TYPE: AttributeType = AttributeType::F64F64F64;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Vector4<f64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F64F64F64F64
-    }
+    const TYPE: AttributeType = AttributeType::F64F64F64F64;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Matrix2<f64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F64x2x2
-    }
+    const TYPE: AttributeType = AttributeType::F64x2x2;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Matrix3<f64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F64x3x3
-    }
+    const TYPE: AttributeType = AttributeType::F64x3x3;
 }
 
 #[cfg(feature="cgmath")]
 unsafe impl Attribute for cgmath::Matrix4<f64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F64x4x4
-    }
+    const TYPE: AttributeType = AttributeType::F64x4x4;
 }
-
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt1<i8> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I8
-    }
+    const TYPE: AttributeType = AttributeType::I8;
 }
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt2<i8> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I8I8
-    }
+    const TYPE: AttributeType = AttributeType::I8I8;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt3<i8> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I8I8I8
-    }
+    const TYPE: AttributeType = AttributeType::I8I8I8;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt4<i8> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I8I8I8I8
-    }
+    const TYPE: AttributeType = AttributeType::I8I8I8I8;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec1<i8> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I8
-    }
+    const TYPE: AttributeType = AttributeType::I8;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec2<i8> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I8I8
-    }
+    const TYPE: AttributeType = AttributeType::I8I8;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec3<i8> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I8I8I8
-    }
+    const TYPE: AttributeType = AttributeType::I8I8I8;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec4<i8> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I8I8I8I8
-    }
+    const TYPE: AttributeType = AttributeType::I8I8I8I8;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt1<u8> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U8
-    }
+    const TYPE: AttributeType = AttributeType::U8;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt2<u8> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U8U8
-    }
+    const TYPE: AttributeType = AttributeType::U8U8;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt3<u8> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U8U8U8
-    }
+    const TYPE: AttributeType = AttributeType::U8U8U8;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt4<u8> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U8U8U8U8
-    }
+    const TYPE: AttributeType = AttributeType::U8U8U8U8;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec1<u8> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U8
-    }
+    const TYPE: AttributeType = AttributeType::U8;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec2<u8> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U8U8
-    }
+    const TYPE: AttributeType = AttributeType::U8U8;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec3<u8> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U8U8U8
-    }
+    const TYPE: AttributeType = AttributeType::U8U8U8;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec4<u8> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U8U8U8U8
-    }
+    const TYPE: AttributeType = AttributeType::U8U8U8U8;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt1<i16> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I16
-    }
+    const TYPE: AttributeType = AttributeType::I16;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt2<i16> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I16I16
-    }
+    const TYPE: AttributeType = AttributeType::I16I16;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt3<i16> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I16I16I16
-    }
+    const TYPE: AttributeType = AttributeType::I16I16I16;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt4<i16> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I16I16I16I16
-    }
+    const TYPE: AttributeType = AttributeType::I16I16I16I16;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec1<i16> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I16
-    }
+    const TYPE: AttributeType = AttributeType::I16;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec2<i16> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I16I16
-    }
+    const TYPE: AttributeType = AttributeType::I16I16;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec3<i16> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I16I16I16
-    }
+    const TYPE: AttributeType = AttributeType::I16I16I16;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec4<i16> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I16I16I16I16
-    }
+    const TYPE: AttributeType = AttributeType::I16I16I16I16;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt1<u16> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U16
-    }
+    const TYPE: AttributeType = AttributeType::U16;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt2<u16> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U16U16
-    }
+    const TYPE: AttributeType = AttributeType::U16U16;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt3<u16> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U16U16U16
-    }
+    const TYPE: AttributeType = AttributeType::U16U16U16;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt4<u16> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U16U16U16U16
-    }
+    const TYPE: AttributeType = AttributeType::U16U16U16U16;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec1<u16> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U16
-    }
+    const TYPE: AttributeType = AttributeType::U16;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec2<u16> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U16U16
-    }
+    const TYPE: AttributeType = AttributeType::U16U16;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec3<u16> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U16U16U16
-    }
+    const TYPE: AttributeType = AttributeType::U16U16U16;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec4<u16> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U16U16U16U16
-    }
+    const TYPE: AttributeType = AttributeType::U16U16U16U16;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt1<i32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I32
-    }
+    const TYPE: AttributeType = AttributeType::I32;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt2<i32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I32I32
-    }
+    const TYPE: AttributeType = AttributeType::I32I32;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt3<i32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I32I32I32
-    }
+    const TYPE: AttributeType = AttributeType::I32I32I32;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt4<i32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I32I32I32I32
-    }
+    const TYPE: AttributeType = AttributeType::I32I32I32I32;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec1<i32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I32
-    }
+    const TYPE: AttributeType = AttributeType::I32;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec2<i32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I32I32
-    }
+    const TYPE: AttributeType = AttributeType::I32I32;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec3<i32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I32I32I32
-    }
+    const TYPE: AttributeType = AttributeType::I32I32I32;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec4<i32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I32I32I32I32
-    }
+    const TYPE: AttributeType = AttributeType::I32I32I32I32;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt1<u32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U32
-    }
+    const TYPE: AttributeType = AttributeType::U32;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt2<u32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U32U32
-    }
+    const TYPE: AttributeType = AttributeType::U32U32;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt3<u32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U32U32U32
-    }
+    const TYPE: AttributeType = AttributeType::U32U32U32;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt4<u32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U32U32U32U32
-    }
+    const TYPE: AttributeType = AttributeType::U32U32U32U32;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec1<u32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U32
-    }
+    const TYPE: AttributeType = AttributeType::U32;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec2<u32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U32U32
-    }
+    const TYPE: AttributeType = AttributeType::U32U32;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec3<u32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U32U32U32
-    }
+    const TYPE: AttributeType = AttributeType::U32U32U32;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec4<u32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U32U32U32U32
-    }
+    const TYPE: AttributeType = AttributeType::U32U32U32U32;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt1<i64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I64
-    }
+    const TYPE: AttributeType = AttributeType::I64;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt2<i64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I64I64
-    }
+    const TYPE: AttributeType = AttributeType::I64I64;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt3<i64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I64I64I64
-    }
+    const TYPE: AttributeType = AttributeType::I64I64I64;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt4<i64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I64I64I64I64
-    }
+    const TYPE: AttributeType = AttributeType::I64I64I64I64;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec1<i64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I64
-    }
+    const TYPE: AttributeType = AttributeType::I64;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec2<i64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I64I64
-    }
+    const TYPE: AttributeType = AttributeType::I64I64;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec3<i64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I64I64I64
-    }
+    const TYPE: AttributeType = AttributeType::I64I64I64;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec4<i64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::I64I64I64I64
-    }
+    const TYPE: AttributeType = AttributeType::I64I64I64I64;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt1<u64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U64
-    }
+    const TYPE: AttributeType = AttributeType::U64;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt2<u64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U64U64
-    }
+    const TYPE: AttributeType = AttributeType::U64U64;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt3<u64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U64U64U64
-    }
+    const TYPE: AttributeType = AttributeType::U64U64U64;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt4<u64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U64U64U64U64
-    }
+    const TYPE: AttributeType = AttributeType::U64U64U64U64;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec1<u64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U64
-    }
+    const TYPE: AttributeType = AttributeType::U64;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec2<u64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U64U64
-    }
+    const TYPE: AttributeType = AttributeType::U64U64;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec3<u64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U64U64U64
-    }
+    const TYPE: AttributeType = AttributeType::U64U64U64;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec4<u64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::U64U64U64U64
-    }
+    const TYPE: AttributeType = AttributeType::U64U64U64U64;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt1<f32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F32
-    }
+    const TYPE: AttributeType = AttributeType::F32;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt2<f32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F32F32
-    }
+    const TYPE: AttributeType = AttributeType::F32F32;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt3<f32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F32F32F32
-    }
+    const TYPE: AttributeType = AttributeType::F32F32F32;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt4<f32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F32F32F32F32
-    }
+    const TYPE: AttributeType = AttributeType::F32F32F32F32;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec1<f32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F32
-    }
+    const TYPE: AttributeType = AttributeType::F32;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec2<f32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F32F32
-    }
+    const TYPE: AttributeType = AttributeType::F32F32;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec3<f32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F32F32F32
-    }
+    const TYPE: AttributeType = AttributeType::F32F32F32;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec4<f32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F32F32F32F32
-    }
+    const TYPE: AttributeType = AttributeType::F32F32F32F32;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Mat1<f32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F32
-    }
+    const TYPE: AttributeType = AttributeType::F32;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Mat2<f32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F32x2x2
-    }
+    const TYPE: AttributeType = AttributeType::F32x2x2;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Mat3<f32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F32x3x3
-    }
+    const TYPE: AttributeType = AttributeType::F32x3x3;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Mat4<f32> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F32x4x4
-    }
+    const TYPE: AttributeType = AttributeType::F32x4x4;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt1<f64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F64
-    }
+    const TYPE: AttributeType = AttributeType::F64;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt2<f64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F64F64
-    }
+    const TYPE: AttributeType = AttributeType::F64F64;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt3<f64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F64F64F64
-    }
+    const TYPE: AttributeType = AttributeType::F64F64F64;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Pnt4<f64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F64F64F64F64
-    }
+    const TYPE: AttributeType = AttributeType::F64F64F64F64;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec1<f64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F64
-    }
+    const TYPE: AttributeType = AttributeType::F64;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec2<f64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F64F64
-    }
+    const TYPE: AttributeType = AttributeType::F64F64;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec3<f64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F64F64F64
-    }
+    const TYPE: AttributeType = AttributeType::F64F64F64;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Vec4<f64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F64F64F64F64
-    }
+    const TYPE: AttributeType = AttributeType::F64F64F64F64;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Mat1<f64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F64
-    }
+    const TYPE: AttributeType = AttributeType::F64;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Mat2<f64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F64x2x2
-    }
+    const TYPE: AttributeType = AttributeType::F64x2x2;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Mat3<f64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F64x3x3
-    }
+    const TYPE: AttributeType = AttributeType::F64x3x3;
 }
 
 #[cfg(feature="nalgebra")]
 unsafe impl Attribute for nalgebra::Mat4<f64> {
-    #[inline]
-    fn get_type() -> AttributeType {
-        AttributeType::F64x4x4
-    }
+    const TYPE: AttributeType = AttributeType::F64x4x4;
 }
 
 

--- a/src/vertex/mod.rs
+++ b/src/vertex/mod.rs
@@ -152,7 +152,7 @@ pub enum VerticesSource<'a> {
     ///
     /// The third parameter tells whether or not this buffer is "per instance" (true) or
     /// "per vertex" (false).
-    VertexBuffer(BufferAnySlice<'a>, &'a VertexFormat, bool),
+    VertexBuffer(BufferAnySlice<'a>, VertexFormat, bool),
 
     /// A marker indicating a "phantom list of attributes".
     Marker {
@@ -191,7 +191,7 @@ impl<'a> From<EmptyInstanceAttributes> for VerticesSource<'a> {
 }
 
 /// Marker that instructs glium that the buffer is to be used per instance.
-pub struct PerInstance<'a>(BufferAnySlice<'a>, &'a VertexFormat);
+pub struct PerInstance<'a>(BufferAnySlice<'a>, VertexFormat);
 
 impl<'a> From<PerInstance<'a>> for VerticesSource<'a> {
     #[inline]
@@ -302,8 +302,14 @@ pub trait Vertex: Copy + Sized {
 
 /// Trait for types that can be used as vertex attributes.
 pub unsafe trait Attribute: Sized {
+    /// The type of data.
+    const TYPE: AttributeType;
+
+    #[inline]
     /// Get the type of data.
-    fn get_type() -> AttributeType;
+    fn get_type() -> AttributeType {
+        Self::TYPE
+    }
 
     /// Returns true if the backend supports this type of attribute.
     #[inline]

--- a/src/vertex_array_object.rs
+++ b/src/vertex_array_object.rs
@@ -1,4 +1,4 @@
-use std::borrow::Borrow;
+use std::borrow::{Borrow};
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::mem;
@@ -22,7 +22,7 @@ use crate::version::Version;
 pub struct VertexAttributesSystem {
     // we maintain a list of VAOs for each vertexbuffer-indexbuffer-program association
     // the key is a (buffers-list-with-offset, program) ; the buffers list must be sorted
-    vaos: RefCell<HashMap<(Vec<(gl::types::GLuint, usize)>, Handle), VertexArrayObject>>,
+    vaos: RefCell<HashMap<(SmallVec<[(gl::types::GLuint, usize); 3]>, Handle), VertexArrayObject>>,
 }
 
 /// Object allowing one to bind vertex attributes to the current context.
@@ -116,7 +116,7 @@ impl VertexAttributesSystem {
 
     /// Purges VAOs that match a certain condition.
     fn purge_if<F>(ctxt: &mut CommandContext<'_>, mut condition: F)
-                   where F: FnMut(&(Vec<(gl::types::GLuint, usize)>, Handle)) -> bool
+                   where F: FnMut(&(SmallVec<[(gl::types::GLuint, usize); 3]>, Handle)) -> bool
     {
         let mut vaos = ctxt.vertex_array_objects.vaos.borrow_mut();
 
@@ -142,15 +142,17 @@ impl<'a, 'b, 'c> Binder<'a, 'b, 'c> {
     /// - `first`: Offset of the first element of the buffer in number of elements.
     /// - `divisor`: If `Some`, use this value for `glVertexAttribDivisor` (instancing-related).
     #[inline]
-    pub fn add(mut self, buffer: &BufferAnySlice<'_>, bindings: &VertexFormat, divisor: Option<u32>)
+    pub fn add(mut self, buffer: &BufferAnySlice<'_>, bindings: VertexFormat, divisor: Option<u32>)
                -> Binder<'a, 'b, 'c>
     {
         let offset = buffer.get_offset_bytes();
 
         buffer.prepare_for_vertex_attrib_array(self.context);
 
-        let (buffer, format, stride) = (buffer.get_id(), bindings.clone(),
+        let (buffer, format, stride) = (buffer.get_id(), bindings,
                                         buffer.get_elements_size());
+
+
 
         self.vertex_buffers.push((buffer, format, offset, stride, divisor));
         self
@@ -185,7 +187,7 @@ impl<'a, 'b, 'c> Binder<'a, 'b, 'c> {
                 }
             }
 
-            let mut buffers_list: Vec<_> = self.vertex_buffers.iter()
+            let mut buffers_list: SmallVec<[_; 3]> = self.vertex_buffers.iter()
                                                               .map(|&(v, _, o, s, _)| (v, o))
                                                               .collect();
             buffers_list.push((self.element_array_buffer.map(|b| b.get_id()).unwrap_or(0), 0));


### PR DESCRIPTION
Hi,
This PR reduces memory allocations in draw calls by doing two things:

1. By changing `VertexFormat` from `Cow<'static, [...]>` to a `&'static [...]`.
2. Changing `vaos` from Vec to SmallVec of 3 elements.

## VertexFormat
Now, as far as I can tell from the comments in the code, this is something that the original author wanted to.

What's wrong with the `Cow`? Well, first of all, it's useless - Cow::Borrowed was never constructed, and in every draw call it was [cloned](https://github.com/glium/glium/blob/9045bc1e9e4bbcc149be29078f28921ac413cd28/src/vertex_array_object.rs#LL152C64-L152C64), and `Cow::Owned::clone` clones the data, meaning it cloned the `Vec`.

How it's possible to use a static slice as a vertex format?
The main problem was adapting `implement_vertex` macro. Essentially a macro now has to create a const or static field, and in the trait implementation return it. To do this, the whole logic behind this const generation should also be const. This implies two things:
1. Calculating field offset (`__glium_offset_of`). This is easily doable now, since `offset_from` on pointers is const in rust stable. The latest `memoffset` crate uses it, so `__glium_offset_of` is now also const
2. Making `attr_type_of_val` const. This was a bit more complicated because it called a trait fn, and trait fn's can't be const. So I've adapted the trait, and now it has a const field. The other thing is `Option::map` which is not const, so I had to rewrite that to match.

## vaos

The only place that writes vaos is [this](https://github.com/glium/glium/blob/9045bc1e9e4bbcc149be29078f28921ac413cd28/src/vertex_array_object.rs#L188), and `self.vertex_buffers` is already a `SmallVec` with 2 elements. Only one element is pushed there two lines later, meaning this Vec will always have a constant 3-element size. By changing data type we reduce 2 allocations (one in collect, and one in vec resize in push)


## glium_derive

glium/glium_derive#7