### PR TITLE
Fix panic for stencil-only textures

### DIFF
--- a/src/texture/get_format.rs
+++ b/src/texture/get_format.rs
@@ -229,6 +229,7 @@ pub fn get_format(ctxt: &mut CommandContext<'_>, texture: &TextureAny)
         Ok(match (red_sz, red_ty, green_sz, green_ty, blue_sz, blue_ty,
                alpha_sz, alpha_ty, depth_sz, depth_ty)
         {
+            (_, gl::NONE, _, _, _, _, _, _, _, gl::NONE) => return Err(GetFormatError::NotSupported),
             (_, gl::NONE, _, _, _, _, _, _, sz1, ty1) => InternalFormat::OneComponent {
                 ty1: InternalFormatType::from_glenum(ty1),
                 bits1: sz1 as usize,


### PR DESCRIPTION
This is an issue I found while running the tests on Windows 10 and Debian 12. It can also be reproduced with this simple program:
``` rust
fn main() {
    let wb = glium::glutin::window::WindowBuilder::new();
    let cb = glium::glutin::ContextBuilder::new();
    let event_loop = glium::glutin::event_loop::EventLoop::new();
    let display = glium::Display::new(wb, cb, &event_loop).unwrap();

    // any stencil-only texture used will panic
    let texture = glium::texture::StencilCubemapArray::empty_with_format(
        &display,
        glium::texture::StencilFormat::I8,
        glium::texture::MipmapsOption::NoMipmap,
        64,
        32
    ).unwrap();
    let _ = texture.get_internal_format();
}
```

The issue is just with calling `get_internal_format`, creating the stencil-only textures appears fine.

An alternative change based off this [documentation](https://docs.rs/glium/0.32.1/glium/texture/enum.StencilFormat.html) would be to return `InternalFormat::OneComponent { ty1: InternalFormatType::Int, bits1: 8 }` when both the red and depth types are `gl::NONE`, but this commit is sufficient to fix the failing tests.