### PR TITLE
Fix `static_mut_refs` warnings

### DIFF
--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -173,20 +173,17 @@ pub fn build_display() -> Display<WindowSurface> {
     unsafe { initialize_event_loop(); }
 
     // Tell event loop to create a window and config for creating a display
-    unsafe {
-        EVENT_LOOP_PROXY
-            .read().unwrap()
-            .as_ref().unwrap()
-            .send_event(()).unwrap();
-    }
+    EVENT_LOOP_PROXY
+        .read().unwrap()
+        .as_ref().unwrap()
+        .send_event(()).unwrap();
 
     // Receive said window and config one thread at a time
-    let (handle_or_window, gl_config) = unsafe {
+    let (handle_or_window, gl_config) =
         WINDOW_RECEIVER
             .lock().unwrap()
             .as_ref().unwrap()
-            .recv().unwrap()
-    };
+            .recv().unwrap();
 
     // Then the configuration which decides which OpenGL version we'll end up using, here we just use the default which is currently 3.3 core
     // When this fails we'll try and create an ES context, this is mainly used on mobile devices or various ARM SBC's

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -36,12 +36,12 @@ use glium::winit::platform::x11::EventLoopBuilderExtX11;
 use glium::winit::platform::windows::EventLoopBuilderExtWindows;
 
 // Thread communication
-static mut EVENT_LOOP_PROXY: RwLock<Option<EventLoopProxy<()>>> = RwLock::new(None);
-static mut WINDOW_RECEIVER: Mutex<Option<Receiver<(HandleOrWindow, Config)>>> = Mutex::new(None);
+static EVENT_LOOP_PROXY: RwLock<Option<EventLoopProxy<()>>> = RwLock::new(None);
+static WINDOW_RECEIVER: Mutex<Option<Receiver<(HandleOrWindow, Config)>>> = Mutex::new(None);
 
 // Initialization
-static mut INIT_EVENT_LOOP: Once = Once::new();
-static mut SEND_PROXY: Once = Once::new();
+static INIT_EVENT_LOOP: Once = Once::new();
+static SEND_PROXY: Once = Once::new();
 
 #[derive(Debug)]
 enum HandleOrWindow {
@@ -135,7 +135,9 @@ unsafe fn initialize_event_loop() {
                             // SAFETY
                             // The event loop is a single thread
                             // The `HashMap` only grows so references to its values stay valid
+                            #[allow(static_mut_refs)]
                             WINDOWS.as_mut().unwrap().insert(key, window);
+                            #[allow(static_mut_refs)]
                             let window = &WINDOWS.as_ref().unwrap()[&key];
 
                             sender.send((window.into(), gl_config)).unwrap();


### PR DESCRIPTION
Fix for nightly check warnings discovered in #2126.

Turns out, most of `static mut`'s are not needed in the first place, and the one that is necessary is a dirty hack regardless.