### PR TITLE
Fix documentation around `outputs_srgb` and other `cargo doc` warnings

### DIFF
--- a/src/image_format.rs
+++ b/src/image_format.rs
@@ -1034,13 +1034,13 @@ pub enum CompressedFormat {
     /// BPTC format with three components (no alpha) represented as unsigned floats.
     BptcUnsignedFloat3,
 
-    /// S3TC DXT1 without alpha, see https://www.opengl.org/wiki/S3_Texture_Compression.
+    /// S3TC DXT1 without alpha, see <https://www.opengl.org/wiki/S3_Texture_Compression>.
     S3tcDxt1NoAlpha,
-    /// S3TC DXT1 with 1-bit alpha, see https://www.opengl.org/wiki/S3_Texture_Compression.
+    /// S3TC DXT1 with 1-bit alpha, see <https://www.opengl.org/wiki/S3_Texture_Compression>.
     S3tcDxt1Alpha,
-    /// S3TC DXT3, see https://www.opengl.org/wiki/S3_Texture_Compression.
+    /// S3TC DXT3, see <https://www.opengl.org/wiki/S3_Texture_Compression>.
     S3tcDxt3Alpha,
-    /// S3TC DXT5, see https://www.opengl.org/wiki/S3_Texture_Compression.
+    /// S3TC DXT5, see <https://www.opengl.org/wiki/S3_Texture_Compression>.
     S3tcDxt5Alpha,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ Easy-to-use, high-level, OpenGL3+ wrapper.
 Glium is based on glutin - a cross-platform crate for building an OpenGL window and handling
 application events.
 
-Glium provides a [**Display**](`Display`) which extends the [**glutin::WindowedContext**](`glutin::WindowedContext`) with a high-level, safe API.
+Glium provides a [`Display`] which uses `glutin` for the Window and its associated GL Context.
 
 # Initialization
 

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -278,7 +278,7 @@ pub enum ProgramCreationInput<'a> {
         /// The data.
         data: Binary,
 
-        /// See `SourceCode::outputs_srgb`.
+        /// See [`ProgramCreationInput::SourceCode::outputs_srgb`].
         outputs_srgb: bool,
 
         /// Whether the shader uses point size.
@@ -313,7 +313,7 @@ pub struct SpirvProgram<'a> {
     /// `None`, then you won't be able to use transform feedback.
     pub transform_feedback_varyings: Option<(Vec<String>, TransformFeedbackMode)>,
 
-    /// See `SourceCode::outputs_srgb`.
+    /// See [`ProgramCreationInput::SourceCode::outputs_srgb`].
     pub outputs_srgb: bool,
 
     /// Whether the shader uses point size.

--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -39,7 +39,7 @@ impl std::fmt::Display for SemaphoreCreationError {
 
 impl std::error::Error for SemaphoreCreationError {}
 
-/// Describes a Vulkan image layout that a texture can be in. See https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageLayout.html
+/// Describes a Vulkan image layout that a texture can be in. See <https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageLayout.html>
 #[derive(Debug, Clone, Copy)]
 pub enum TextureLayout {
     /// Corresponds to VK_IMAGE_LAYOUT_UNDEFINED

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -524,7 +524,7 @@ impl<'a, T: Clone + 'a> RawImage2d<'a, T> {
         RawImage2d::from_raw_rgba(data, dimensions)
     }
 
-    ///Transforms a Vec<RawImage1d> into a RawImage2d
+    /// Transforms a `Vec<RawImage1d>` into a `RawImage2d`
     pub fn from_vec_raw1d(arr: &Vec<RawImage1d<'a, T>>) -> RawImage2d<'a, T> {
         let width   = arr[0].width;
         let height  = arr.len() as u32;
@@ -728,7 +728,7 @@ pub struct RawImage3d<'a, T: Clone> {
 }
 
 impl<'a, T: Clone + 'a> RawImage3d<'a, T> {
-    ///Transforms a Vec<RawImage2d> into a RawImage3d
+    /// Transforms a `Vec<RawImage2d>` into a `RawImage3d`
     pub fn from_vec_raw2d(arr: &Vec<RawImage2d<'a, T>>) -> RawImage3d<'a, T> {
         let depth   = arr.len() as u32;
         let width   = arr[0].width;


### PR DESCRIPTION
To partially help with #2098 by making the `outputs_srgb` documentation clickable and more discoverable.

I also took the opportunity to fix the remaining warnings printed by `cargo doc`. The part about `Vec<RawImage1d>` previously actually rendered completely wrong.

The librarys initial doc seems wrong. There is no trait name `WindowedContext` in `glutin`. I did not do too much investigation. I just assume `glutin`s API changed and an upgrade forgot the docs. I just copied what the docs on `Display` says about itself here.