### PR TITLE
Remove unneeded dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,9 +59,7 @@ default-features = false
 
 [dependencies]
 memoffset = "0.9.0"
-takeable-option = "0.5"
 backtrace = "0.3.2"
-lazy_static = "1.0"
 smallvec = "1.0"
 fnv = "1.0.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ libc = "0.2.62"
 winit = "0.29"
 raw-window-handle = "0.5"
 glutin-winit = "0.4"
+takeable-option = "0.5"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/backend/glutin/mod.rs
+++ b/src/backend/glutin/mod.rs
@@ -10,18 +10,18 @@ Only available if the 'glutin' feature is enabled.
 */
 pub use glutin;
 use glutin::surface::Surface;
-use takeable_option::Takeable;
 
-use crate::SwapBuffersError;
 use crate::backend;
 use crate::backend::Backend;
 use crate::backend::Context;
 use crate::context;
 use crate::debug;
-use crate::glutin::prelude::*;
 use crate::glutin::context::PossiblyCurrentContext;
 use crate::glutin::display::GetGlDisplay;
-use crate::glutin::surface::{SurfaceTypeTrait, ResizeableSurface};
+use crate::glutin::prelude::*;
+use crate::glutin::surface::{ResizeableSurface, SurfaceTypeTrait};
+use crate::SwapBuffersError;
+use crate::{Frame, IncompatibleOpenGl};
 use std::cell::RefCell;
 use std::error::Error;
 use std::ffi::CString;
@@ -30,7 +30,6 @@ use std::num::NonZeroU32;
 use std::ops::Deref;
 use std::os::raw::c_void;
 use std::rc::Rc;
-use crate::{Frame, IncompatibleOpenGl};
 
 /// Wraps a glutin context together with the corresponding Surface.
 /// This is necessary so that we can swap buffers and determine the framebuffer size within glium.
