### PR TITLE
Fix examples and tests for Windows

### DIFF
--- a/examples/support/mod.rs
+++ b/examples/support/mod.rs
@@ -113,6 +113,9 @@ impl<T: ApplicationContext + 'static> ApplicationHandler<()> for App<T> {
     // For convenience's sake, the resumed handler is also called on other platforms on program startup.
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
         self.state = Some(State::new(event_loop, self.visible));
+        if !self.visible && self.close_promptly {
+            event_loop.exit();
+        }
     }
     fn suspended(&mut self, _event_loop: &ActiveEventLoop) {
         self.state = None;

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -56,17 +56,19 @@ impl From<&'static Window> for HandleOrWindow {
         match window_handle.as_raw() {
             RawWindowHandle::Xlib(_) |
             RawWindowHandle::Xcb(_) |
-            // n.b. `Window` is `!Send` and `!Sync` for wasm32
-            RawWindowHandle::Web(_) |
-            RawWindowHandle::Drm(_)
+            RawWindowHandle::Drm(_) |
+            RawWindowHandle::Win32(_) |
+            RawWindowHandle::Web(_)
                 => HandleOrWindow::SendHandle(window_handle),
             RawWindowHandle::UiKit(_) |
             RawWindowHandle::AppKit(_) |
             RawWindowHandle::Orbital(_) |
+            RawWindowHandle::OhosNdk(_) |
             RawWindowHandle::Wayland(_) |
             RawWindowHandle::Gbm(_) |
-            RawWindowHandle::Win32(_) |
             RawWindowHandle::WinRt(_) |
+            RawWindowHandle::WebCanvas(_) |
+            RawWindowHandle::WebOffscreenCanvas(_) |
             RawWindowHandle::AndroidNdk(_) |
             RawWindowHandle::Haiku(_)
                 => HandleOrWindow::RefWindow(window),


### PR DESCRIPTION
Examples
-
The underlying API used by [`request_redraw()`](https://docs.rs/winit/0.30.5/winit/window/struct.Window.html#method.request_redraw) does not produce any `WM_PAINT` messages for invisible windows, so these windows do not receive the `RedrawRequested` event. This leaves the two examples `info` and `gpgpu` running indefinitely with no clean way to exit. This change requires any future, invisible, run once examples to also complete by the time `State::new()` returns like the current two do.

Tests
-
With `raw-window-handle-0.6` Windows handles now implement `Send + Sync`. The tests workaround is erroring when passing a `RefWindow`:
```
thread 'basic' panicked at tests\support\mod.rs:83:73:
called `Result::unwrap()` on an `Err` value: Unavailable
``` 

OHOS was added in v0.6.2 and can cause build errors if an older version is cached.
