### PR TITLE
SimpleWindowBuilder.build should be generic over EventLoop<T>

### DIFF
--- a/src/backend/glutin/mod.rs
+++ b/src/backend/glutin/mod.rs
@@ -330,7 +330,7 @@ impl SimpleWindowBuilder {
 
     /// Create a new [`Window`](winit::window::Window) and [`Display`]
     /// with the specified parameters.
-    pub fn build(self, event_loop: &winit::event_loop::EventLoop<()>) -> (winit::window::Window, Display<glutin::surface::WindowSurface>) {
+    pub fn build<T>(self, event_loop: &winit::event_loop::EventLoop<T>) -> (winit::window::Window, Display<glutin::surface::WindowSurface>) {
         use glutin::prelude::*;
         use raw_window_handle::HasRawWindowHandle;
 


### PR DESCRIPTION
This allows me to add my own events to the event loop via
`winit::event::Event`, prior to this change I was seeing errors that looked
like the following:

```
error[E0308]: mismatched types
   --> src/main.rs:62:16
    |
62  |         .build(&el);
    |          ----- ^^^ expected `&EventLoop<()>`, found `&EventLoop<MyEvent>`
    |          |
    |          arguments to this method are incorrect
    |
    = note: expected reference `&EventLoop<()>`
               found reference `&EventLoop<MyEvent>`
```

I haven't tried running any tests, just thought I would get feedback from
maintainers before doing any more.