@@ -47,7 +46,10 @@ impl<T: SurfaceTypeTrait + ResizeableSurface> ContextSurfacePair<T> {
     #[inline]
     /// Return the stored framebuffer dimensions
     pub fn get_framebuffer_dimensions(&self) -> (u32, u32) {
-        (self.surface.width().unwrap(), self.surface.height().unwrap())
+        (
+            self.surface.width().unwrap(),
+            self.surface.height().unwrap(),
+        )
     }
 
     #[inline]
@@ -58,7 +60,7 @@ impl<T: SurfaceTypeTrait + ResizeableSurface> ContextSurfacePair<T> {
 
     #[inline]
     /// Resize the associated surface
-    pub fn resize(&self, new_size:(u32, u32)) {
+    pub fn resize(&self, new_size: (u32, u32)) {
         // Make sure that no dimension is zero, which happens when minimizing on Windows for example.
         let width = NonZeroU32::new(new_size.0).unwrap_or(NonZeroU32::new(1).unwrap());
         let height = NonZeroU32::new(new_size.1).unwrap_or(NonZeroU32::new(1).unwrap());
@@ -84,12 +86,14 @@ pub struct Display<T: SurfaceTypeTrait + ResizeableSurface + 'static> {
     // contains everything related to the current glium context and its state
     context: Rc<context::Context>,
     // The glutin Surface alongside its associated glutin Context.
-    gl_context: Rc<RefCell<Takeable<ContextSurfacePair<T>>>>,
+    gl_context: Rc<RefCell<Option<ContextSurfacePair<T>>>>,
 }
 
 /// An implementation of the `Backend` trait for glutin.
 #[derive(Clone)]
-pub struct GlutinBackend<T: SurfaceTypeTrait + ResizeableSurface>(Rc<RefCell<Takeable<ContextSurfacePair<T>>>>);
+pub struct GlutinBackend<T: SurfaceTypeTrait + ResizeableSurface>(
+    Rc<RefCell<Option<ContextSurfacePair<T>>>>,
+);
 
 /// Error that can happen while creating a glium display.
 #[derive(Debug)]
@@ -165,7 +169,7 @@ impl<T: SurfaceTypeTrait + ResizeableSurface> Display<T> {
         checked: bool,
     ) -> Result<Self, IncompatibleOpenGl> {
         let context_surface_pair = ContextSurfacePair::new(context, surface);
-        let gl_window = Rc::new(RefCell::new(Takeable::new(context_surface_pair)));
+        let gl_window = Rc::new(RefCell::new(Some(context_surface_pair)));
         let glutin_backend = GlutinBackend(gl_window.clone());
         let context = unsafe { context::Context::new(glutin_backend, checked, debug) }?;
         Ok(Display {
@@ -176,8 +180,8 @@ impl<T: SurfaceTypeTrait + ResizeableSurface> Display<T> {
 
     /// Resize the underlying surface.
     #[inline]
-    pub fn resize(&self, new_size:(u32, u32)) {
-        self.gl_context.borrow().resize(new_size)
+    pub fn resize(&self, new_size: (u32, u32)) {
+        self.gl_context.borrow().as_ref().unwrap().resize(new_size)
     }
 
     /// Start drawing on the backbuffer.
@@ -242,7 +246,7 @@ impl<T: SurfaceTypeTrait + ResizeableSurface> backend::Facade for Display<T> {
 }
 
 impl<T: SurfaceTypeTrait + ResizeableSurface> Deref for GlutinBackend<T> {
-    type Target = Rc<RefCell<Takeable<ContextSurfacePair<T>>>>;
+    type Target = Rc<RefCell<Option<ContextSurfacePair<T>>>>;
     #[inline]
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -252,7 +256,7 @@ impl<T: SurfaceTypeTrait + ResizeableSurface> Deref for GlutinBackend<T> {
 unsafe impl<T: SurfaceTypeTrait + ResizeableSurface> Backend for GlutinBackend<T> {
     #[inline]
     fn swap_buffers(&self) -> Result<(), SwapBuffersError> {
-        match self.borrow().swap_buffers() {
+        match self.borrow().as_ref().unwrap().swap_buffers() {
             Ok(()) => Ok(()),
             _ => Err(SwapBuffersError::ContextLost),
         }
@@ -261,35 +265,47 @@ unsafe impl<T: SurfaceTypeTrait + ResizeableSurface> Backend for GlutinBackend<T
     #[inline]
     unsafe fn get_proc_address(&self, symbol: &str) -> *const c_void {
         let symbol = CString::new(symbol).unwrap();
-        self.borrow().display().get_proc_address(&symbol) as *const _
+        self.borrow()
+            .as_ref()
+            .unwrap()
+            .display()
+            .get_proc_address(&symbol) as *const _
     }
 
     #[inline]
     fn get_framebuffer_dimensions(&self) -> (u32, u32) {
-        self.0.borrow().get_framebuffer_dimensions()
+        self.0
+            .borrow()
+            .as_ref()
+            .unwrap()
+            .get_framebuffer_dimensions()
     }
 
     #[inline]
-    fn resize(&self, new_size:(u32, u32)) {
-        self.borrow().resize(new_size)
+    fn resize(&self, new_size: (u32, u32)) {
+        self.borrow().as_ref().unwrap().resize(new_size)
     }
 
     #[inline]
     fn is_current(&self) -> bool {
-        self.borrow().is_current()
+        self.borrow().as_ref().unwrap().is_current()
     }
 
     #[inline]
     unsafe fn make_current(&self) {
         let pair = self.borrow();
-        pair.context.make_current(&pair.surface).unwrap();
+        pair.as_ref()
+            .unwrap()
+            .context
+            .make_current(&pair.as_ref().unwrap().surface)
+            .unwrap();
     }
 }
 
 #[cfg(feature = "simple_window_builder")]
 /// Builder to simplify glium/glutin context creation.
 pub struct SimpleWindowBuilder {
-    builder: winit::window::WindowBuilder
+    builder: winit::window::WindowBuilder,
 }
 
 #[cfg(feature = "simple_window_builder")]
@@ -299,14 +315,16 @@ impl SimpleWindowBuilder {
         Self {
             builder: winit::window::WindowBuilder::new()
                 .with_title("Simple Glium Window")
-                .with_inner_size(winit::dpi::PhysicalSize::new(800, 480))
+                .with_inner_size(winit::dpi::PhysicalSize::new(800, 480)),
         }
     }
 
     /// Requests the window to be of a certain size.
     /// If this is not set, the builder defaults to 800x480.
     pub fn with_inner_size(mut self, width: u32, height: u32) -> Self {
-        self.builder = self.builder.with_inner_size(winit::dpi::PhysicalSize::new(width, height));
+        self.builder = self
+            .builder
+            .with_inner_size(winit::dpi::PhysicalSize::new(width, height));
         self
     }
 
@@ -330,12 +348,19 @@ impl SimpleWindowBuilder {
 
     /// Create a new [`Window`](winit::window::Window) and [`Display`]
     /// with the specified parameters.
-    pub fn build<T>(self, event_loop: &winit::event_loop::EventLoop<T>) -> (winit::window::Window, Display<glutin::surface::WindowSurface>) {
+    pub fn build<T>(
+        self,
+        event_loop: &winit::event_loop::EventLoop<T>,
+    ) -> (
+        winit::window::Window,
+        Display<glutin::surface::WindowSurface>,
+    ) {
         use glutin::prelude::*;
         use raw_window_handle::HasRawWindowHandle;
 
         // First we start by opening a new Window
-        let display_builder = glutin_winit::DisplayBuilder::new().with_window_builder(Some(self.builder));
+        let display_builder =
+            glutin_winit::DisplayBuilder::new().with_window_builder(Some(self.builder));
         let config_template_builder = glutin::config::ConfigTemplateBuilder::new();
         let (window, gl_config) = display_builder
             .build(&event_loop, config_template_builder, |mut configs| {
@@ -347,18 +372,32 @@ impl SimpleWindowBuilder {
 
         // Now we get the window size to use as the initial size of the Surface
         let (width, height): (u32, u32) = window.inner_size().into();
-        let attrs = glutin::surface::SurfaceAttributesBuilder::<glutin::surface::WindowSurface>::new().build(
-            window.raw_window_handle(),
-            NonZeroU32::new(width).unwrap(),
-            NonZeroU32::new(height).unwrap(),
-        );
+        let attrs =
+            glutin::surface::SurfaceAttributesBuilder::<glutin::surface::WindowSurface>::new()
+                .build(
+                    window.raw_window_handle(),
+                    NonZeroU32::new(width).unwrap(),
+                    NonZeroU32::new(height).unwrap(),
+                );
 
         // Finally we can create a Surface, use it to make a PossiblyCurrentContext and create the glium Display
-        let surface = unsafe { gl_config.display().create_window_surface(&gl_config, &attrs).unwrap() };
-        let context_attributes = glutin::context::ContextAttributesBuilder::new().build(Some(window.raw_window_handle()));
+        let surface = unsafe {
+            gl_config
+                .display()
+                .create_window_surface(&gl_config, &attrs)
+                .unwrap()
+        };
+        let context_attributes = glutin::context::ContextAttributesBuilder::new()
+            .build(Some(window.raw_window_handle()));
         let current_context = Some(unsafe {
-            gl_config.display().create_context(&gl_config, &context_attributes).expect("failed to create context")
-        }).unwrap().make_current(&surface).unwrap();
+            gl_config
+                .display()
+                .create_context(&gl_config, &context_attributes)
+                .expect("failed to create context")
+        })
+        .unwrap()
+        .make_current(&surface)
+        .unwrap();
         let display = Display::from_context_surface(current_context, surface).unwrap();
 
         (window, display)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,9 +106,6 @@ result to the user.
     clippy::wrong_self_convention,
 )]
 
-#[macro_use]
-extern crate lazy_static;
-
 #[cfg(feature = "glutin")]
 pub use crate::backend::glutin::glutin;
 pub use crate::context::{Capabilities, ExtensionsList, Profile, UuidError};

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -57,10 +57,7 @@ pub fn is_subroutine_supported<C: ?Sized>(ctxt: &C) -> bool where C: Capabilitie
 
 // Some shader compilers have race-condition issues, so we lock this mutex
 // in the GL thread every time we compile a shader or link a program.
-// TODO: replace by a StaticMutex
-lazy_static! {
-    static ref COMPILER_GLOBAL_LOCK: Mutex<()> = Mutex::new(());
-}
+static COMPILER_GLOBAL_LOCK: Mutex<()> = Mutex::new(());
 
 /// Used in ProgramCreationError::CompilationError to explain which shader stage failed compilation
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
- Remove `lazy_static`. It is only used to create a static Mutex, which can be done now on stable Rust.
- Remove `takeable_option`. We can just use a regular `Option`.
