### PR TITLE
Running tests on Unix and Windows

### DIFF
--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -20,12 +20,22 @@ use glutin::surface::{SurfaceAttributesBuilder, WindowSurface};
 use glutin_winit::DisplayBuilder;
 use raw_window_handle::HasRawWindowHandle;
 
+// There is a Wayland version of this extension trait but the X11 version also works on Wayland
+#[cfg(unix)]
+use winit::platform::x11::EventLoopBuilderExtX11;
+#[cfg(windows)]
+use winit::platform::windows::EventLoopBuilderExtWindows;
+
 use std::env;
 
 /// Builds a display for tests.
 pub fn build_display() -> Display<WindowSurface> {
     let version = parse_version();
-    let event_loop = EventLoopBuilder::new().build();
+    let event_loop = if cfg!(unix) || cfg!(windows) {
+        EventLoopBuilder::new().with_any_thread(true).build()
+    } else {
+        EventLoopBuilder::new().build()
+    };
     let window_builder = WindowBuilder::new().with_visible(false);
     let config_template_builder = ConfigTemplateBuilder::new();
     let display_builder = DisplayBuilder::new().with_window_builder(Some(window_builder));


### PR DESCRIPTION
Attempting to run `cargo test --tests` or `cargo test [--all] --all-targets` quickly results in failure with:

> thread 'basic' panicked at 'Initializing the event loop outside of the main thread is a significant cross-platform compatibility hazard. If you absolutely need to create an EventLoop on a different thread, you can use the EventLoopBuilderExtUnix::any_thread function.', /home/justin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.28.6/src/platform_impl/linux/mod.rs:697:13

Following the error message's advice leads to the next error:

> thread 'attribute_float_i16' panicked at 'Creating EventLoop multiple times is not supported.', /home/justin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.28.6/src/event_loop.rs:116:13

This change addresses both issues on Unix and Windows by creating the event loop on its own thread and setting up communication channels so new windows can be sent to test threads on request. On Wayland, the `WindowBuilder` option `with_visible(false)` is not respected, but this is just an annoyance and does not cause issues running the tests. On X11, there are additional issues that prevent the tests from simply being run:
- All tests under `tests/attrs.rs` hang indefinitely.
- The other test targets can run to completion but are often met with the intermittent failure `error: XError(XError { description: "GLXBadWindow", error_code: 170, request_code: 152, minor_code: 32 })` that causes any remaining tests in the target to also fail

The implementation has a bit of a code smell, but it allows the changes to be localised around the `build_display` function and the call sites do not need to be updated. I have no experience with GitHub Actions, but I attempted to update the CI and was met with the errors:

Ubuntu
> thread 'event_loop' panicked at 'Failed to initialize any backend! Wayland status: NoCompositorListening X11 status: XOpenDisplayFailed', /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.28.6/src/platform_impl/linux/mod.rs:757:9

Windows
> thread 'basic' panicked at 'called `Result::unwrap()` on an `Err` value: IncompatibleOpenGl("OpenGL implementation doesn't support buffer objects\nOpenGL implementation doesn't support vertex/fragment shaders\nOpenGL implementation doesn't support framebuffers\nOpenGL implementation doesn't support blitting framebuffers")', tests\support\mod.rs:139:75