### PR TITLE
Support all matrix variants in uniforms

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -464,9 +464,24 @@ pub enum RawUniformValue {
 
     // Double precision primitives
     Double(gl::types::GLdouble),
+    /// 2x2 column-major double-precision matrix.
     DoubleMat2([[gl::types::GLdouble; 2]; 2]),
+    /// 3x3 column-major double-precision matrix.
     DoubleMat3([[gl::types::GLdouble; 3]; 3]),
+    /// 4x4 column-major double-precision matrix.
     DoubleMat4([[gl::types::GLdouble; 4]; 4]),
+    /// 2x3 column-major double-precision matrix.
+    DoubleMat2x3([[gl::types::GLdouble; 3]; 2]),
+    /// 2x4 column-major double-precision matrix.
+    DoubleMat2x4([[gl::types::GLdouble; 4]; 2]),
+    /// 3x2 column-major double-precision matrix.
+    DoubleMat3x2([[gl::types::GLdouble; 2]; 3]),
+    /// 3x4 column-major double-precision matrix.
+    DoubleMat3x4([[gl::types::GLdouble; 4]; 3]),
+    /// 4x2 column-major double-precision matrix.
+    DoubleMat4x2([[gl::types::GLdouble; 2]; 4]),
+    /// 4x3 column-major double-precision matrix.
+    DoubleMat4x3([[gl::types::GLdouble; 3]; 4]),
     DoubleVec2([gl::types::GLdouble; 2]),
     DoubleVec3([gl::types::GLdouble; 3]),
     DoubleVec4([gl::types::GLdouble; 4]),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -440,6 +440,16 @@ pub enum RawUniformValue {
     Mat3([[gl::types::GLfloat; 3]; 3]),
     /// 4x4 column-major matrix.
     Mat4([[gl::types::GLfloat; 4]; 4]),
+    /// 2x3 column-major matrix.
+    Mat2x3([[gl::types::GLfloat; 3]; 2]),
+    /// 2x4 column-major matrix.
+    Mat2x4([[gl::types::GLfloat; 4]; 2]),
+    /// 3x2 column-major matrix.
+    Mat3x2([[gl::types::GLfloat; 2]; 3]),
+    /// 3x4 column-major matrix.
+    Mat3x4([[gl::types::GLfloat; 4]; 3]),
+    /// 4x2 column-major matrix.
+    Mat4x2([[gl::types::GLfloat; 2]; 4]),
     /// 4x3 column-major matrix.
     Mat4x3([[gl::types::GLfloat; 3]; 4]),
     Vec2([gl::types::GLfloat; 2]),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -440,6 +440,8 @@ pub enum RawUniformValue {
     Mat3([[gl::types::GLfloat; 3]; 3]),
     /// 4x4 column-major matrix.
     Mat4([[gl::types::GLfloat; 4]; 4]),
+    /// 4x3 column-major matrix.
+    Mat4x3([[gl::types::GLfloat; 3]; 4]),
     Vec2([gl::types::GLfloat; 2]),
     Vec3([gl::types::GLfloat; 3]),
     Vec4([gl::types::GLfloat; 4]),

--- a/src/program/uniforms_storage.rs
+++ b/src/program/uniforms_storage.rs
@@ -109,6 +109,12 @@ impl UniformsStorage {
             (&RawUniformValue::DoubleMat2(a), &mut Some(RawUniformValue::DoubleMat2(b))) if a == b => (),
             (&RawUniformValue::DoubleMat3(a), &mut Some(RawUniformValue::DoubleMat3(b))) if a == b => (),
             (&RawUniformValue::DoubleMat4(a), &mut Some(RawUniformValue::DoubleMat4(b))) if a == b => (),
+            (&RawUniformValue::DoubleMat2x3(a), &mut Some(RawUniformValue::DoubleMat2x3(b))) if a == b => (),
+            (&RawUniformValue::DoubleMat2x4(a), &mut Some(RawUniformValue::DoubleMat2x4(b))) if a == b => (),
+            (&RawUniformValue::DoubleMat3x2(a), &mut Some(RawUniformValue::DoubleMat3x2(b))) if a == b => (),
+            (&RawUniformValue::DoubleMat3x4(a), &mut Some(RawUniformValue::DoubleMat3x4(b))) if a == b => (),
+            (&RawUniformValue::DoubleMat4x2(a), &mut Some(RawUniformValue::DoubleMat4x2(b))) if a == b => (),
+            (&RawUniformValue::DoubleMat4x3(a), &mut Some(RawUniformValue::DoubleMat4x3(b))) if a == b => (),
             (&RawUniformValue::DoubleVec2(a), &mut Some(RawUniformValue::DoubleVec2(b))) if a == b => (),
             (&RawUniformValue::DoubleVec3(a), &mut Some(RawUniformValue::DoubleVec3(b))) if a == b => (),
             (&RawUniformValue::DoubleVec4(a), &mut Some(RawUniformValue::DoubleVec4(b))) if a == b => (),
@@ -310,6 +316,42 @@ impl UniformsStorage {
             (&RawUniformValue::DoubleMat4(v), target) => {
                 *target = Some(RawUniformValue::DoubleMat4(v));
                 uniform_f64!(ctxt, UniformMatrix4dv,
+                         location, 1, gl::FALSE, v.as_ptr() as *const gl::types::GLdouble);
+            },
+
+            (&RawUniformValue::DoubleMat2x3(v), target) => {
+                *target = Some(RawUniformValue::DoubleMat2x3(v));
+                uniform_f64!(ctxt, UniformMatrix2x3dv,
+                         location, 1, gl::FALSE, v.as_ptr() as *const gl::types::GLdouble);
+            },
+
+            (&RawUniformValue::DoubleMat2x4(v), target) => {
+                *target = Some(RawUniformValue::DoubleMat2x4(v));
+                uniform_f64!(ctxt, UniformMatrix2x4dv,
+                         location, 1, gl::FALSE, v.as_ptr() as *const gl::types::GLdouble);
+            },
+
+            (&RawUniformValue::DoubleMat3x2(v), target) => {
+                *target = Some(RawUniformValue::DoubleMat3x2(v));
+                uniform_f64!(ctxt, UniformMatrix3x2dv,
+                         location, 1, gl::FALSE, v.as_ptr() as *const gl::types::GLdouble);
+            },
+
+            (&RawUniformValue::DoubleMat3x4(v), target) => {
+                *target = Some(RawUniformValue::DoubleMat3x4(v));
+                uniform_f64!(ctxt, UniformMatrix3x4dv,
+                         location, 1, gl::FALSE, v.as_ptr() as *const gl::types::GLdouble);
+            },
+
+            (&RawUniformValue::DoubleMat4x2(v), target) => {
+                *target = Some(RawUniformValue::DoubleMat4x2(v));
+                uniform_f64!(ctxt, UniformMatrix4x2dv,
+                         location, 1, gl::FALSE, v.as_ptr() as *const gl::types::GLdouble);
+            },
+
+            (&RawUniformValue::DoubleMat4x3(v), target) => {
+                *target = Some(RawUniformValue::DoubleMat4x3(v));
+                uniform_f64!(ctxt, UniformMatrix4x3dv,
                          location, 1, gl::FALSE, v.as_ptr() as *const gl::types::GLdouble);
             },
 

--- a/src/program/uniforms_storage.rs
+++ b/src/program/uniforms_storage.rs
@@ -90,6 +90,7 @@ impl UniformsStorage {
             (&RawUniformValue::Mat2(a), &mut Some(RawUniformValue::Mat2(b))) if a == b => (),
             (&RawUniformValue::Mat3(a), &mut Some(RawUniformValue::Mat3(b))) if a == b => (),
             (&RawUniformValue::Mat4(a), &mut Some(RawUniformValue::Mat4(b))) if a == b => (),
+            (&RawUniformValue::Mat4x3(a), &mut Some(RawUniformValue::Mat4x3(b))) if a == b => (),
             (&RawUniformValue::Vec2(a), &mut Some(RawUniformValue::Vec2(b))) if a == b => (),
             (&RawUniformValue::Vec3(a), &mut Some(RawUniformValue::Vec3(b))) if a == b => (),
             (&RawUniformValue::Vec4(a), &mut Some(RawUniformValue::Vec4(b))) if a == b => (),
@@ -157,6 +158,14 @@ impl UniformsStorage {
                 *target = Some(RawUniformValue::Mat4(v));
                 uniform!(ctxt, UniformMatrix4fv, UniformMatrix4fvARB,
                          location, 1, gl::FALSE, v.as_ptr() as *const f32);
+            },
+
+            (&RawUniformValue::Mat4x3(v), target) => {
+                *target = Some(RawUniformValue::Mat4x3(v));
+                unsafe {
+                    // TODO: If OpenGL <3.0 support is required, add panic branch
+                    ctxt.gl.UniformMatrix4x3fv(location, 1, gl::FALSE, v.as_ptr() as *const f32);
+                }
             },
 
             (&RawUniformValue::Vec2(v), target) => {

--- a/src/program/uniforms_storage.rs
+++ b/src/program/uniforms_storage.rs
@@ -90,6 +90,11 @@ impl UniformsStorage {
             (&RawUniformValue::Mat2(a), &mut Some(RawUniformValue::Mat2(b))) if a == b => (),
             (&RawUniformValue::Mat3(a), &mut Some(RawUniformValue::Mat3(b))) if a == b => (),
             (&RawUniformValue::Mat4(a), &mut Some(RawUniformValue::Mat4(b))) if a == b => (),
+            (&RawUniformValue::Mat2x3(a), &mut Some(RawUniformValue::Mat2x3(b))) if a == b => (),
+            (&RawUniformValue::Mat2x4(a), &mut Some(RawUniformValue::Mat2x4(b))) if a == b => (),
+            (&RawUniformValue::Mat3x2(a), &mut Some(RawUniformValue::Mat3x2(b))) if a == b => (),
+            (&RawUniformValue::Mat3x4(a), &mut Some(RawUniformValue::Mat3x4(b))) if a == b => (),
+            (&RawUniformValue::Mat4x2(a), &mut Some(RawUniformValue::Mat4x2(b))) if a == b => (),
             (&RawUniformValue::Mat4x3(a), &mut Some(RawUniformValue::Mat4x3(b))) if a == b => (),
             (&RawUniformValue::Vec2(a), &mut Some(RawUniformValue::Vec2(b))) if a == b => (),
             (&RawUniformValue::Vec3(a), &mut Some(RawUniformValue::Vec3(b))) if a == b => (),
@@ -158,6 +163,46 @@ impl UniformsStorage {
                 *target = Some(RawUniformValue::Mat4(v));
                 uniform!(ctxt, UniformMatrix4fv, UniformMatrix4fvARB,
                          location, 1, gl::FALSE, v.as_ptr() as *const f32);
+            },
+
+            (&RawUniformValue::Mat2x3(v), target) => {
+                *target = Some(RawUniformValue::Mat2x3(v));
+                unsafe {
+                    // TODO: If OpenGL <3.0 support is required, add panic branch
+                    ctxt.gl.UniformMatrix2x3fv(location, 1, gl::FALSE, v.as_ptr() as *const f32);
+                }
+            },
+
+            (&RawUniformValue::Mat2x4(v), target) => {
+                *target = Some(RawUniformValue::Mat2x4(v));
+                unsafe {
+                    // TODO: If OpenGL <3.0 support is required, add panic branch
+                    ctxt.gl.UniformMatrix2x4fv(location, 1, gl::FALSE, v.as_ptr() as *const f32);
+                }
+            },
+
+            (&RawUniformValue::Mat3x2(v), target) => {
+                *target = Some(RawUniformValue::Mat3x2(v));
+                unsafe {
+                    // TODO: If OpenGL <3.0 support is required, add panic branch
+                    ctxt.gl.UniformMatrix3x2fv(location, 1, gl::FALSE, v.as_ptr() as *const f32);
+                }
+            },
+
+            (&RawUniformValue::Mat3x4(v), target) => {
+                *target = Some(RawUniformValue::Mat3x4(v));
+                unsafe {
+                    // TODO: If OpenGL <3.0 support is required, add panic branch
+                    ctxt.gl.UniformMatrix3x4fv(location, 1, gl::FALSE, v.as_ptr() as *const f32);
+                }
+            },
+
+            (&RawUniformValue::Mat4x2(v), target) => {
+                *target = Some(RawUniformValue::Mat4x2(v));
+                unsafe {
+                    // TODO: If OpenGL <3.0 support is required, add panic branch
+                    ctxt.gl.UniformMatrix4x2fv(location, 1, gl::FALSE, v.as_ptr() as *const f32);
+                }
             },
 
             (&RawUniformValue::Mat4x3(v), target) => {

--- a/src/uniforms/bind.rs
+++ b/src/uniforms/bind.rs
@@ -345,6 +345,26 @@ fn bind_uniform<P>(ctxt: &mut context::CommandContext,
             program.set_uniform(ctxt, location, &RawUniformValue::Mat4(val));
             Ok(())
         },
+        UniformValue::Mat2x3(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::Mat2x3(val));
+            Ok(())
+        },
+        UniformValue::Mat2x4(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::Mat2x4(val));
+            Ok(())
+        },
+        UniformValue::Mat3x2(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::Mat3x2(val));
+            Ok(())
+        },
+        UniformValue::Mat3x4(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::Mat3x4(val));
+            Ok(())
+        },
+        UniformValue::Mat4x2(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::Mat4x2(val));
+            Ok(())
+        },
         UniformValue::Mat4x3(val) => {
             program.set_uniform(ctxt, location, &RawUniformValue::Mat4x3(val));
             Ok(())

--- a/src/uniforms/bind.rs
+++ b/src/uniforms/bind.rs
@@ -345,6 +345,10 @@ fn bind_uniform<P>(ctxt: &mut context::CommandContext,
             program.set_uniform(ctxt, location, &RawUniformValue::Mat4(val));
             Ok(())
         },
+        UniformValue::Mat4x3(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::Mat4x3(val));
+            Ok(())
+        },
         UniformValue::Vec2(val) => {
             program.set_uniform(ctxt, location, &RawUniformValue::Vec2(val));
             Ok(())

--- a/src/uniforms/bind.rs
+++ b/src/uniforms/bind.rs
@@ -436,6 +436,30 @@ fn bind_uniform<P>(ctxt: &mut context::CommandContext,
             program.set_uniform(ctxt, location, &RawUniformValue::DoubleMat4(val));
             Ok(())
         },
+        UniformValue::DoubleMat2x3(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::DoubleMat2x3(val));
+            Ok(())
+        },
+        UniformValue::DoubleMat2x4(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::DoubleMat2x4(val));
+            Ok(())
+        },
+        UniformValue::DoubleMat3x2(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::DoubleMat3x2(val));
+            Ok(())
+        },
+        UniformValue::DoubleMat3x4(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::DoubleMat3x4(val));
+            Ok(())
+        },
+        UniformValue::DoubleMat4x2(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::DoubleMat4x2(val));
+            Ok(())
+        },
+        UniformValue::DoubleMat4x3(val) => {
+            program.set_uniform(ctxt, location, &RawUniformValue::DoubleMat4x3(val));
+            Ok(())
+        },
         UniformValue::DoubleVec2(val) => {
             program.set_uniform(ctxt, location, &RawUniformValue::DoubleVec2(val));
             Ok(())

--- a/src/uniforms/value.rs
+++ b/src/uniforms/value.rs
@@ -157,6 +157,8 @@ pub enum UniformValue<'a> {
     Mat3([[f32; 3]; 3]),
     /// 4x4 column-major matrix.
     Mat4([[f32; 4]; 4]),
+    /// 4x3 column-major matrix.
+    Mat4x3([[f32; 3]; 4]),
     Vec2([f32; 2]),
     Vec3([f32; 3]),
     Vec4([f32; 4]),
@@ -287,6 +289,7 @@ impl<'a> UniformValue<'a> {
             (&UniformValue::Mat2(_), UniformType::FloatMat2) => true,
             (&UniformValue::Mat3(_), UniformType::FloatMat3) => true,
             (&UniformValue::Mat4(_), UniformType::FloatMat4) => true,
+            (&UniformValue::Mat4x3(_), UniformType::FloatMat4x3) => true,
             (&UniformValue::Vec2(_), UniformType::FloatVec2) => true,
             (&UniformValue::Vec3(_), UniformType::FloatVec3) => true,
             (&UniformValue::Vec4(_), UniformType::FloatVec4) => true,
@@ -698,6 +701,15 @@ impl AsUniformValue for [[f32; 4]; 4] {
 }
 
 impl_uniform_block_basic!([[f32; 4]; 4], UniformType::FloatMat4);
+
+impl AsUniformValue for [[f32; 3]; 4] {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue<'_> {
+        UniformValue::Mat4x3(*self)
+    }
+}
+
+impl_uniform_block_basic!([[f32; 3]; 4], UniformType::FloatMat4x3);
 
 impl AsUniformValue for (f32, f32) {
     #[inline]

--- a/src/uniforms/value.rs
+++ b/src/uniforms/value.rs
@@ -157,6 +157,16 @@ pub enum UniformValue<'a> {
     Mat3([[f32; 3]; 3]),
     /// 4x4 column-major matrix.
     Mat4([[f32; 4]; 4]),
+    /// 2x3 column-major matrix.
+    Mat2x3([[f32; 3]; 2]),
+    /// 2x4 column-major matrix.
+    Mat2x4([[f32; 4]; 2]),
+    /// 3x2 column-major matrix.
+    Mat3x2([[f32; 2]; 3]),
+    /// 3x4 column-major matrix.
+    Mat3x4([[f32; 4]; 3]),
+    /// 4x2 column-major matrix.
+    Mat4x2([[f32; 2]; 4]),
     /// 4x3 column-major matrix.
     Mat4x3([[f32; 3]; 4]),
     Vec2([f32; 2]),
@@ -289,6 +299,11 @@ impl<'a> UniformValue<'a> {
             (&UniformValue::Mat2(_), UniformType::FloatMat2) => true,
             (&UniformValue::Mat3(_), UniformType::FloatMat3) => true,
             (&UniformValue::Mat4(_), UniformType::FloatMat4) => true,
+            (&UniformValue::Mat2x3(_), UniformType::FloatMat2x3) => true,
+            (&UniformValue::Mat2x4(_), UniformType::FloatMat2x4) => true,
+            (&UniformValue::Mat3x2(_), UniformType::FloatMat3x2) => true,
+            (&UniformValue::Mat3x4(_), UniformType::FloatMat3x4) => true,
+            (&UniformValue::Mat4x2(_), UniformType::FloatMat4x2) => true,
             (&UniformValue::Mat4x3(_), UniformType::FloatMat4x3) => true,
             (&UniformValue::Vec2(_), UniformType::FloatVec2) => true,
             (&UniformValue::Vec3(_), UniformType::FloatVec3) => true,
@@ -701,6 +716,51 @@ impl AsUniformValue for [[f32; 4]; 4] {
 }
 
 impl_uniform_block_basic!([[f32; 4]; 4], UniformType::FloatMat4);
+
+impl AsUniformValue for [[f32; 3]; 2] {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue<'_> {
+        UniformValue::Mat2x3(*self)
+    }
+}
+
+impl_uniform_block_basic!([[f32; 3]; 2], UniformType::FloatMat2x3);
+
+impl AsUniformValue for [[f32; 4]; 2] {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue<'_> {
+        UniformValue::Mat2x4(*self)
+    }
+}
+
+impl_uniform_block_basic!([[f32; 4]; 2], UniformType::FloatMat2x4);
+
+impl AsUniformValue for [[f32; 2]; 3] {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue<'_> {
+        UniformValue::Mat3x2(*self)
+    }
+}
+
+impl_uniform_block_basic!([[f32; 2]; 3], UniformType::FloatMat3x2);
+
+impl AsUniformValue for [[f32; 4]; 3] {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue<'_> {
+        UniformValue::Mat3x4(*self)
+    }
+}
+
+impl_uniform_block_basic!([[f32; 4]; 3], UniformType::FloatMat3x4);
+
+impl AsUniformValue for [[f32; 2]; 4] {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue<'_> {
+        UniformValue::Mat4x2(*self)
+    }
+}
+
+impl_uniform_block_basic!([[f32; 2]; 4], UniformType::FloatMat4x2);
 
 impl AsUniformValue for [[f32; 3]; 4] {
     #[inline]

--- a/src/uniforms/value.rs
+++ b/src/uniforms/value.rs
@@ -186,9 +186,24 @@ pub enum UniformValue<'a> {
     DoubleVec2([f64; 2]),
     DoubleVec3([f64; 3]),
     DoubleVec4([f64; 4]),
-    DoubleMat2([[f64;2]; 2]),
-    DoubleMat3([[f64;3]; 3]),
-    DoubleMat4([[f64;4]; 4]),
+    /// 2x2 column-major double-precision matrix.
+    DoubleMat2([[f64; 2]; 2]),
+    /// 3x3 column-major double-precision matrix.
+    DoubleMat3([[f64; 3]; 3]),
+    /// 4x4 column-major double-precision matrix.
+    DoubleMat4([[f64; 4]; 4]),
+    /// 2x3 column-major double-precision matrix.
+    DoubleMat2x3([[f64; 3]; 2]),
+    /// 2x4 column-major double-precision matrix.
+    DoubleMat2x4([[f64; 4]; 2]),
+    /// 3x2 column-major double-precision matrix.
+    DoubleMat3x2([[f64; 2]; 3]),
+    /// 3x4 column-major double-precision matrix.
+    DoubleMat3x4([[f64; 4]; 3]),
+    /// 4x2 column-major double-precision matrix.
+    DoubleMat4x2([[f64; 2]; 4]),
+    /// 4x3 column-major double-precision matrix.
+    DoubleMat4x3([[f64; 3]; 4]),
     Int64(i64),
     Int64Vec2([i64; 2]),
     Int64Vec3([i64; 3]),
@@ -321,6 +336,12 @@ impl<'a> UniformValue<'a> {
             (&UniformValue::DoubleMat2(_), UniformType::DoubleMat2) => true,
             (&UniformValue::DoubleMat3(_), UniformType::DoubleMat3) => true,
             (&UniformValue::DoubleMat4(_), UniformType::DoubleMat4) => true,
+            (&UniformValue::DoubleMat2x3(_), UniformType::DoubleMat2x3) => true,
+            (&UniformValue::DoubleMat2x4(_), UniformType::DoubleMat2x4) => true,
+            (&UniformValue::DoubleMat3x2(_), UniformType::DoubleMat3x2) => true,
+            (&UniformValue::DoubleMat3x4(_), UniformType::DoubleMat3x4) => true,
+            (&UniformValue::DoubleMat4x2(_), UniformType::DoubleMat4x2) => true,
+            (&UniformValue::DoubleMat4x3(_), UniformType::DoubleMat4x3) => true,
             (&UniformValue::DoubleVec2(_), UniformType::DoubleVec2) => true,
             (&UniformValue::DoubleVec3(_), UniformType::DoubleVec3) => true,
             (&UniformValue::DoubleVec4(_), UniformType::DoubleVec4) => true,
@@ -916,6 +937,60 @@ impl AsUniformValue for [[f64; 4]; 4] {
 }
 
 impl_uniform_block_basic!([[f64; 4]; 4], UniformType::DoubleMat4);
+
+impl AsUniformValue for [[f64; 3]; 2] {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue<'_> {
+        UniformValue::DoubleMat2x3(*self)
+    }
+}
+
+impl_uniform_block_basic!([[f64; 3]; 2], UniformType::DoubleMat2x3);
+
+impl AsUniformValue for [[f64; 4]; 2] {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue<'_> {
+        UniformValue::DoubleMat2x4(*self)
+    }
+}
+
+impl_uniform_block_basic!([[f64; 4]; 2], UniformType::DoubleMat2x4);
+
+impl AsUniformValue for [[f64; 2]; 3] {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue<'_> {
+        UniformValue::DoubleMat3x2(*self)
+    }
+}
+
+impl_uniform_block_basic!([[f64; 2]; 3], UniformType::DoubleMat3x2);
+
+impl AsUniformValue for [[f64; 4]; 3] {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue<'_> {
+        UniformValue::DoubleMat3x4(*self)
+    }
+}
+
+impl_uniform_block_basic!([[f64; 4]; 3], UniformType::DoubleMat3x4);
+
+impl AsUniformValue for [[f64; 2]; 4] {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue<'_> {
+        UniformValue::DoubleMat4x2(*self)
+    }
+}
+
+impl_uniform_block_basic!([[f64; 2]; 4], UniformType::DoubleMat4x2);
+
+impl AsUniformValue for [[f64; 3]; 4] {
+    #[inline]
+    fn as_uniform_value(&self) -> UniformValue<'_> {
+        UniformValue::DoubleMat4x3(*self)
+    }
+}
+
+impl_uniform_block_basic!([[f64; 3]; 4], UniformType::DoubleMat4x3);
 
 impl AsUniformValue for i64 {
     #[inline]


### PR DESCRIPTION
Non-square matrices (e.g. `dmat3x4`) are currently not supported in `uniform!` macros. This PR addresses this defect with a truckload of copy and paste.

## Checklist
- Data types:
  - [x] single-precision float
  - [x] double-precision float
  - [x] ~~signed integer~~ (apparently these are not supported by OpenGL)
  - [x] ~~unsigned integer~~ (see above)
  - [x] ~~boolean (to be implemented with singed integers)~~ (see above)
- [ ] Add proper support detection (see TODOs in diffs)

## Approach
I initially wanted to introduce some fancy macros to deal with the repetitiveness of the subject, but I decided against that to make grepping stuff easier.

## Availability control
Necessary API like `glUniformMatrix4x3fv` is only generally available since OpenGL 3.0. I have not researched OpenGL ES availability yet, nor do I have a good understanding of the extension-based workarounds for older versions.

While researching how this problem was dealt with in the past in this library, I stumbled upon something that confused me. This topic is effectively blocked until #2132 is resolved.

## Testing
`mat4x3` has been tested:
- by me on a Debian 12 on Microsoft Surface Laptop Go 2
- by @dsxack on MacOS 15.1 Beta on MacBook Pro (Apple M1 Max)

-----
Closes #1708.