### PR TITLE
Use the std::mem::offset_of!() macro to calculate field offsets

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -431,7 +431,7 @@ macro_rules! implement_uniform_block {
                             }
                         }
 
-                        fn matches_from_ty<T: $crate::uniforms::UniformBlock + ?Sized>(_: &T,
+                        fn matches_from_ty<T: $crate::uniforms::UniformBlock + ?Sized>(_: Option<&T>,
                             layout: &$crate::program::BlockLayout, base_offset: usize)
                             -> ::std::result::Result<(), $crate::uniforms::LayoutMismatchError>
                         {
@@ -449,12 +449,11 @@ macro_rules! implement_uniform_block {
                                     name: stringify!($field_name).to_owned(),
                                 })
                             };
-                            let dummy: mem::MaybeUninit<$struct_name> = mem::MaybeUninit::zeroed();
-                            let dummy = unsafe { dummy.assume_init() };
 
                             let input_offset = mem::offset_of!($struct_name, $field_name);
+                            let dummy_field = None::<&$struct_name>.map(|v| &v.$field_name);
 
-                            match matches_from_ty(&dummy.$field_name, reflected_ty, input_offset) {
+                            match matches_from_ty(dummy_field, reflected_ty, input_offset) {
                                 Ok(_) => (),
                                 Err(e) => return Err(LayoutMismatchError::MemberMismatch {
                                     member: stringify!($field_name).to_owned(),


### PR DESCRIPTION
Rust 1.86 [added more null checks](https://github.com/rust-lang/rust/pull/134424) when debug assertions are enabled which was causing this code in the `implement_uniform_block!()` macro to throw a null pointer dereference error.

Here's a small [playground example](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=5acca75733b1496472979fa9ba3c0b12) which demonstrates the problem. Run it in debug mode, or run miri on it.

As far as I can tell, the original code wanted two things:

* The offset of the field in question, which the standard library now has an answer for (and glium was also already pulling in a crate which did this, not sure why it wasn't used)
* A valid reference to `$struct_name.$field_name`, so it can pass it to `matches_from_ty`, cast it to a `UniformBlock`, and recursively call `matches()` on it.

I verified that this fixed the null pointer dereference in my project's code which was using this macro, but I might be missing something.

One difference with my code is it constructs an entire zeroed instance of the struct, instead of just a zeroed _pointer_ to the struct. There might be a performance penalty to that which the original authors were trying to avoid, I'm not sure.

Related to https://github.com/glium/glium/issues/1918#issuecomment-1433533902