### PR TITLE
Reuse cached fences Vec to reduce allocations to zero

### DIFF
--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -49,6 +49,7 @@ pub use self::view::{BufferSlice, BufferAnySlice};
 pub use self::alloc::{Mapping, WriteMapping, ReadMapping, ReadError, CopyError};
 pub use self::alloc::{is_buffer_read_supported};
 pub use self::fences::Inserter;
+pub use self::fences::FenceInserters;
 
 /// DEPRECATED. Only here for backwards compatibility.
 #[deprecated(note = "Only here for backwards compatibility")]

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -1,6 +1,6 @@
 //! Contains everything related to the interface between glium and the OpenGL implementation.
 
-use crate::gl;
+use crate::{gl, buffer::{Inserter, FenceInserters}};
 
 use std::collections::HashMap;
 use std::mem;
@@ -97,6 +97,15 @@ pub struct Context {
     /// List of images handles that are resident. We need to call `MakeImageHandleResidentARB`
     /// when rebuilding the context.
     resident_image_handles: RefCell<Vec<(gl::types::GLuint64, gl::types::GLenum)>>,
+
+    /// A cached Vec used for fences. Used to reduce memory allocations.
+    fences_cache: RefCell<Vec<Option<Inserter<'static>>>>,
+}
+
+impl Context {
+    pub(crate) fn get_fences<'a>(&self) -> FenceInserters<'a> {
+        FenceInserters::new(self.fences_cache.borrow_mut())
+    }
 }
 
 /// This struct is a guard that is returned when you want to access the OpenGL backend.
@@ -212,6 +221,7 @@ impl Context {
             samplers,
             resident_texture_handles,
             resident_image_handles,
+            fences_cache: Default::default(),
         });
 
         if context.debug_callback.is_some() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,7 @@ use std::fmt;
 use std::hash::BuildHasherDefault;
 use std::collections::HashMap;
 
+use buffer::FenceInserters;
 use fnv::FnvHasher;
 
 use crate::context::Context;
@@ -425,7 +426,7 @@ trait UniformsExt {
     /// Binds the uniforms to a given program.
     ///
     /// Will replace texture and buffer bind points.
-    fn bind_uniforms<'a, P>(&'a self, _: &mut CommandContext<'_>, _: &P, _: &mut Vec<buffer::Inserter<'a>>)
+    fn bind_uniforms<'a, P>(&'a self, _: &mut CommandContext<'_>, _: &P, _: &mut FenceInserters<'a>)
                             -> Result<(), DrawError> where P: ProgramExt;
 }
 

--- a/src/ops/draw.rs
+++ b/src/ops/draw.rs
@@ -33,7 +33,7 @@ pub fn draw<'a, U, V>(context: &Context, framebuffer: Option<&ValidatedAttachmen
 {
     // this contains the list of fences that will need to be fulfilled after the draw command
     // has started
-    let mut fences = Vec::with_capacity(0);
+    let mut fences = context.get_fences();
 
     // handling tessellation
     let vertices_per_patch = match indices.get_primitives_type() {
@@ -328,9 +328,7 @@ pub fn draw<'a, U, V>(context: &Context, framebuffer: Option<&ValidatedAttachmen
     ctxt.state.next_draw_call_id += 1;
 
     // fulfilling the fences
-    for fence in fences.into_iter() {
-        fence.insert(&mut ctxt);
-    }
+    fences.fulfill(&mut ctxt);
 
     Ok(())
 }

--- a/src/program/raw.rs
+++ b/src/program/raw.rs
@@ -562,15 +562,13 @@ impl RawProgram {
 
         TimeElapsedQuery::end_conditional_render(&mut ctxt);
 
-        let mut fences = Vec::with_capacity(0);
+        let mut fences = self.context.get_fences();
 
         self.use_program(&mut ctxt);
         uniforms.bind_uniforms(&mut ctxt, self, &mut fences)?;
         ctxt.gl.DispatchCompute(x, y, z);
 
-        for fence in fences {
-            fence.insert(&mut ctxt);
-        }
+        fences.fulfill(&mut ctxt);
 
         ctxt.state.next_draw_call_id += 1;
 
@@ -608,14 +606,13 @@ impl RawProgram {
 
         self.use_program(&mut ctxt);
 
-        let mut fences = Vec::with_capacity(0);
+        let mut fences = self.context.get_fences();
+
         uniforms.bind_uniforms(&mut ctxt, self, &mut fences)?;
 
         ctxt.gl.DispatchComputeIndirect(offset as gl::types::GLintptr);
 
-        for fence in fences {
-            fence.insert(&mut ctxt);
-        }
+        fences.fulfill(&mut ctxt);
 
         ctxt.state.next_draw_call_id += 1;
 

--- a/src/uniforms/bind.rs
+++ b/src/uniforms/bind.rs
@@ -3,7 +3,7 @@
 Handles binding uniforms to the OpenGL state machine.
 
 */
-use crate::gl;
+use crate::{gl, buffer::FenceInserters};
 
 use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
@@ -36,7 +36,7 @@ use crate::version::Api;
 
 impl<U> UniformsExt for U where U: Uniforms {
     fn bind_uniforms<'a, P>(&'a self, mut ctxt: &mut CommandContext<'_>, program: &P,
-                            fences: &mut Vec<Inserter<'a>>)
+                            fences: &mut FenceInserters<'a>)
                             -> Result<(), DrawError>
                             where P: ProgramExt
     {


### PR DESCRIPTION
This reduces heap allocations to zero (at least in my use case). Related to #2056.

The idea here is that `Context` and `CommandContext` can only be used in a single thread, and fences Vec's used to be created and collected in the scope of a function call. Meaning we can pre-allocate a single Vec for fences, and then just "take" it on every call and "return it back" when the call ends.

There are a couple of caveats though:
1. Inserter has a lifetime. If we are to cache the Vec of Inserters, the lifetime in our cache must be broader than the lifetime that Inserter will have in a particular draw/compute call. Meaning I don't really see a way of implementing that without the unsafe magic of downcasting lifetimes. So the general idea is:
   1. We have a preallocated Vec somewhere in the context. The size of the Vec is zero, but the capacity is remaining from the previous call
   2. In a draw/compute call we take a mut ref to this Vec, downcast a lifetime to a local one, and push new inserted to this vec as needed
   3. At the end of the draw/compute call we fulfill those fences, by taking them from Vec
   4. We clean the Vec, so the size now is 0 (but capacity remains), so the Vec does not contain any references with a local lifetime
   5. We're back to an empty Vec of inserters with a 'static lifetime (but capacity remains, so we don't have to reallocate in the next draw/compute calls)
2. Due to the current architecture I wasn't able to put this fences cache in `CommandContext` without refactoring Fences and `sync` stuff, simply because `Inserters.insert` call takes a mut ref to `CommandContext` as an argument. So in this implementation, I made a `pub(crate) fn` that "takes" fences Vec from the `Context` instead.