### PR TITLE
Publicly export `Capabilities` and `ExtensionsList` struct

### DIFF
--- a/src/context/extensions.rs
+++ b/src/context/extensions.rs
@@ -9,6 +9,7 @@ macro_rules! extensions {
         #[derive(Debug, Clone, Copy)]
         pub struct ExtensionsList {
             $(
+                #[allow(missing_docs)]
                 pub $field: bool,
             )+
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ extern crate lazy_static;
 
 #[cfg(feature = "glutin")]
 pub use crate::backend::glutin::glutin;
-pub use crate::context::{Profile, UuidError};
+pub use crate::context::{Profile, UuidError, Capabilities};
 pub use crate::draw_parameters::{Blend, BlendingFunction, LinearBlendingFactor, BackfaceCullingMode};
 pub use crate::draw_parameters::{Depth, DepthTest, PolygonMode, DrawParameters, StencilTest, StencilOperation};
 pub use crate::draw_parameters::{Smooth};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ extern crate lazy_static;
 
 #[cfg(feature = "glutin")]
 pub use crate::backend::glutin::glutin;
-pub use crate::context::{Profile, UuidError, Capabilities};
+pub use crate::context::{Capabilities, ExtensionsList, Profile, UuidError};
 pub use crate::draw_parameters::{Blend, BlendingFunction, LinearBlendingFactor, BackfaceCullingMode};
 pub use crate::draw_parameters::{Depth, DepthTest, PolygonMode, DrawParameters, StencilTest, StencilOperation};
 pub use crate::draw_parameters::{Smooth};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ pub use crate::backend::glutin::glutin;
 pub use crate::context::{Capabilities, ExtensionsList, Profile, UuidError};
 pub use crate::draw_parameters::{Blend, BlendingFunction, LinearBlendingFactor, BackfaceCullingMode};
 pub use crate::draw_parameters::{Depth, DepthTest, PolygonMode, DrawParameters, StencilTest, StencilOperation};
-pub use crate::draw_parameters::{Smooth};
+pub use crate::draw_parameters::Smooth;
 pub use crate::index::IndexBuffer;
 pub use crate::vertex::{VertexBuffer, Vertex, VertexFormat};
 pub use crate::program::{Program, ProgramCreationError};


### PR DESCRIPTION
It was already exposed via the `CapabilitiesSource::get_capabalities` method anyway, but the struct itself was not public. So a library user could not refer to the type, neither could they click their way through to the struct documentation.

See https://docs.rs/glium/latest/glium/trait.CapabilitiesSource.html#tymethod.get_capabilities