### PR TITLE
Apply fix to resurrected tests

### DIFF
--- a/tests/uniforms.rs
+++ b/tests/uniforms.rs
@@ -212,8 +212,8 @@ fn uniforms_dynamic_single_value() {
     texture.as_surface().draw(&vb, &ib, &program, &uniforms, &Default::default()).unwrap();
 
     let data: Vec<Vec<(u8, u8, u8, u8)>> = texture.read();
-    assert_eq!(data[0][0], (255, 0, 0, 128));
-    assert_eq!(data.last().unwrap().last().unwrap(), &(255, 0, 0, 128));
+    assert_eq!(data[0][0], RED_HALF_ALPHA);
+    assert_eq!(data.last().unwrap().last().unwrap(), &RED_HALF_ALPHA);
 
     display.assert_no_error(None);
 }
@@ -296,8 +296,8 @@ fn uniforms_dynamic_ignore_inactive_uniforms() {
     texture.as_surface().draw(&vb, &ib, &program, &uniforms, &Default::default()).unwrap();
 
     let data: Vec<Vec<(u8, u8, u8, u8)>> = texture.read();
-    assert_eq!(data[0][0], (255, 0, 0, 128));
-    assert_eq!(data.last().unwrap().last().unwrap(), &(255, 0, 0, 128));
+    assert_eq!(data[0][0], RED_HALF_ALPHA);
+    assert_eq!(data.last().unwrap().last().unwrap(), &RED_HALF_ALPHA);
 
     display.assert_no_error(None);
 }


### PR DESCRIPTION
I wasn't able to track down how these two tests disappeared in the glutin 0.30 branch, but a rebase several weeks before it was merged is what resurrected them.

This change applies to these two tests a previously merged fix 4add826bcb34cfb6f5fb1ed38215cbb8ddc4101f for the other two tests that use the (1.0, 0.0, 0.0, 0.5) colour value.