### PR TITLE
Fix sRGB confusion

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -784,12 +784,12 @@ pub trait Surface {
     fn clear(&mut self, rect: Option<&Rect>, color: Option<(f32, f32, f32, f32)>, color_srgb: bool,
              depth: Option<f32>, stencil: Option<i32>);
 
-    /// Clears the color attachment of the target.
+    /// Clears the color attachment of the target. The color is converted to sRGB when the target has sRGB format.
     fn clear_color(&mut self, red: f32, green: f32, blue: f32, alpha: f32) {
         self.clear(None, Some((red, green, blue, alpha)), false, None, None);
     }
 
-    /// Clears the color attachment of the target. The color is in sRGB format.
+    /// Clears the color attachment of the target. The color is in sRGB format and is not converted in the target.
     fn clear_color_srgb(&mut self, red: f32, green: f32, blue: f32, alpha: f32) {
         self.clear(None, Some((red, green, blue, alpha)), true, None, None);
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -616,7 +616,7 @@ macro_rules! program {
             let __tessellation_evaluation_shader: Option<&str> = None;
             let __geometry_shader: Option<&str> = None;
             let __fragment_shader: &str = "";
-            let __outputs_srgb: bool = false;
+            let __outputs_srgb: bool = true;
             let __uses_point_size: bool = false;
 
             $(

--- a/src/ops/clear.rs
+++ b/src/ops/clear.rs
@@ -35,11 +35,11 @@ pub fn clear(context: &Context, framebuffer: Option<&ValidatedAttachments<'_>>,
         if ctxt.version >= &Version(Api::Gl, 3, 0) || ctxt.extensions.gl_arb_framebuffer_srgb ||
            ctxt.extensions.gl_ext_framebuffer_srgb || ctxt.extensions.gl_ext_srgb_write_control
         {
-            if color_srgb && !ctxt.state.enabled_framebuffer_srgb {
+            if !color_srgb && !ctxt.state.enabled_framebuffer_srgb {
                 ctxt.gl.Enable(gl::FRAMEBUFFER_SRGB);
                 ctxt.state.enabled_framebuffer_srgb = true;
 
-            } else if !color_srgb && ctxt.state.enabled_framebuffer_srgb {
+            } else if color_srgb && ctxt.state.enabled_framebuffer_srgb {
                 ctxt.gl.Disable(gl::FRAMEBUFFER_SRGB);
                 ctxt.state.enabled_framebuffer_srgb = false;
             }

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -262,8 +262,8 @@ pub enum ProgramCreationInput<'a> {
         /// `None`, then you won't be able to use transform feedback.
         transform_feedback_varyings: Option<(Vec<String>, TransformFeedbackMode)>,
 
-        /// Whether the fragment shader outputs colors in `sRGB` or `RGB`. This is false by default,
-        /// meaning that the program outputs `RGB`.
+        /// Whether the fragment shader outputs colors in `sRGB` or `RGB`. This is true by default,
+        /// meaning that the program is responsible for outputting correct `sRGB` values.
         ///
         /// If this is false, then `GL_FRAMEBUFFER_SRGB` will be enabled when this program is used
         /// (if it is supported).
@@ -333,7 +333,7 @@ impl<'a> SpirvProgram<'a> {
             tessellation_evaluation_shader: None,
             geometry_shader: None,
             transform_feedback_varyings: None,
-            outputs_srgb: false,
+            outputs_srgb: true,
             uses_point_size: false,
         }
     }
@@ -416,7 +416,7 @@ impl<'a> From<SourceCode<'a>> for ProgramCreationInput<'a> {
             geometry_shader,
             fragment_shader,
             transform_feedback_varyings: None,
-            outputs_srgb: false,
+            outputs_srgb: true,
             uses_point_size: false,
         }
     }
@@ -436,7 +436,7 @@ impl<'a> From<Binary> for ProgramCreationInput<'a> {
     fn from(binary: Binary) -> ProgramCreationInput<'a> {
         ProgramCreationInput::Binary {
             data: binary,
-            outputs_srgb: false,
+            outputs_srgb: true,
             uses_point_size: false,
         }
     }

--- a/src/program/program.rs
+++ b/src/program/program.rs
@@ -207,7 +207,7 @@ impl Program {
             tessellation_control_shader: None,
             tessellation_evaluation_shader: None,
             transform_feedback_varyings: None,
-            outputs_srgb: false,
+            outputs_srgb: true,
             uses_point_size: false,
         })
     }


### PR DESCRIPTION
Per the conversations from #2069 et cetera.

Part of the confusion is that `glutin` creates an sRGB default framebuffer, and there is apparently no way around this (for WGL and GLX) via the API in recent versions.

`clear_color` will likely remain confusing to new users, but hopefully the documentation update will prevent unnecessary issue tickets.