### PR TITLE
Fix benchmarks

### DIFF
--- a/benches/basic.rs
+++ b/benches/basic.rs
@@ -64,7 +64,6 @@ fn create_program(b: &mut Bencher) {
 }
 
 #[bench]
-#[ignore]       // TODO: segfaults
 fn draw_triangle(b: &mut Bencher) {
     let display = support::build_context();
 

--- a/benches/support/mod.rs
+++ b/benches/support/mod.rs
@@ -199,6 +199,9 @@ unsafe impl glium::backend::Backend for DummyBackend {
     fn resize(&self, _: (u32, u32)) {
     }
 
+    fn set_swap_interval(&self, _: glutin::surface::SwapInterval) {
+    }
+
     fn is_current(&self) -> bool {
         true
     }

--- a/benches/support/mod.rs
+++ b/benches/support/mod.rs
@@ -129,6 +129,7 @@ unsafe impl glium::backend::Backend for DummyBackend {
                 extern "system" fn get_integerv(name: u32, out: *mut i32) {
                     match name {
                         0x821D /* GL_NUM_EXTENSIONS */ => unsafe { *out = 0; },
+                        0x0D3A /* GL_MAX_VIEWPORT_DIMS */ => unsafe { *out = 800; *out.add(1) = 600; },
                         _ => unsafe { *out = 0; },
                     }
                 }

--- a/benches/support/mod.rs
+++ b/benches/support/mod.rs
@@ -185,6 +185,9 @@ unsafe impl glium::backend::Backend for DummyBackend {
         (800, 600)
     }
 
+    fn resize(&self, _: (u32, u32)) {
+    }
+
     fn is_current(&self) -> bool {
         true
     }

--- a/benches/support/mod.rs
+++ b/benches/support/mod.rs
@@ -72,6 +72,11 @@ unsafe impl glium::backend::Backend for DummyBackend {
                 delete as *const _
             },
 
+            "glDrawArrays" => {
+                extern "system" fn draw_arr(_: u32, _: i32, _: isize) {}
+                draw_arr as *const _
+            },
+
             "glEnable" | "glDisable" => {
                 extern "system" fn enable(_: u32) {}
                 enable as *const _
@@ -175,6 +180,11 @@ unsafe impl glium::backend::Backend for DummyBackend {
             "glUseProgram" => {
                 extern "system" fn use_program(_: u32) {}
                 use_program as *const _
+            },
+
+            "glViewport" => {
+                extern "system" fn viewport(_: i32, _: i32, _: isize, _: isize) {}
+                viewport as *const _
             },
 
             _name => ptr::null()


### PR DESCRIPTION
The first and last commit fix the compiler errors, the other two get the `draw_triangle` example benchmark working:
``` shell
cargo +nightly bench --features unstable
```
