### PR TITLE
Release 0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 0.36.0 (2024-10-11)
+
+- Fix UB around FDs being closed
+- Fix static mut ref warnings in tests
+- Make `SimpleWindowBuilder` accept `ActiveEventLoop`
+
 ## Version 0.35.0 (2024-08-04)
 
 - Updated glutin to version 0.32.0. See the glutin release notes [here](https://github.com/rust-windowing/glutin/blob/master/CHANGELOG.md#version-0320).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glium"
-version = "0.35.0"
+version = "0.36.0"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = """
 Elegant and safe OpenGL wrapper.


### PR DESCRIPTION
New release. There have been semver breaking changes in #2126, so we need to change the minor version.
 
Closes #2129.