### PR TITLE
Doc test fixes

### DIFF
--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -25,8 +25,9 @@
 //! `implement_buffer_content!` macro on them. You must then use the `empty_unsized` constructor.
 //!
 //! ```no_run
-//! # #[macro_use] extern crate glium;
-//! # fn example(display: glium::Display) {
+//! # use glium::implement_buffer_content;
+//! # use glutin::surface::{ResizeableSurface, SurfaceTypeTrait};
+//! # fn example<T>(display: glium::Display<T>) where T: SurfaceTypeTrait + ResizeableSurface {
 //! # use std::mem;
 //! # use glium::buffer::{BufferType, BufferMode};
 //! struct Data {

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -510,7 +510,8 @@ impl Context {
     /// ## Example
     ///
     /// ```no_run
-    /// # fn example(display: glium::Display) {
+    /// # use glutin::surface::{ResizeableSurface, SurfaceTypeTrait};
+    /// # fn example<T>(display: glium::Display<T>) where T: SurfaceTypeTrait + ResizeableSurface {
     /// let pixels: Result<Vec<Vec<(u8, u8, u8, u8)>>, _> = display.read_front_buffer();
     /// # }
     /// ```

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -101,7 +101,8 @@ pub enum MessageType {
 /// ## Example
 ///
 /// ```no_run
-/// # fn example(display: glium::Display) {
+/// # use glutin::surface::{ResizeableSurface, SurfaceTypeTrait};
+/// # fn example<T>(display: glium::Display<T>) where T: SurfaceTypeTrait + ResizeableSurface {
 /// let before = glium::debug::TimestampQuery::new(&display);
 /// // do some stuff here
 /// let after = glium::debug::TimestampQuery::new(&display);

--- a/src/draw_parameters/mod.rs
+++ b/src/draw_parameters/mod.rs
@@ -20,7 +20,8 @@
 //! `SamplesPassedQuery` allows you to know the number of samples that have been drawn.
 //!
 //! ```no_run
-//! # fn example(display: glium::Display) {
+//! # use glutin::surface::{ResizeableSurface, SurfaceTypeTrait};
+//! # fn example<T>(display: glium::Display<T>) where T: SurfaceTypeTrait + ResizeableSurface {
 //! let query = glium::draw_parameters::SamplesPassedQuery::new(&display).unwrap();
 //! let params = glium::DrawParameters {
 //!     samples_passed_query: Some((&query).into()),

--- a/src/framebuffer/mod.rs
+++ b/src/framebuffer/mod.rs
@@ -5,7 +5,10 @@ In order to draw on a texture, use a `SimpleFrameBuffer`. This framebuffer is co
 shaders that write to `gl_FragColor`.
 
 ```no_run
-# fn example(display: glium::Display, texture: glium::texture::Texture2d) {
+# use glium::texture::Texture2d;
+# use glutin::surface::{ResizeableSurface, SurfaceTypeTrait};
+# fn example<T>(display: glium::Display<T>, texture: Texture2d)
+#     where T: SurfaceTypeTrait + ResizeableSurface {
 let framebuffer = glium::framebuffer::SimpleFrameBuffer::new(&display, &texture);
 // framebuffer.draw(...);    // draws over `texture`
 # }
@@ -16,7 +19,9 @@ a `MultiOutputFrameBuffer`.
 
 ```no_run
 # use glium::texture::Texture2d;
-# fn example(display: glium::Display, texture1: Texture2d, texture2: Texture2d) {
+# use glutin::surface::{ResizeableSurface, SurfaceTypeTrait};
+# fn example<T>(display: glium::Display<T>, texture1: Texture2d, texture2: Texture2d)
+#     where T: SurfaceTypeTrait + ResizeableSurface {
 let output = [ ("output1", &texture1), ("output2", &texture2) ];
 let framebuffer = glium::framebuffer::MultiOutputFrameBuffer::new(&display, output.iter().cloned());
 // framebuffer.draw(...);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -77,14 +77,15 @@ macro_rules! uniform {
 /// ## Example
 ///
 /// ```rust
+/// # #[macro_use] extern crate glium;
 /// # use glium::uniform;
 /// # fn main(){
-///     let uniforms = dynamic_uniform!{
-///         color: [1.0, 1.0, 0.0, 1.0],
-///         some_value: 12i32,
+///     let mut uniforms = dynamic_uniform!{
+///         color: &[1.0, 1.0, 0.0, 1.0],
+///         some_value: &12i32,
 ///     };
 ///
-///     uniforms.add("another_value", 1.5f32);
+///     uniforms.add("another_value", &1.5f32);
 /// # }
 /// ```
 ///

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -527,7 +527,8 @@ macro_rules! implement_uniform_block {
 ///
 /// ```no_run
 /// use glium::program;
-/// # fn example(display: glium::Display) {
+/// # use glutin::surface::{ResizeableSurface, SurfaceTypeTrait};
+/// # fn example<T>(display: glium::Display<T>) where T: SurfaceTypeTrait + ResizeableSurface {
 /// let program = program!(&display,
 ///     300 => {
 ///         vertex: r#"

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -140,6 +140,11 @@ macro_rules! dynamic_uniform{
 ///
 /// You can specify a normalize option for attributes.
 /// ```
+/// # #[derive(Clone, Copy)]
+/// # struct Vertex {
+/// #     position: [f32; 2],
+/// #     tex_coords: [f32; 2],
+/// # }
 /// # use glium::implement_vertex;
 /// # fn main() {
 /// implement_vertex!(Vertex, position normalize(false), tex_coords normalize(false));
@@ -149,6 +154,11 @@ macro_rules! dynamic_uniform{
 ///
 /// You can specify a location option for attributes.
 /// ```
+/// # #[derive(Clone, Copy)]
+/// # struct Vertex {
+/// #     position: [f32; 2],
+/// #     tex_coords: [f32; 2],
+/// # }
 /// # use glium::implement_vertex;
 /// # fn main() {
 /// implement_vertex!(Vertex, position location(0), tex_coords location(1));

--- a/src/program/program.rs
+++ b/src/program/program.rs
@@ -187,7 +187,8 @@ impl Program {
     /// # Example
     ///
     /// ```no_run
-    /// # fn example(display: glium::Display) {
+    /// # use glutin::surface::{ResizeableSurface, SurfaceTypeTrait};
+    /// # fn example<T>(display: glium::Display<T>) where T: SurfaceTypeTrait + ResizeableSurface {
     /// # let vertex_source = ""; let fragment_source = ""; let geometry_source = "";
     /// let program = glium::Program::from_source(&display, vertex_source, fragment_source,
     ///     Some(geometry_source));

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -22,7 +22,8 @@ pub struct SyncNotSupportedError;
 /// ## Example
 ///
 /// ```no_run
-/// # fn example(display: glium::Display) {
+/// # use glutin::surface::{ResizeableSurface, SurfaceTypeTrait};
+/// # fn example<T>(display: glium::Display<T>) where T: SurfaceTypeTrait + ResizeableSurface {
 /// # fn do_something<T>(_: &T) {}
 /// let fence = glium::SyncFence::new(&display).unwrap();
 /// do_something(&display);

--- a/src/texture/bindless.rs
+++ b/src/texture/bindless.rs
@@ -17,7 +17,9 @@ Bindless textures are a very recent feature that is supported only by recent har
 drivers. `resident` will return an `Err` if this feature is not supported.
 
 ```no_run
-# fn example(display: glium::Display, texture: glium::texture::Texture2d) {
+# use glutin::surface::{ResizeableSurface, SurfaceTypeTrait};
+# fn example<T>(display: glium::Display<T>, texture: glium::texture::Texture2d)
+#     where T: SurfaceTypeTrait + ResizeableSurface {
 let texture = texture.resident().unwrap();
 # }
 ```
@@ -42,7 +44,9 @@ struct UniformBuffer<'a> {
 
 implement_uniform_block!(UniformBuffer<'a>, texture, some_value);
 
-# fn example(display: glium::Display, texture: glium::texture::bindless::ResidentTexture) {
+# use glutin::surface::{ResizeableSurface, SurfaceTypeTrait};
+# fn example<T>(display: glium::Display<T>, texture: glium::texture::bindless::ResidentTexture)
+#     where T: SurfaceTypeTrait + ResizeableSurface {
 let uniform_buffer = glium::uniforms::UniformBuffer::new(&display, UniformBuffer {
     texture: glium::texture::TextureHandle::new(&texture, &Default::default()),
     some_value: 5.0,

--- a/src/uniforms/mod.rs
+++ b/src/uniforms/mod.rs
@@ -7,7 +7,8 @@ The currently preferred way to do this is to use the `uniform!` macro provided b
 
 ```no_run
 # use glium::uniform;
-# fn example(display: glium::Display) {
+# use glutin::surface::{ResizeableSurface, SurfaceTypeTrait};
+# fn example<T>(display: glium::Display<T>) where T: SurfaceTypeTrait + ResizeableSurface {
 # let tex: f32 = 0.0;
 # let matrix: f32 = 0.0;
 let uniforms = uniform! {
@@ -25,7 +26,9 @@ In order to customize the way a texture is being sampled, you must use a `Sample
 
 ```no_run
 # use glium::uniform;
-# fn example(display: glium::Display, texture: glium::texture::Texture2d) {
+# use glutin::surface::{ResizeableSurface, SurfaceTypeTrait};
+# fn example<T>(display: glium::Display<T>, texture: glium::texture::Texture2d)
+#     where T: SurfaceTypeTrait + ResizeableSurface {
 let uniforms = uniform! {
     texture: glium::uniforms::Sampler::new(&texture)
                         .magnify_filter(glium::uniforms::MagnifySamplerFilter::Nearest)
@@ -41,7 +44,9 @@ can link the buffer to the name of the block, just like any other uniform.
 
 ```no_run
 # use glium::uniform;
-# fn example(display: glium::Display, texture: glium::texture::Texture2d) {
+# use glutin::surface::{ResizeableSurface, SurfaceTypeTrait};
+# fn example<T>(display: glium::Display<T>, texture: glium::texture::Texture2d)
+#     where T: SurfaceTypeTrait + ResizeableSurface {
 let program = glium::Program::from_source(&display,
     "
         #version 110
@@ -83,7 +88,9 @@ A subroutine uniform is unique per shader stage, and not per program.
 
 ```no_run
 # use glium::uniform;
-# fn example(display: glium::Display, texture: glium::texture::Texture2d) {
+# use glutin::surface::{ResizeableSurface, SurfaceTypeTrait};
+# fn example<T>(display: glium::Display<T>, texture: glium::texture::Texture2d)
+#     where T: SurfaceTypeTrait + ResizeableSurface {
 let program = glium::Program::from_source(&display,
     "
         #version 150

--- a/src/vertex/buffer.rs
+++ b/src/vertex/buffer.rs
@@ -117,8 +117,8 @@ impl<T> VertexBuffer<T> where T: Vertex {
     /// }
     ///
     /// implement_vertex!(Vertex, position, texcoords);
-    ///
-    /// # fn example(display: glium::Display) {
+    /// # use glutin::surface::{ResizeableSurface, SurfaceTypeTrait};
+    /// # fn example<T>(display: glium::Display<T>) where T: SurfaceTypeTrait + ResizeableSurface {
     /// let vertex_buffer = glium::VertexBuffer::new(&display, &[
     ///     Vertex { position: [0.0,  0.0, 0.0], texcoords: [0.0, 1.0] },
     ///     Vertex { position: [5.0, -3.0, 2.0], texcoords: [1.0, 0.0] },
@@ -234,7 +234,8 @@ impl<T> VertexBuffer<T> where T: Copy {
     /// # Example
     ///
     /// ```no_run
-    /// # fn example(display: glium::Display) {
+    /// # use glutin::surface::{ResizeableSurface, SurfaceTypeTrait};
+    /// # fn example<T>(display: glium::Display<T>) where T: SurfaceTypeTrait + ResizeableSurface {
     /// use std::borrow::Cow;
     ///
     /// let bindings = Cow::Owned(vec![(

--- a/src/vertex/mod.rs
+++ b/src/vertex/mod.rs
@@ -32,7 +32,8 @@ Once you have a struct that implements the `Vertex` trait, you can build an arra
 upload it to the video memory by creating a `VertexBuffer`.
 
 ```no_run
-# fn example(display: glium::Display) {
+# use glutin::surface::{ResizeableSurface, SurfaceTypeTrait};
+# fn example<T>(display: glium::Display<T>) where T: SurfaceTypeTrait + ResizeableSurface {
 # #[derive(Copy, Clone)]
 # struct MyVertex {
 #     position: [f32; 3],
@@ -75,8 +76,10 @@ Each source can be:
 
 ```no_run
 # use glium::Surface;
-# fn example<V: glium::vertex::Vertex>(display: glium::Display, program: glium::program::Program,
-#            vertex_buffer: glium::vertex::VertexBuffer<V>, vertex_buffer2: glium::vertex::VertexBuffer<V>) {
+# use glutin::surface::{ResizeableSurface, SurfaceTypeTrait};
+# fn example<T, V>(display: glium::Display<T>, program: glium::program::Program,
+#            vertex_buffer: glium::vertex::VertexBuffer<V>, vertex_buffer2: glium::vertex::VertexBuffer<V>)
+#     where T: SurfaceTypeTrait + ResizeableSurface, V: glium::vertex::Vertex {
 # let indices = glium::index::NoIndices(glium::index::PrimitiveType::TrianglesList);
 # let uniforms = glium::uniforms::EmptyUniforms;
 # let mut frame = display.draw();

--- a/src/vertex/transform_feedback.rs
+++ b/src/vertex/transform_feedback.rs
@@ -59,8 +59,10 @@ use crate::gl;
 /// ```no_run
 /// # use glium::{implement_vertex, uniform};
 /// # use glium::Surface;
-/// # fn example(display: glium::Display, program: glium::Program,
-/// #            vb: glium::vertex::VertexBufferAny, ib: glium::index::IndexBuffer<u16>) {
+/// # use glutin::surface::{ResizeableSurface, SurfaceTypeTrait};
+/// # fn example<T>(display: glium::Display<T>, program: glium::Program,
+/// #            vb: glium::vertex::VertexBufferAny, ib: glium::index::IndexBuffer<u16>)
+/// #     where T: SurfaceTypeTrait + ResizeableSurface {
 /// #[derive(Copy, Clone, Debug, PartialEq)]
 /// struct Vertex {
 ///     output_val: (f32, f32),


### PR DESCRIPTION
This mostly just updates the `Display`s to be generic in the doc tests. The other `src/macros.rs` doc test issues are addressed in separate commits. Only `src/vertex/buffer.rs` has a remaining test that fails when running

`cargo test --doc`

I'm not sure what the right approach for that doc test would be.