### PR TITLE
Run tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,33 @@ jobs:
         RUSTFLAGS: -D warnings
       run: |
          cargo test --all --all-targets --no-run
+    - name: Install Xvfb
+      if: (matrix.os == 'ubuntu-latest')
+      run: |
+        sudo apt-get install libxkbcommon-x11-0
+        sudo apt-get install xvfb
+    - name: Run the tests (X11)
+      if: (matrix.os == 'ubuntu-latest')
+      env:
+        RUST_BACKTRACE: 1
+        RUSTFLAGS: -D warnings
+      run: xvfb-run cargo test --all --all-targets
+    - name: Set up Mesa
+      if: (matrix.os == 'windows-latest')
+      run: |
+        $url = 'https://github.com/pal1000/mesa-dist-win/releases/download/25.0.3/mesa3d-25.0.3-release-msvc.7z'
+        curl.exe -L --output mesa.7z --url $url
+        7z e mesa.7z -otarget\debug\deps `
+            x64\opengl32.dll `
+            x64\libgallium_wgl.dll `
+            x64\dxil.dll `
+            x64\d3d10warp.dll
+    - name: Run the tests (Windows)
+      if: (matrix.os == 'windows-latest')
+      env:
+        RUST_BACKTRACE: 1
+        RUSTFLAGS: -D warnings
+      run: cargo test --all --all-targets
     - name: Run cargo doc
       env:
         RUSTFLAGS: -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,4 +78,4 @@ jobs:
       with:
         branch: gh-pages
         folder: book/gh-pages
-      if: github.event_name == 'push'
+      if: github.event.repository.owner.login == 'glium' && github.event_name == 'push'


### PR DESCRIPTION
Add ~30s for windows and 20-30s for ubuntu in CI jobs. The change to the book job is itself useful even if running the tests is not desirable.

The following tests are false positives on free-tier runners as they lack the capabilities to execute the test:
| Target | Test | Only on Windows |
| - | - | - |
| draw_parameters | provoking_vertex_first | |
| | provoking_vertex_last | |
| shaders | complex_layout | |
| | get_program_binary | Y |
| | program_binary_reload | Y |
| | program_binary_working | Y |
| ssbo | basic | |
| | custom_bind_point | |
| texture_creation | bindless_texture_residency_context_rebuild | |
| texture_sample | bindless_texture | |
| uniform_buffer | block | |
| | block_wrong_type | |
| | persistent_block_race_condition | |
