### PR TITLE
Fix `VertexFormat` and framebuffer docs

### DIFF
--- a/src/framebuffer/mod.rs
+++ b/src/framebuffer/mod.rs
@@ -134,7 +134,7 @@ impl<'a> SimpleFrameBuffer<'a> {
                                     Some(depth.to_depth_attachment()), None, None)
     }
 
-    /// Creates a `SimpleFrameBuffer` with a single color attachment and no depth
+    /// Creates a `SimpleFrameBuffer` with a depth buffer and no color attachment
     /// nor stencil buffer.
     #[inline]
     pub fn depth_only<F: ?Sized, D>(facade: &F, depth: D)
@@ -160,8 +160,8 @@ impl<'a> SimpleFrameBuffer<'a> {
                                     Some(stencil.to_stencil_attachment()), None)
     }
 
-    /// Creates a `SimpleFrameBuffer` with a single color attachment and no depth
-    /// nor stencil buffer.
+    /// Creates a `SimpleFrameBuffer` with a depth buffer and a stencil buffer,
+    /// but no color attachment.
     #[inline]
     pub fn depth_and_stencil_only<F: ?Sized, D, S>(facade: &F, depth: D, stencil: S)
                                            -> Result<SimpleFrameBuffer<'a>, ValidationError>
@@ -184,8 +184,8 @@ impl<'a> SimpleFrameBuffer<'a> {
                                     Some(stencil.to_stencil_attachment()), None)
     }
 
-    /// Creates a `SimpleFrameBuffer` with a single color attachment and a stencil
-    /// buffer, but no depth buffer.
+    /// Creates a `SimpleFrameBuffer` with a stencil buffer and no color attachment
+    /// nor depth buffer.
     #[inline]
     pub fn stencil_only<F: ?Sized, S>(facade: &F, stencil: S)
                               -> Result<SimpleFrameBuffer<'a>, ValidationError>
@@ -206,7 +206,7 @@ impl<'a> SimpleFrameBuffer<'a> {
                                     Some(depthstencil.to_depth_stencil_attachment()))
     }
 
-    /// Creates a `SimpleFrameBuffer` with a single color attachment and a depth-stencil buffer.
+    /// Creates a `SimpleFrameBuffer` with a depth-stencil buffer and no color attachment.
     #[inline]
     pub fn depth_stencil_only<F: ?Sized, D>(facade: &F, depthstencil: D)
                                     -> Result<SimpleFrameBuffer<'a>, ValidationError>
@@ -354,7 +354,7 @@ impl<'a> FboAttachments for SimpleFrameBuffer<'a> {
     }
 }
 
-/// This struct is useless for the moment.
+/// A framebuffer which has multiple color attachments.
 pub struct MultiOutputFrameBuffer<'a> {
     context: Rc<Context>,
     example_attachments: fbo::ValidatedAttachments<'a>,

--- a/src/vertex/buffer.rs
+++ b/src/vertex/buffer.rs
@@ -238,16 +238,16 @@ impl<T> VertexBuffer<T> where T: Copy {
     /// # fn example<T>(display: glium::Display<T>) where T: SurfaceTypeTrait + ResizeableSurface {
     /// use std::borrow::Cow;
     ///
-    /// let bindings = Cow::Owned(vec![(
-    ///         Cow::Borrowed("position"), 0,
+    /// const BINDINGS: glium::vertex::VertexFormat = &[(
+    ///         Cow::Borrowed("position"), 0, -1,
     ///         glium::vertex::AttributeType::F32F32,
     ///         false,
     ///     ), (
-    ///         Cow::Borrowed("color"), 2 * ::std::mem::size_of::<f32>(),
+    ///         Cow::Borrowed("color"), 2 * ::std::mem::size_of::<f32>(), -1,
     ///         glium::vertex::AttributeType::F32,
     ///         false,
     ///     ),
-    /// ]);
+    /// ];
     ///
     /// let data = vec![
     ///     1.0, -0.3, 409.0,
@@ -255,7 +255,7 @@ impl<T> VertexBuffer<T> where T: Copy {
     /// ];
     ///
     /// let vertex_buffer = unsafe {
-    ///     glium::VertexBuffer::new_raw(&display, &data, bindings, 3 * ::std::mem::size_of::<f32>())
+    ///     glium::VertexBuffer::new_raw(&display, &data, BINDINGS, 3 * ::std::mem::size_of::<f32>())
     /// };
     /// # }
     /// ```

--- a/src/vertex/format.rs
+++ b/src/vertex/format.rs
@@ -407,7 +407,8 @@ impl AttributeType {
 ///
 /// The first element is the name of the binding, the second element
 /// is the offset from the start of each vertex to this element, the
-/// third element is the type and the fourth element indicates whether
+/// third element is the layout location specified in the shader, the
+/// fourth element is the type and the fifth element indicates whether
 /// or not the element should use fixed-point normalization when
 /// binding in a VAO.
 pub type VertexFormat = &'static [(Cow<'static, str>, usize, i32, AttributeType, bool)];


### PR DESCRIPTION
Some useful patches were merged in #2013 and #2056, but the docs got out-of-sync. With this all doc tests are passing.

Also this should close #1719. While comparing the framebuffer docs, I noticed copy-paste errors in the [`SimpleFrameBuffer`](https://docs.rs/glium/0.34.0/glium/framebuffer/struct.SimpleFrameBuffer.html) constructors.