### PR TITLE
Fix examples for new sRGB conventions

### DIFF
--- a/examples/blitting.rs
+++ b/examples/blitting.rs
@@ -29,7 +29,7 @@ impl ApplicationContext for Application {
                             glium::texture::UncompressedFloatFormat::U8U8U8U8,
                             glium::texture::MipmapsOption::NoMipmap,
                             1024, 1024).unwrap();
-        dest_texture.as_surface().clear_color(0.0, 0.0, 0.0, 1.0);
+        dest_texture.as_surface().clear_color_srgb(0.0, 0.0, 0.0, 1.0);
 
         Self {
             opengl_texture,

--- a/examples/displacement_mapping.rs
+++ b/examples/displacement_mapping.rs
@@ -43,28 +43,28 @@ impl ApplicationContext for Application {
                 display,
                 &[
                     Vertex {
-                        position: [-0.5, 0.5, 3.0],
+                        position: [-0.5, 0.5, 0.0],
+                        tex_coords: [0.0, 1.0],
+                    },
+                    Vertex {
+                        position: [0.5, 0.5, 0.0],
                         tex_coords: [1.0, 1.0],
                     },
                     Vertex {
-                        position: [0.5, 0.5, 3.0],
-                        tex_coords: [0.0, 1.0],
-                    },
-                    Vertex {
-                        position: [-0.5, -0.5, 3.0],
-                        tex_coords: [1.0, 0.0],
-                    },
-                    Vertex {
-                        position: [0.5, 0.5, 3.0],
-                        tex_coords: [0.0, 1.0],
-                    },
-                    Vertex {
-                        position: [0.5, -0.5, 3.0],
+                        position: [-0.5, -0.5, 0.0],
                         tex_coords: [0.0, 0.0],
                     },
                     Vertex {
-                        position: [-0.5, -0.5, 3.0],
+                        position: [0.5, 0.5, 0.0],
+                        tex_coords: [1.0, 1.0],
+                    },
+                    Vertex {
+                        position: [0.5, -0.5, 0.0],
                         tex_coords: [1.0, 0.0],
+                    },
+                    Vertex {
+                        position: [-0.5, -0.5, 0.0],
+                        tex_coords: [0.0, 0.0],
                     },
                 ],
             )
@@ -210,13 +210,13 @@ impl ApplicationContext for Application {
 
                     uniform sampler2D color_texture;
 
-                    const vec3 LIGHT = vec3(-0.2, 0.1, 0.8);
+                    const vec3 LIGHT = vec3(-0.2, 0.1, -0.8);
 
                     void main() {
                         float lum = max(dot(normalize(g_normal), normalize(LIGHT)), 0.0);
                         vec3 tex_color = texture(color_texture, g_tex_coords).rgb;
                         vec3 color = (0.6 + 0.4 * lum) * tex_color;
-                        o_color = vec4(1.0, 0.0, 0.0, 1.0);
+                        o_color = vec4(color, 1);
                     }
                 ",
             },
@@ -239,12 +239,7 @@ impl ApplicationContext for Application {
             inner_level: 64.0f32,
             outer_level: 64.0f32,
             projection_matrix: self.camera.get_perspective(),
-            view_matrix: [
-                [1.0, 0.0, 0.0, 0.0],
-                [0.0, 1.0, 0.0, 0.0],
-                [0.0, 0.0, 1.0, 0.0],
-                [0.0, 0.0, 0.0, 1.0f32]
-            ],
+            view_matrix: self.camera.get_view(),
             height_texture: &self.opengl_texture,
             elevation: 0.3f32,
             color_texture: &self.opengl_texture

--- a/examples/displacement_mapping.rs
+++ b/examples/displacement_mapping.rs
@@ -16,7 +16,7 @@ struct Vertex {
 implement_vertex!(Vertex, position, tex_coords);
 
 struct Application {
-    pub opengl_texture: glium::texture::CompressedSrgbTexture2d,
+    pub opengl_texture: glium::texture::CompressedTexture2d,
     pub vertex_buffer: glium::VertexBuffer<Vertex>,
     pub program: glium::Program,
     pub camera: support::camera::CameraState,
@@ -35,7 +35,7 @@ impl ApplicationContext for Application {
         let image_dimensions = image.dimensions();
         let image =
             glium::texture::RawImage2d::from_raw_rgba_reversed(&image.into_raw(), image_dimensions);
-        let opengl_texture = glium::texture::CompressedSrgbTexture2d::new(display, image).unwrap();
+        let opengl_texture = glium::texture::CompressedTexture2d::new(display, image).unwrap();
 
         // building the vertex buffer, which contains all the vertices that we will draw
         let vertex_buffer = {

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -20,7 +20,7 @@ implement_vertex!(Vertex, position, tex_coords);
 struct Application {
     pub vertex_buffer: glium::VertexBuffer<Vertex>,
     pub index_buffer: glium::IndexBuffer<u16>,
-    pub opengl_texture: glium::texture::CompressedSrgbTexture2d,
+    pub opengl_texture: glium::texture::CompressedTexture2d,
     pub program: glium::Program,
 }
 
@@ -38,7 +38,7 @@ impl ApplicationContext for Application {
         let image_dimensions = image.dimensions();
         let image =
             glium::texture::RawImage2d::from_raw_rgba_reversed(&image.into_raw(), image_dimensions);
-        let opengl_texture = glium::texture::CompressedSrgbTexture2d::new(display, image).unwrap();
+        let opengl_texture = glium::texture::CompressedTexture2d::new(display, image).unwrap();
 
         // building the vertex buffer, which contains all the vertices that we will draw
         let vertex_buffer = {

--- a/examples/tutorial-06.rs
+++ b/examples/tutorial-06.rs
@@ -14,7 +14,7 @@ fn main() {
                             image::ImageFormat::Png).unwrap().to_rgba8();
     let image_dimensions = image.dimensions();
     let image = glium::texture::RawImage2d::from_raw_rgba_reversed(&image.into_raw(), image_dimensions);
-    let texture = glium::texture::SrgbTexture2d::new(&display, image).unwrap();
+    let texture = glium::Texture2d::new(&display, image).unwrap();
 
     #[derive(Copy, Clone)]
     struct Vertex {


### PR DESCRIPTION
First commit, which should have been included in #2076:
- Calls `clear_color_srgb` to disable colour conversion when blitting to the default framebuffer
- Uses non-sRGB 2D texture types to prevent darkening the texture in tutorial-06, image, and displacement_mapping

Second commit shows the displacement_mapping example by:
- Moving the quad in front of the camera view and fixing tex-coords (flip horizontal)
- Flipping the Z-value of fragment lighting and unmasking the computed colours
- Using the camera view, thus unlocking camera movement