### PR TITLE
Fix UB due to FDs being closed after importing

### DIFF
--- a/src/memory_object.rs
+++ b/src/memory_object.rs
@@ -86,6 +86,8 @@ impl MemoryObject {
                 fd.as_raw_fd(),
             );
 
+            std::mem::forget(fd);
+
             Ok(mem_obj)
         }
     }

--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -108,6 +108,8 @@ impl Semaphore {
             if ctxt.gl.IsSemaphoreEXT(sem.id) == gl::FALSE {
                 Err(SemaphoreCreationError::NullResult)
             } else {
+                std::mem::forget(fd);
+
                 Ok(sem)
             }
         } else {


### PR DESCRIPTION
The spec says (emphasis added):

> The command
> 
>     ImportSemaphoreFdEXT(uint semaphore,
>                          enum handleType,
>                          int fd);
> 
> imports a semaphore from the file descriptor \<fd\>.  What type of
> object \<fd\> refers to is determined by \<handleType\>.  A successful
> import operation transfers ownership of \<fd\> to the GL
> implementation, and **performing any operation on \<fd\> in the
> application after an import results in undefined behavior**.

> The command
> 
>     void ImportMemoryFdEXT(uint memory,
>                            uint64 size,
>                            enum handleType,
>                            int fd);
> 
> imports a memory object of length \<size\> from the file descriptor
> \<fd\>.  What type of object \<fd\> refers to is determined by
> \<handleType\>.  A successful import operation transfers ownership
> of \<fd\> to the GL implementation, and **performing any operation on
> \<fd\> in the application after an import results in undefined
> behavior**.

We noticed this thanks to some check that was added that makes it so that the program aborts due to this when interoperating with Vulkan:

```
fatal runtime error: IO Safety violation: owned file descriptor already closed
```